### PR TITLE
fix(FEC-7226, FEC-7243): create comparer func to default tracks

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1228,8 +1228,16 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _setDefaultTrack(type: string, language: string, defaultTrack: Track): void {
+    function langComparer(inputLang: string, trackLang: string): boolean {
+      if (inputLang.length === trackLang.length) {
+        return inputLang === trackLang;
+      } else {
+        return (inputLang > trackLang ? inputLang.startsWith(trackLang) : trackLang.startsWith(inputLang));
+      }
+    }
+
     if (language) {
-      const track: ?Track = this._getTracksByType(type).find(track => track.language === language);
+      const track: ?Track = this._getTracksByType(type).find(track => langComparer(language, track.language));
       if (track) {
         this.selectTrack(track);
       }

--- a/src/player.js
+++ b/src/player.js
@@ -1228,6 +1228,12 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _setDefaultTrack(type: string, language: string, defaultTrack: Track): void {
+    /**
+     * Comparing language string according to their length.
+     * @param {string} inputLang - The configured language.
+     * @param {string} trackLang - The default track language.
+     * @returns {boolean} - Whether the strings are equal or starts with the same substring.
+     */
     function langComparer(inputLang: string, trackLang: string): boolean {
       const inputLangLength = inputLang.length;
       const trackLangLength = trackLang.length;

--- a/src/player.js
+++ b/src/player.js
@@ -1228,24 +1228,8 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _setDefaultTrack(type: string, language: string, defaultTrack: Track): void {
-    /**
-     * Comparing language string according to their length.
-     * @param {string} inputLang - The configured language.
-     * @param {string} trackLang - The default track language.
-     * @returns {boolean} - Whether the strings are equal or starts with the same substring.
-     */
-    function langComparer(inputLang: string, trackLang: string): boolean {
-      const inputLangLength = inputLang.length;
-      const trackLangLength = trackLang.length;
-      if (inputLangLength === trackLangLength) {
-        return inputLang === trackLang;
-      } else {
-        return (inputLangLength > trackLangLength ? inputLang.startsWith(trackLang) : trackLang.startsWith(inputLang));
-      }
-    }
-
     if (language) {
-      const track: ?Track = this._getTracksByType(type).find(track => langComparer(language, track.language));
+      const track: ?Track = this._getTracksByType(type).find(track => TextTrack.langComparer(language, track.language));
       if (track) {
         this.selectTrack(track);
       }

--- a/src/player.js
+++ b/src/player.js
@@ -1229,10 +1229,12 @@ export default class Player extends FakeEventTarget {
    */
   _setDefaultTrack(type: string, language: string, defaultTrack: Track): void {
     function langComparer(inputLang: string, trackLang: string): boolean {
-      if (inputLang.length === trackLang.length) {
+      const inputLangLength = inputLang.length;
+      const trackLangLength = trackLang.length;
+      if (inputLangLength === trackLangLength) {
         return inputLang === trackLang;
       } else {
-        return (inputLang > trackLang ? inputLang.startsWith(trackLang) : trackLang.startsWith(inputLang));
+        return (inputLangLength > trackLangLength ? inputLang.startsWith(trackLang) : trackLang.startsWith(inputLang));
       }
     }
 

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -7,6 +7,21 @@ import Track from './track'
  */
 export default class TextTrack extends Track {
   /**
+   * Comparing language strings according to their length.
+   * @param {string} inputLang - The configured language.
+   * @param {string} trackLang - The default track language.
+   * @returns {boolean} - Whether the strings are equal or starts with the same substring.
+   */
+  static langComparer(inputLang: string, trackLang: string): boolean {
+    const inputLangLength = inputLang.length;
+    const trackLangLength = trackLang.length;
+    if (inputLangLength === trackLangLength) {
+      return inputLang === trackLang;
+    }
+    return (inputLangLength > trackLangLength ? inputLang.startsWith(trackLang) : trackLang.startsWith(inputLang));
+  }
+
+  /**
    * The kind of the text track:
    * subtitles/captions/metadata.
    * @member

--- a/test/src/track/text-track.spec.js
+++ b/test/src/track/text-track.spec.js
@@ -1,0 +1,17 @@
+import TextTrack from '../../../src/track/text-track'
+
+describe('TextTrack', () => {
+  describe('langComparer', () => {
+    it('should compare 2 languages with same length', () => {
+      TextTrack.langComparer('ita', 'ita').should.be.true;
+      TextTrack.langComparer('ita', 'eng').should.be.false;
+    });
+
+    it('should compare 2 languages with different length', () => {
+      TextTrack.langComparer('ita', 'it').should.be.true;
+      TextTrack.langComparer('it', 'ita').should.be.true;
+      TextTrack.langComparer('es', 'ita').should.be.true;
+      TextTrack.langComparer('ita', 'es').should.be.true;
+    });
+  });
+});

--- a/test/src/track/text-track.spec.js
+++ b/test/src/track/text-track.spec.js
@@ -10,8 +10,8 @@ describe('TextTrack', () => {
     it('should compare 2 languages with different length', () => {
       TextTrack.langComparer('ita', 'it').should.be.true;
       TextTrack.langComparer('it', 'ita').should.be.true;
-      TextTrack.langComparer('es', 'ita').should.be.true;
-      TextTrack.langComparer('ita', 'es').should.be.true;
+      TextTrack.langComparer('es', 'ita').should.be.false;
+      TextTrack.langComparer('ita', 'es').should.be.false;
     });
   });
 });


### PR DESCRIPTION
### Description of the Changes

The comparer func will consider the length of the inputs and return the appropriate comparison accordingly.  

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
