### PR TITLE
fix(FEC-7242): subtitles transition in safari 9.0

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -49,9 +49,3 @@
   left: 0;
 }
 
-.playkit-subtitles > div > div {
-  -webkit-transition: 0.3s ease-in-out;
-  -moz-transition: 0.3s ease-in-out;
-  -o-transition: 0.3s ease-in-out;
-  transition: 0.3s ease-in-out;
-}


### PR DESCRIPTION
### Description of the Changes

subtitles are dropping from the top of the player to their correct location in safari 9. it looks like animation.. the correct behaviour would be that the subtitles appears at the bottom of the player.

@OrenMe - seems like there is duplication in the css.. why is there a css file for the subtitles in the playkit-js? isn't all the ui handled in the playkit-ui-js? should i try and remove the whole file?

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
