### PR TITLE
feat: add default text font family and expose ENUM

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1254,6 +1254,15 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
+   * Get the player TextStyle.
+   * @returns {TextStyle} - The TextStyle class
+   * @public
+   */
+  get TextStyle(): typeof TextStyle {
+    return TextStyle;
+  }
+
+  /**
    * Get the player states.
    * @returns {Object} - The states of the player.
    * @public

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -21,11 +21,8 @@ class TextStyle {
    */
   static FontFamily: {[string]: string} = {
     "ARIAL": "Arial",
-    "ROBOTO": "Roboto",
-    "ARIAL_UNICODE_MS": "Arial Unicode Ms",
     "HELVETICA": "Helvetica",
     "VERDANA": "Verdana",
-    "PT_SANS_CAPTION": "PT Sans Caption",
     "SANS_SERIF": "sans-serif"
   };
 

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -15,6 +15,21 @@
 class TextStyle {
 
   /**
+   * Defined set of font families
+   * @enum {Object.<string, string>}}
+   * @export
+   */
+  static FontFamily: {[string]: string} = {
+    "ARIAL": "Arial",
+    "ROBOTO": "Roboto",
+    "ARIAL_UNICODE_MS": "Arial Unicode Ms",
+    "HELVETICA": "Helvetica",
+    "VERDANA": "Verdana",
+    "PT_SANS_CAPTION": "PT Sans Caption",
+    "SANS_SERIF": "sans-serif"
+  };
+
+  /**
    * Defined in {@link https://goo.gl/ZcqOOM FCC 12-9}, paragraph 111, footnote
    * 448.  Each value is an array of the three RGB values for that color.
    * @enum {!Array.<number>}
@@ -103,6 +118,11 @@ class TextStyle {
   fontSize: string = '100%';
 
   /**
+   * @type {TextStyle.FontFamily}
+   */
+  fontFamily: string = TextStyle.FontFamily.SANS_SERIF;
+
+  /**
    * @type {TextStyle.StandardColors}
    */
   fontColor: Array<number> = TextStyle.StandardColors.WHITE;
@@ -138,6 +158,7 @@ class TextStyle {
   toCSS(): string {
     let attributes: Array<string> = [];
 
+    attributes.push('font-family: ' + this.fontFamily);
     attributes.push('font-size: ' + this.fontSize);
     attributes.push('color: ' + TextStyle._toRGBA(this.fontColor, this.fontOpacity));
     attributes.push('background-color: ' +

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -32,10 +32,10 @@ class TextStyle {
   /**
    * Defined in {@link https://goo.gl/ZcqOOM FCC 12-9}, paragraph 111, footnote
    * 448.  Each value is an array of the three RGB values for that color.
-   * @enum {!Array.<number>}
+   * @enum {Object.<string, Array.<number>>}}
    * @export
    */
-  static StandardColors: Object = {
+  static StandardColors: {[string]: Array<number>} = {
     'WHITE': [255, 255, 255],
     'BLACK': [0, 0, 0],
     'RED': [255, 0, 0],
@@ -48,10 +48,10 @@ class TextStyle {
 
   /**
    * Defined in {@link https://goo.gl/ZcqOOM FCC 12-9}, paragraph 111.
-   * @enum {number}
+   * @enum {Object.<string, number>}}
    * @export
    */
-  static StandardOpacities: Object = {
+  static StandardOpacities: {[string]: number} = {
     'OPAQUE': 1,
     'SEMI_HIGH': 0.75,
     'SEMI_LOW': 0.25,


### PR DESCRIPTION
### Description of the Changes

add default text font-family to text style and expose the TextStyle on the player instance so ENUM is more accessible.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
