### PR TITLE
fix(FEC-6971): load video element on native adapter load

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -144,6 +144,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         if (startTime) {
           this._videoElement.currentTime = startTime;
         }
+        this._videoElement.load();
       });
     }
     return this._loadPromise;


### PR DESCRIPTION
### Description of the Changes

We forgot to actually call load() on the video element.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
