### PR TITLE
fix(FEC-7138): enable setting 0 and 1 values

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -850,7 +850,7 @@ export default class Player extends FakeEventTarget {
    */
   set volume(vol: number): void {
     if (this._engine) {
-      if (Utils.Number.isFloat(vol)) {
+      if (Utils.Number.isFloat(vol) || (vol === 0) || (vol === 1)) {
         let boundedVol = vol;
         if (boundedVol < 0) {
           boundedVol = 0;

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1649,3 +1649,53 @@ describe('seekToLiveEdge', function () {
     }
   });
 });
+
+describe('volume', function () {
+  let player, config;
+
+  before(() => {
+    createElement('DIV', targetId);
+  });
+
+  beforeEach(() => {
+    config = getConfigStructure();
+    config.sources = sourcesConfig.Mp4;
+    player = new Player(targetId, config);
+  });
+
+  afterEach(() => {
+    player.destroy();
+  });
+
+  after(() => {
+    removeVideoElementsFromTestPage();
+    removeElement(targetId);
+  });
+
+  it('should return 1 by default', function () {
+    player.volume.should.equal(1);
+
+  });
+
+  it('should enable setting the volume via API', function () {
+    player.volume = 0.9;
+    player.volume.should.equal(0.9);
+    player.volume = 0.3;
+    player.volume.should.equal(0.3);
+    player.volume = 0;
+    player.volume.should.equal(0);
+  });
+
+  it('should enable setting the volume via config', function () {
+    config.playback.volume = 0.9;
+    player.configure(config);
+    player.volume.should.equal(0.9);
+  });
+
+  it('should cap volume values between 0 and 1(including)', function () {
+    player.volume = 1.1;
+    player.volume.should.equal(1);
+    player.volume = -0.1;
+    player.volume.should.equal(0);
+  });
+});


### PR DESCRIPTION
### Description of the Changes

The volume check is not enabling setting 0 or 1

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
