### PR TITLE
fix(FEC-7238): captions failing on IE11 and Edge

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -274,9 +274,9 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     textTrack.mode = 'hidden';
     for (let cue of textTrack.activeCues) {
       //Normalize cues to be of type of VTT model
-      if (cue instanceof window.VTTCue) {
+      if (window.VTTCue && (cue instanceof window.VTTCue)) {
         activeCues.push(cue);
-      } else if (cue instanceof window.TextTrackCue) {
+      } else if (window.TextTrackCue && (cue instanceof window.TextTrackCue)) {
         activeCues.push(new Cue(cue.startTime, cue.endTime, cue.text));
       }
     }


### PR DESCRIPTION
### Description of the Changes

`instanceof` check on undefined method caused IE11 and Edge to fail on `oncuechange` event handler, make sure window.VTTCue exist before checking against instance of it.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
