### PR TITLE
fix(base-plugin): getConfig api should return copy of his config

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -207,14 +207,14 @@ export default class Player extends FakeEventTarget {
       const plugin = this._pluginManager.get(name);
       if (plugin) {
         plugin.updateConfig(plugins[name]);
-        this._config.plugins[name] = Utils.Object.copyDeep(plugin.getConfig());
+        this._config.plugins[name] = plugin.getConfig();
       } else {
         // We allow to load plugins as long as the player has no engine
         if (!this._engine) {
           this._pluginManager.load(name, this, plugins[name]);
           let plugin = this._pluginManager.get(name);
           if (plugin) {
-            this._config.plugins[name] = Utils.Object.copyDeep(plugin.getConfig());
+            this._config.plugins[name] = plugin.getConfig();
             if (typeof plugin.getMiddlewareImpl === "function") {
               this._playbackMiddleware.use(plugin.getMiddlewareImpl());
             }

--- a/src/player.js
+++ b/src/player.js
@@ -207,14 +207,14 @@ export default class Player extends FakeEventTarget {
       const plugin = this._pluginManager.get(name);
       if (plugin) {
         plugin.updateConfig(plugins[name]);
-        this._config.plugins[name] = plugin.getConfig();
+        this._config.plugins[name] = Utils.Object.copyDeep(plugin.getConfig());
       } else {
         // We allow to load plugins as long as the player has no engine
         if (!this._engine) {
           this._pluginManager.load(name, this, plugins[name]);
           let plugin = this._pluginManager.get(name);
           if (plugin) {
-            this._config.plugins[name] = plugin.getConfig();
+            this._config.plugins[name] = Utils.Object.copyDeep(plugin.getConfig());
             if (typeof plugin.getMiddlewareImpl === "function") {
               this._playbackMiddleware.use(plugin.getMiddlewareImpl());
             }

--- a/src/plugin/base-plugin.js
+++ b/src/plugin/base-plugin.js
@@ -96,9 +96,9 @@ export default class BasePlugin implements IPlugin {
    */
   getConfig(attr?: string): any {
     if (attr) {
-      return this.config[attr];
+      return Utils.Object.copyDeep(this.config[attr]);
     }
-    return this.config;
+    return Utils.Object.copyDeep(this.config);
   }
 
   /**
@@ -108,7 +108,7 @@ export default class BasePlugin implements IPlugin {
    * @returns {void}
    */
   updateConfig(update: Object): void {
-    this.config = Utils.Object.mergeDeep(this.config, update);
+    Utils.Object.mergeDeep(this.config, update);
   }
 
   /**

--- a/test/src/plugin/base-plugin.spec.js
+++ b/test/src/plugin/base-plugin.spec.js
@@ -28,6 +28,13 @@ describe('BasePlugin', () => {
     basePlugin.getConfig().should.deep.equal(config);
   });
 
+  it('should return copy of the plugin config', () => {
+    basePlugin.getConfig().x = 100;
+    basePlugin.getConfig().y = 200;
+    basePlugin.getConfig().x.should.equals(1);
+    basePlugin.getConfig().y.should.equals(2);
+  });
+
   it('should return the config attribute value', () => {
     basePlugin.getConfig('x').should.deep.equal(1);
   });


### PR DESCRIPTION
### Description of the Changes

getConfig api should return copy of his config instead of reference.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
