### PR TITLE
feat(FEC-7171): handle preload when ads plugin enabled

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -363,7 +363,15 @@ export default class Player extends FakeEventTarget {
         this.playsinline = true;
       }
       if (this._config.playback.preload === "auto") {
-        this.load();
+        /**
+         * If ads plugin enabled it's his responsibility to preload the content player.
+         * So to avoid loading the player twice which can cause errors on MSEs we are not
+         * calling load from the player.
+         * TODO: Change it to check the ads configuration when we will develop the ads manager.
+         */
+        if (!this._config.plugins.ima) {
+          this.load();
+        }
       }
       if (this._canAutoPlay()) {
         this.play();


### PR DESCRIPTION
### Description of the Changes

If ads plugin enabled it's his responsibility to preload the content player,
so to avoid loading the player twice which can cause errors on MSEs we are overriding
the configuration and sending preload "none".

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
