### PR TITLE
feat: order media source adapters depends on preferNative value

### DIFF
--- a/flow-typed/interfaces/media-source-adapter.js
+++ b/flow-typed/interfaces/media-source-adapter.js
@@ -19,7 +19,7 @@ declare interface IMediaSourceAdapter {
   isLive(): boolean;
   static +id: string;
   static isSupported(): boolean;
-  static canPlayType(mimeType: string, preferNative: boolean): boolean;
+  static canPlayType(mimeType: string): boolean;
   static canPlayDrm(drmData: Array<Object>): boolean;
   static createAdapter(videoElement: HTMLVideoElement, source: Source, config: Object): IMediaSourceAdapter;
 }

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -274,9 +274,9 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     textTrack.mode = 'hidden';
     for (let cue of textTrack.activeCues) {
       //Normalize cues to be of type of VTT model
-      if (cue instanceof window.VTTCue) {
+      if (window.VTTCue && (cue instanceof window.VTTCue)) {
         activeCues.push(cue);
-      } else if (cue instanceof window.TextTrackCue) {
+      } else if (window.TextTrackCue && (cue instanceof window.TextTrackCue)) {
         activeCues.push(new Cue(cue.startTime, cue.endTime, cue.text));
       }
     }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -78,14 +78,13 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * Checks if NativeAdapter can play a given mime type.
    * @function canPlayType
    * @param {string} mimeType - The mime type to check
-   * @param {boolean} [preferNative=true] - prefer native flag
    * @returns {boolean} - Whether the native adapter can play a specific mime type
    * @static
    */
-  static canPlayType(mimeType: string, preferNative: boolean = true): boolean {
+  static canPlayType(mimeType: string): boolean {
     let canPlayType = false;
     if (typeof mimeType === 'string') {
-      canPlayType = !!(NativeAdapter.TEST_VIDEO.canPlayType(mimeType.toLowerCase())) && !!preferNative;
+      canPlayType = !!(NativeAdapter.TEST_VIDEO.canPlayType(mimeType.toLowerCase()));
     }
     NativeAdapter._logger.debug('canPlayType result for mimeType:' + mimeType + ' is ' + canPlayType.toString());
     return canPlayType;

--- a/src/engines/html5/media-source/media-source-provider.js
+++ b/src/engines/html5/media-source/media-source-provider.js
@@ -71,10 +71,11 @@ export default class MediaSourceProvider {
    * @static
    */
   static canPlaySource(source: Source, preferNative: boolean = true): boolean {
+    MediaSourceProvider._orderMediaSourceAdapters(preferNative);
     let mediaSourceAdapters = MediaSourceProvider._mediaSourceAdapters;
     if (source && source.mimetype) {
       for (let i = 0; i < mediaSourceAdapters.length; i++) {
-        if (mediaSourceAdapters[i].canPlayType(source.mimetype, preferNative) && (!source.drmData || mediaSourceAdapters[i].canPlayDrm(source.drmData))) {
+        if (mediaSourceAdapters[i].canPlayType(source.mimetype) && (!source.drmData || mediaSourceAdapters[i].canPlayDrm(source.drmData))) {
           MediaSourceProvider._selectedAdapter = mediaSourceAdapters[i];
           MediaSourceProvider._logger.debug(`Selected adapter is <${MediaSourceProvider._selectedAdapter.id}>`);
           return true;
@@ -82,6 +83,22 @@ export default class MediaSourceProvider {
       }
     }
     return false;
+  }
+
+  /**
+   * Orders the media source adapters array according to the preferNative value.
+   * @param {boolean} preferNative - Whether to prefer native playback.
+   * @private
+   * @returns {void}
+   */
+  static _orderMediaSourceAdapters(preferNative: boolean): void {
+    MediaSourceProvider._mediaSourceAdapters =
+      MediaSourceProvider._mediaSourceAdapters.filter(mse => mse.id !== 'NativeAdapter');
+    if (preferNative) {
+      MediaSourceProvider._mediaSourceAdapters.unshift(NativeAdapter);
+    } else {
+      MediaSourceProvider._mediaSourceAdapters.push(NativeAdapter);
+    }
   }
 
   /**

--- a/test/src/engines/html5/media-source/adapters/test-adapters/test-adapters.js
+++ b/test/src/engines/html5/media-source/adapters/test-adapters/test-adapters.js
@@ -1,4 +1,22 @@
-class adapter1 implements IMediaSourceAdapter {
+class FakeNativeAdapter implements IMediaSourceAdapter {
+  static get id() {
+    return 'NativeAdapter';
+  }
+}
+
+class FakeHlsAdapter implements IMediaSourceAdapter {
+  static get id() {
+    return 'HlsAdapter';
+  }
+}
+
+class FakeDashAdapter implements IMediaSourceAdapter {
+  static get id() {
+    return 'DashAdapter';
+  }
+}
+
+class Adapter1 implements IMediaSourceAdapter {
   static get id() {
     return 'adapter1';
   }
@@ -26,7 +44,7 @@ class adapter1 implements IMediaSourceAdapter {
   }
 }
 
-class adapter2 implements IMediaSourceAdapter {
+class Adapter2 implements IMediaSourceAdapter {
   static get id() {
     return 'adapter2';
   }
@@ -53,7 +71,7 @@ class adapter2 implements IMediaSourceAdapter {
   }
 }
 
-class adapter3 implements IMediaSourceAdapter {
+class Adapter3 implements IMediaSourceAdapter {
   static get id() {
     return 'adapter3';
   }
@@ -80,4 +98,7 @@ class adapter3 implements IMediaSourceAdapter {
   }
 }
 
-export {adapter1, adapter2, adapter3};
+export {
+  Adapter1, Adapter2, Adapter3,
+  FakeDashAdapter, FakeHlsAdapter, FakeNativeAdapter
+};

--- a/test/src/engines/html5/media-source/adapters/test-adapters/test-adapters.js
+++ b/test/src/engines/html5/media-source/adapters/test-adapters/test-adapters.js
@@ -18,7 +18,7 @@ class FakeDashAdapter implements IMediaSourceAdapter {
 
 class Adapter1 implements IMediaSourceAdapter {
   static get id() {
-    return 'adapter1';
+    return 'Adapter1';
   }
 
   static canPlayType(mimeType: string): boolean {
@@ -46,7 +46,7 @@ class Adapter1 implements IMediaSourceAdapter {
 
 class Adapter2 implements IMediaSourceAdapter {
   static get id() {
-    return 'adapter2';
+    return 'Adapter2';
   }
 
   static canPlayType(mimeType: string): boolean {
@@ -73,7 +73,7 @@ class Adapter2 implements IMediaSourceAdapter {
 
 class Adapter3 implements IMediaSourceAdapter {
   static get id() {
-    return 'adapter3';
+    return 'Adapter3';
   }
 
   static canPlayType(mimeType: string): boolean {

--- a/test/src/engines/html5/media-source/media-source-provider.spec.js
+++ b/test/src/engines/html5/media-source/media-source-provider.spec.js
@@ -97,9 +97,20 @@ describe('mediaSourceProvider:unRegister', () => {
 });
 
 describe('mediaSourceProvider:canPlaySource', () => {
+  let sandbox;
 
   before(() => {
     MediaSourceProvider._mediaSourceAdapters = [Adapter1, Adapter2, Adapter3];
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(MediaSourceProvider, '_orderMediaSourceAdapters', () => {
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   after(() => {
@@ -148,13 +159,24 @@ describe('mediaSourceProvider:canPlaySource', () => {
 });
 
 describe('mediaSourceProvider:getMediaSourceAdapter', () => {
+  let sandbox;
 
   before(() => {
     MediaSourceProvider._mediaSourceAdapters = [Adapter1, Adapter2, Adapter3];
   });
 
   beforeEach(() => {
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
     MediaSourceProvider._selectedAdapter = null;
+    sandbox.stub(MediaSourceProvider, '_orderMediaSourceAdapters', () => {
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   after(() => {

--- a/test/src/engines/html5/media-source/media-source-provider.spec.js
+++ b/test/src/engines/html5/media-source/media-source-provider.spec.js
@@ -17,28 +17,28 @@ describe('mediaSourceProvider:register', () => {
     MediaSourceProvider._mediaSourceAdapters = oldMediaSourceAdapters;
   });
 
-  it('should register adapter1', () => {
+  it('should register Adapter1', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(0);
     MediaSourceProvider.register(Adapter1);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(1);
-    MediaSourceProvider._mediaSourceAdapters[0].name.should.equal("adapter1");
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equal("Adapter1");
   });
 
-  it('should not register adapter1 twice', () => {
+  it('should not register Adapter1 twice', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(0);
     MediaSourceProvider.register(Adapter1);
     MediaSourceProvider.register(Adapter1);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(1);
-    MediaSourceProvider._mediaSourceAdapters[0].name.should.equal("adapter1");
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equal("Adapter1");
   });
 
-  it('should register adapter1 and adapter2', () => {
+  it('should register Adapter1 and Adapter2', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(0);
     MediaSourceProvider.register(Adapter1);
     MediaSourceProvider.register(Adapter2);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(2);
-    MediaSourceProvider._mediaSourceAdapters[0].name.should.equal("adapter1");
-    MediaSourceProvider._mediaSourceAdapters[1].name.should.equal("adapter2");
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equal("Adapter1");
+    MediaSourceProvider._mediaSourceAdapters[1].id.should.equal("Adapter2");
   });
 
   it('should not register null', () => {
@@ -63,14 +63,14 @@ describe('mediaSourceProvider:unRegister', () => {
     MediaSourceProvider._mediaSourceAdapters = oldMediaSourceAdapters;
   });
 
-  it('should unRegister adapter1', () => {
+  it('should unRegister Adapter1', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(2);
     MediaSourceProvider.unRegister(Adapter1);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(1);
-    MediaSourceProvider._mediaSourceAdapters[0].name.should.equal("adapter2");
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equal("Adapter2");
   });
 
-  it('should unRegister adapter1 and adapter2', () => {
+  it('should unRegister Adapter1 and Adapter2', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(2);
     MediaSourceProvider.unRegister(Adapter1);
     MediaSourceProvider.unRegister(Adapter2);
@@ -108,27 +108,27 @@ describe('mediaSourceProvider:canPlaySource', () => {
 
   it('should can play source with type mimeType1', () => {
     MediaSourceProvider.canPlaySource({mimetype: 'mimeType1'}).should.be.true;
-    MediaSourceProvider._selectedAdapter.id.should.equal("adapter1");
+    MediaSourceProvider._selectedAdapter.id.should.equal("Adapter1");
   });
 
   it('should can play source with type mimeType1 and drm scheme s1', () => {
     MediaSourceProvider.canPlaySource({mimetype: 'mimeType1', drmData: [{scheme: 's1'}]}).should.be.true;
-    MediaSourceProvider._selectedAdapter.id.should.equal("adapter1");
+    MediaSourceProvider._selectedAdapter.id.should.equal("Adapter1");
   });
 
   it('should can play source with type mimeType2', () => {
     MediaSourceProvider.canPlaySource({mimetype: 'mimeType2'}).should.be.true;
-    MediaSourceProvider._selectedAdapter.id.should.equal("adapter2");
+    MediaSourceProvider._selectedAdapter.id.should.equal("Adapter2");
   });
 
   it('should can play source with type video/mp4', () => {
     MediaSourceProvider.canPlaySource({mimetype: 'video/mp4'}).should.be.true;
-    MediaSourceProvider._selectedAdapter.id.should.equal("adapter3");
+    MediaSourceProvider._selectedAdapter.id.should.equal("Adapter3");
   });
 
   it('should can play source with type video/mp4 and drm scheme s3', () => {
     MediaSourceProvider.canPlaySource({mimetype: 'video/mp4', drmData: [{scheme: 's3'}]}).should.be.true;
-    MediaSourceProvider._selectedAdapter.id.should.equal("adapter3");
+    MediaSourceProvider._selectedAdapter.id.should.equal("Adapter3");
   });
 
   it('should cannot play source with valid mime type and not valid drm scheme', () => {
@@ -161,19 +161,19 @@ describe('mediaSourceProvider:getMediaSourceAdapter', () => {
     MediaSourceProvider._mediaSourceAdapters = oldMediaSourceAdapters;
   });
 
-  it('should provide adapter1', () => {
+  it('should provide Adapter1', () => {
     let adapter = MediaSourceProvider.getMediaSourceAdapter(video, {mimetype: 'mimeType1', url: 'url1'}, {});
-    adapter.constructor.name.should.equal("adapter1");
+    adapter.constructor.id.should.equal("Adapter1");
   });
 
-  it('should provide adapter2', () => {
+  it('should provide Adapter2', () => {
     let adapter = MediaSourceProvider.getMediaSourceAdapter(video, {mimetype: 'mimeType2', url: 'url3'}, {});
-    adapter.constructor.name.should.equal("adapter2");
+    adapter.constructor.id.should.equal("Adapter2");
   });
 
-  it('should provide adapter3', () => {
+  it('should provide Adapter3', () => {
     let adapter = MediaSourceProvider.getMediaSourceAdapter(video, {mimetype: 'video/mp4', url: 'url3'}, {});
-    adapter.constructor.name.should.equal("adapter3");
+    adapter.constructor.id.should.equal("Adapter3");
   });
 
   it('should provide null for unknown mime type', () => {

--- a/test/src/engines/html5/media-source/media-source-provider.spec.js
+++ b/test/src/engines/html5/media-source/media-source-provider.spec.js
@@ -1,5 +1,8 @@
 import MediaSourceProvider from '../../../../../src/engines/html5/media-source/media-source-provider'
-import {adapter1, adapter2, adapter3} from './adapters/test-adapters/test-adapters'
+import {
+  Adapter1, Adapter2, Adapter3,
+  FakeDashAdapter, FakeNativeAdapter, FakeHlsAdapter
+} from './adapters/test-adapters/test-adapters'
 
 let video = document.createElement("video");
 let oldMediaSourceAdapters = MediaSourceProvider._mediaSourceAdapters;
@@ -16,23 +19,23 @@ describe('mediaSourceProvider:register', () => {
 
   it('should register adapter1', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(0);
-    MediaSourceProvider.register(adapter1);
+    MediaSourceProvider.register(Adapter1);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(1);
     MediaSourceProvider._mediaSourceAdapters[0].name.should.equal("adapter1");
   });
 
   it('should not register adapter1 twice', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(0);
-    MediaSourceProvider.register(adapter1);
-    MediaSourceProvider.register(adapter1);
+    MediaSourceProvider.register(Adapter1);
+    MediaSourceProvider.register(Adapter1);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(1);
     MediaSourceProvider._mediaSourceAdapters[0].name.should.equal("adapter1");
   });
 
   it('should register adapter1 and adapter2', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(0);
-    MediaSourceProvider.register(adapter1);
-    MediaSourceProvider.register(adapter2);
+    MediaSourceProvider.register(Adapter1);
+    MediaSourceProvider.register(Adapter2);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(2);
     MediaSourceProvider._mediaSourceAdapters[0].name.should.equal("adapter1");
     MediaSourceProvider._mediaSourceAdapters[1].name.should.equal("adapter2");
@@ -54,7 +57,7 @@ describe('mediaSourceProvider:register', () => {
 describe('mediaSourceProvider:unRegister', () => {
 
   beforeEach(() => {
-    MediaSourceProvider._mediaSourceAdapters = [adapter1, adapter2];
+    MediaSourceProvider._mediaSourceAdapters = [Adapter1, Adapter2];
   });
   after(() => {
     MediaSourceProvider._mediaSourceAdapters = oldMediaSourceAdapters;
@@ -62,21 +65,21 @@ describe('mediaSourceProvider:unRegister', () => {
 
   it('should unRegister adapter1', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(2);
-    MediaSourceProvider.unRegister(adapter1);
+    MediaSourceProvider.unRegister(Adapter1);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(1);
     MediaSourceProvider._mediaSourceAdapters[0].name.should.equal("adapter2");
   });
 
   it('should unRegister adapter1 and adapter2', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(2);
-    MediaSourceProvider.unRegister(adapter1);
-    MediaSourceProvider.unRegister(adapter2);
+    MediaSourceProvider.unRegister(Adapter1);
+    MediaSourceProvider.unRegister(Adapter2);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(0);
   });
 
   it('should do nothing for adapter 3', () => {
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(2);
-    MediaSourceProvider.unRegister(adapter3);
+    MediaSourceProvider.unRegister(Adapter3);
     MediaSourceProvider._mediaSourceAdapters.length.should.equal(2);
   });
 
@@ -96,7 +99,7 @@ describe('mediaSourceProvider:unRegister', () => {
 describe('mediaSourceProvider:canPlaySource', () => {
 
   before(() => {
-    MediaSourceProvider._mediaSourceAdapters = [adapter1, adapter2, adapter3];
+    MediaSourceProvider._mediaSourceAdapters = [Adapter1, Adapter2, Adapter3];
   });
 
   after(() => {
@@ -147,7 +150,7 @@ describe('mediaSourceProvider:canPlaySource', () => {
 describe('mediaSourceProvider:getMediaSourceAdapter', () => {
 
   before(() => {
-    MediaSourceProvider._mediaSourceAdapters = [adapter1, adapter2, adapter3];
+    MediaSourceProvider._mediaSourceAdapters = [Adapter1, Adapter2, Adapter3];
   });
 
   beforeEach(() => {
@@ -199,3 +202,72 @@ describe('mediaSourceProvider:getMediaSourceAdapter', () => {
   });
 });
 
+describe('mediaSourceProvider:_orderMediaSourceAdapters', () => {
+  it('should place NativeAdapter last with preferNative=false', () => {
+    MediaSourceProvider._mediaSourceAdapters = [FakeNativeAdapter, FakeHlsAdapter, FakeDashAdapter];
+    MediaSourceProvider._orderMediaSourceAdapters(false);
+    MediaSourceProvider._mediaSourceAdapters.length.should.equals(3);
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equals('HlsAdapter');
+    MediaSourceProvider._mediaSourceAdapters[1].id.should.equals('DashAdapter');
+    MediaSourceProvider._mediaSourceAdapters[2].id.should.equals('NativeAdapter');
+  });
+
+  it('should place NativeAdapter last with preferNative=false', () => {
+    MediaSourceProvider._mediaSourceAdapters = [FakeHlsAdapter, FakeNativeAdapter, FakeDashAdapter];
+    MediaSourceProvider._orderMediaSourceAdapters(false);
+    MediaSourceProvider._mediaSourceAdapters.length.should.equals(3);
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equals('HlsAdapter');
+    MediaSourceProvider._mediaSourceAdapters[1].id.should.equals('DashAdapter');
+    MediaSourceProvider._mediaSourceAdapters[2].id.should.equals('NativeAdapter');
+  });
+
+  it('should place NativeAdapter last with preferNative=false', () => {
+    MediaSourceProvider._mediaSourceAdapters = [FakeHlsAdapter, FakeDashAdapter, FakeNativeAdapter];
+    MediaSourceProvider._orderMediaSourceAdapters(false);
+    MediaSourceProvider._mediaSourceAdapters.length.should.equals(3);
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equals('HlsAdapter');
+    MediaSourceProvider._mediaSourceAdapters[1].id.should.equals('DashAdapter');
+    MediaSourceProvider._mediaSourceAdapters[2].id.should.equals('NativeAdapter');
+  });
+
+  it('should place NativeAdapter first with preferNative=true', () => {
+    MediaSourceProvider._mediaSourceAdapters = [FakeNativeAdapter, FakeHlsAdapter, FakeDashAdapter];
+    MediaSourceProvider._orderMediaSourceAdapters(true);
+    MediaSourceProvider._mediaSourceAdapters.length.should.equals(3);
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equals('NativeAdapter');
+    MediaSourceProvider._mediaSourceAdapters[1].id.should.equals('HlsAdapter');
+    MediaSourceProvider._mediaSourceAdapters[2].id.should.equals('DashAdapter');
+  });
+
+  it('should place NativeAdapter first with preferNative=true', () => {
+    MediaSourceProvider._mediaSourceAdapters = [FakeHlsAdapter, FakeNativeAdapter, FakeDashAdapter];
+    MediaSourceProvider._orderMediaSourceAdapters(true);
+    MediaSourceProvider._mediaSourceAdapters.length.should.equals(3);
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equals('NativeAdapter');
+    MediaSourceProvider._mediaSourceAdapters[1].id.should.equals('HlsAdapter');
+    MediaSourceProvider._mediaSourceAdapters[2].id.should.equals('DashAdapter');
+  });
+
+  it('should place NativeAdapter first with preferNative=true', () => {
+    MediaSourceProvider._mediaSourceAdapters = [FakeHlsAdapter, FakeDashAdapter, FakeNativeAdapter];
+    MediaSourceProvider._orderMediaSourceAdapters(true);
+    MediaSourceProvider._mediaSourceAdapters.length.should.equals(3);
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equals('NativeAdapter');
+    MediaSourceProvider._mediaSourceAdapters[1].id.should.equals('HlsAdapter');
+    MediaSourceProvider._mediaSourceAdapters[2].id.should.equals('DashAdapter');
+  });
+
+  it('should place NativeAdapter first with preferNative=true', () => {
+    MediaSourceProvider._mediaSourceAdapters = [FakeNativeAdapter];
+    MediaSourceProvider._orderMediaSourceAdapters(true);
+    MediaSourceProvider._mediaSourceAdapters.length.should.equals(1);
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equals('NativeAdapter');
+  });
+
+  it('should place NativeAdapter first with preferNative=false', () => {
+    MediaSourceProvider._mediaSourceAdapters = [FakeNativeAdapter];
+    MediaSourceProvider._orderMediaSourceAdapters(false);
+    MediaSourceProvider._mediaSourceAdapters.length.should.equals(1);
+    MediaSourceProvider._mediaSourceAdapters[0].id.should.equals('NativeAdapter');
+  });
+});


### PR DESCRIPTION
### Description of the Changes

Change the implementation of preferNative logic for order the MSEs array, instead of return always false in NativeAdapter when preferNative=false.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
