### PR TITLE
fix(FEC-7040, FEC-7016, FEC-6946): move from buffering to playing on seeked

### DIFF
--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -126,7 +126,7 @@ export default class StateManager {
         this._dispatchEvent();
       },
       [Html5Events.SEEKED]: () => {
-        if (this._prevState.type === PlayerStates.PLAYING) {
+        if (this._prevState && this._prevState.type === PlayerStates.PLAYING) {
           this._updateState(PlayerStates.PLAYING);
           this._dispatchEvent();
         }

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -124,6 +124,12 @@ export default class StateManager {
       [Html5Events.PAUSE]: () => {
         this._updateState(PlayerStates.PAUSED);
         this._dispatchEvent();
+      },
+      [Html5Events.SEEKED]: () => {
+        if (this._prevState.type === PlayerStates.PLAYING) {
+          this._updateState(PlayerStates.PLAYING);
+          this._dispatchEvent();
+        }
       }
     }
   };
@@ -156,6 +162,7 @@ export default class StateManager {
     this._eventManager.listen(this._player, Html5Events.LOADED_METADATA, this._doTransition.bind(this));
     this._eventManager.listen(this._player, Html5Events.PAUSE, this._doTransition.bind(this));
     this._eventManager.listen(this._player, Html5Events.WAITING, this._doTransition.bind(this));
+    this._eventManager.listen(this._player, Html5Events.SEEKED, this._doTransition.bind(this));
   }
 
   /**
@@ -165,7 +172,7 @@ export default class StateManager {
    * @returns {void}
    */
   _doTransition(event: FakeEvent): void {
-    this._logger.debug('Do transition request', event);
+    this._logger.debug('Do transition request', event.type);
     let transition = this._transitions[this._curState.type];
     if (typeof transition[event.type] === 'function') {
       transition[event.type]();

--- a/test/src/state/state-manger.spec.js
+++ b/test/src/state/state-manger.spec.js
@@ -183,7 +183,7 @@ describe("StateManager.Transitions:PAUSED", () => {
   });
 });
 
-describe.only("StateManager.Transitions:BUFFERING", () => {
+describe("StateManager.Transitions:BUFFERING", () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(StateManager.prototype, '_attachListeners').callsFake(function () {

--- a/test/src/state/state-manger.spec.js
+++ b/test/src/state/state-manger.spec.js
@@ -183,7 +183,7 @@ describe("StateManager.Transitions:PAUSED", () => {
   });
 });
 
-describe("StateManager.Transitions:BUFFERING", () => {
+describe.only("StateManager.Transitions:BUFFERING", () => {
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     sandbox.stub(StateManager.prototype, '_attachListeners').callsFake(function () {
@@ -204,6 +204,17 @@ describe("StateManager.Transitions:BUFFERING", () => {
   it('should handle transition from buffering to paused', () => {
     stateManager._doTransition({type: Html5Events.PAUSE});
     stateManager.currentState.type.should.equal(PlayerStates.PAUSED);
+  });
+
+  it('should handle transition from buffering to playing on seeked while playing', () => {
+    stateManager._doTransition({type: Html5Events.PLAYING});
+    stateManager._doTransition({type: Html5Events.SEEKED});
+    stateManager.currentState.type.should.equal(PlayerStates.PLAYING);
+  });
+
+  it('shouldn\'t handle transition from buffering on seeked not while playing', () => {
+    stateManager._doTransition({type: Html5Events.SEEKED});
+    stateManager.currentState.type.should.equal(PlayerStates.BUFFERING);
   });
 
   it('shouldn\'t handle transition from buffering because of unregistered event', () => {


### PR DESCRIPTION
### Description of the Changes

Ie11/Edge doesn't trigger playing event after waiting (on seeking), which remains the player on buffering state, so exit from buffering state on seeked event.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
