### PR TITLE
fix(FEC-7071): call pause on ended for browsers which don't do it natively

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -971,6 +971,7 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEvents.TEXT_CUE_CHANGED, (event: FakeEvent) => this._onCueChange(event));
       this._eventManager.listen(this._engine, CustomEvents.ABR_MODE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this, Html5Events.PLAY, this._onPlay.bind(this));
+      this._eventManager.listen(this, Html5Events.ENDED, this._onEnded.bind(this));
     }
   }
 
@@ -1062,6 +1063,17 @@ export default class Player extends FakeEventTarget {
       this._firstPlay = false;
       this.dispatchEvent(new FakeEvent(CustomEvents.FIRST_PLAY));
       this._posterManager.hide();
+    }
+  }
+
+  /**
+   * @function _onEnded
+   * @return {void}
+   * @private
+   */
+  _onEnded(): void {
+    if (!this.paused) {
+      this._pause();
     }
   }
 

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1316,6 +1316,46 @@ describe('events', function () {
       }
     });
   });
+
+  describe('ended', () => {
+    let config;
+    let player;
+    let playerContainer;
+
+    before(() => {
+      playerContainer = createElement('DIV', targetId);
+    });
+
+    beforeEach(() => {
+      config = getConfigStructure();
+    });
+
+    afterEach(() => {
+      player.destroy();
+    });
+
+    after(() => {
+      removeVideoElementsFromTestPage();
+      removeElement(targetId);
+    });
+
+    it('should be paused', (done) => {
+      let onPlaying = () => {
+        player.removeEventListener(player.Event.PLAYING, onPlaying);
+        player.addEventListener(player.Event.ENDED, () => {
+          player.paused.should.be.true;
+          done();
+        });
+        player.currentTime = player.duration - 1;
+      };
+
+      config.sources = sourcesConfig.Mp4;
+      player = new Player(config);
+      playerContainer.appendChild(player.getView());
+      player.addEventListener(player.Event.PLAYING, onPlaying);
+      player.play();
+    });
+  });
 });
 
 describe('states', function () {


### PR DESCRIPTION
### Description of the Changes

IE11 and some old safari's don't pause on ended. so do it for them.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
