### PR TITLE
Open Mocha html reporter when running tests in Karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,13 +1,13 @@
-module.exports = function ( config ) {
-  config.set( {
+module.exports = function (config) {
+  config.set({
     // Run in Chrome
-    browsers: [ 'Chrome' ],
+    browsers: ['Chrome'],
 
     // Just run once by default
     singleRun: true,
 
     // Use the mocha test framework
-    frameworks: [ 'mocha' ],
+    frameworks: ['mocha'],
 
     files: [
       'tests.webpack.js' // Just load this file
@@ -15,25 +15,31 @@ module.exports = function ( config ) {
 
     preprocessors: {
       // Preprocess with webpack and our sourcemap loader
-      'tests.webpack.js': [ 'webpack', 'sourcemap' ]
+      'tests.webpack.js': ['webpack', 'sourcemap']
     },
 
 
     // Report results in this format
-    reporters: [ 'dots' ],
+    reporters: ['dots'],
 
     // Kind of a copy of your webpack config
     webpack: {
       devtool: 'inline-source-map', // Just do inline source maps instead of the default
       module: {
         loaders: [
-          { test: /\.js$/, loader: 'babel-loader' }
+          {test: /\.js$/, loader: 'babel-loader'}
         ]
       }
     },
     webpackServer: {
       noInfo: true // Please don't spam the console when running in karma!
-    }
+    },
 
-  } );
+    client: {
+      mocha: {
+        // change Karma's debug.html to the mocha web reporter
+        reporter: 'html'
+      }
+    }
+  });
 };


### PR DESCRIPTION
It will allow us to see the test summary with mocha html web reporter instead of blank page.

- Can run each unit test directly.
- Can see the unit test code.

I've just added this configuration to the karma.conf.js
**`client: {
      mocha: {
        reporter: 'html'
      }
    }`**

The result will looks like that:
![screen shot 2017-03-01 at 19 00 39](https://cloud.githubusercontent.com/assets/21081590/23471432/f3ae8102-feb1-11e6-876f-947537656796.png)
