### PR TITLE
fix(FEC-7172): fix DRM support test on Android devices

### DIFF
--- a/src/drm/drm-support.js
+++ b/src/drm/drm-support.js
@@ -19,7 +19,7 @@ export default class DrmSupport {
     Chrome: () => {
       let device = Env.device.type;
       let os = Env.os.name;
-      if (!device || (os === 'Android')) {
+      if (!device || os === 'Android') {
         return DrmScheme.WIDEVINE;
       }
       return NOT_SUPPORTED;

--- a/src/drm/drm-support.js
+++ b/src/drm/drm-support.js
@@ -19,7 +19,7 @@ export default class DrmSupport {
     Chrome: () => {
       let device = Env.device.type;
       let os = Env.os.name;
-      if (!device || (device === 'mobile' && os === 'Android')) {
+      if (!device || (os === 'Android')) {
         return DrmScheme.WIDEVINE;
       }
       return NOT_SUPPORTED;


### PR DESCRIPTION
### Description of the Changes

The current check is validating both OS is Android and Device is mobile, but device in Android land can be the vendor name, e.g. HTC, Sony etc, so need to remove the check.
IMO it's enough to validate that the OS is Android in this case.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
