### PR TITLE
fix(FEC-7108): native load video element for video sibling on mobile 

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -310,7 +310,11 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @returns {Promise<Object>} - The loaded data
    */
   load(startTime: ?number): Promise<Object> {
-    return this._mediaSourceAdapter ? this._mediaSourceAdapter.load(startTime) : Promise.resolve({});
+    this._el.load();
+    if (this._mediaSourceAdapter) {
+      return this._mediaSourceAdapter.load(startTime);
+    }
+    return Promise.resolve({});
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Load the video element itself - used when user gesture is required to start playback.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
