### PR TITLE
fix(FEC-7089): handle bitrate change in android browser

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -383,7 +383,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       this._eventManager.listen(this._videoElement, Html5Events.LOADED_DATA, () => {
         this._eventManager.unlisten(this._videoElement, Html5Events.LOADED_DATA);
         if (Env.browser.name === 'Android Browser') {
-          // Android browser doesn't support seek before play, we have to play wait to 'durationchanged' event and then seek.
+          // In android browser we have to seek only after some playback.
           this._eventManager.listen(this._videoElement, Html5Events.DURATION_CHANGE, () => {
             this._eventManager.unlisten(this._videoElement, Html5Events.DURATION_CHANGE);
             this._videoElement.currentTime = currentTime;


### PR DESCRIPTION
### Description of the Changes

On bitrate change for progressive download In Android browser (AKA native/stock browser) we have to seek to the current position only after some playback

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
