### PR TITLE
fix(fec-7334): the player state has not saved on change media

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1310,8 +1310,10 @@ export default class Player extends FakeEventTarget {
 
     this.hideTextTrack();
 
-    this._setDefaultTrack(TrackTypes.TEXT, this._playbackAttributesState.textLang, this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT), offTextTrack);
-    this._setDefaultTrack(TrackTypes.AUDIO, this._playbackAttributesState.audioLang, playbackConfig.audioLanguage, activeTracks.audio);
+    let currentOrConfiguredTextLang = this._playbackAttributesState.textLang || this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT);
+    let currentOrConfiguredAudioLang = this._playbackAttributesState.audioLang || playbackConfig.audioLanguage;
+    this._setDefaultTrack(TrackTypes.TEXT, currentOrConfiguredTextLang, offTextTrack);
+    this._setDefaultTrack(TrackTypes.AUDIO, currentOrConfiguredAudioLang, activeTracks.audio);
   }
 
   /**
@@ -1341,23 +1343,17 @@ export default class Player extends FakeEventTarget {
   /**
    * Sets a specific default track.
    * @param {string} type - The track type.
-   * @param {string} currentLang - The current playback track language (in case of change media).
-   * @param {string} configuredLang - The configured track language.
+   * @param {string} language - The language of config or the current (in case of change media).
    * @param {?Track} defaultTrack - The default track to set in case there is no language configured.
    * @returns {void}
    * @private
    */
-  _setDefaultTrack(type: string, currentLang: string, configuredLang: string, defaultTrack: ?Track): void {
-    const currentTrack: ?Track = this._getTracksByType(type).find(track => Track.langComparer(currentLang, track.language));
-    if (currentTrack) {
-      this.selectTrack(currentTrack);
+  _setDefaultTrack(type: string, language: string, defaultTrack: ?Track): void {
+    const track: ?Track = this._getTracksByType(type).find(track => Track.langComparer(language, track.language));
+    if (language) {
+      this.selectTrack(track);
     } else {
-      const configuredTrack: ?Track = this._getTracksByType(type).find(track => Track.langComparer(configuredLang, track.language));
-      if (configuredTrack) {
-        this.selectTrack(configuredTrack);
-      } else {
-        this.selectTrack(defaultTrack);
-      }
+      this.selectTrack(defaultTrack);
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -235,8 +235,8 @@ export default class Player extends FakeEventTarget {
     muted: undefined,
     volume: undefined,
     rate: undefined,
-    audioLang: "",
-    textLang: ""
+    audioLanguage: "",
+    textLanguage: ""
   };
 
 
@@ -715,7 +715,7 @@ export default class Player extends FakeEventTarget {
       } else if (track instanceof TextTrack) {
         if (track.language === OFF) {
           this.hideTextTrack();
-          this._playbackAttributesState.textLang = OFF;
+          this._playbackAttributesState.textLanguage = OFF;
         } else {
           this._engine.selectTextTrack(track);
         }
@@ -1019,12 +1019,12 @@ export default class Player extends FakeEventTarget {
         return this.dispatchEvent(event);
       });
       this._eventManager.listen(this._engine, CustomEvents.AUDIO_TRACK_CHANGED, (event: FakeEvent) => {
-        this._playbackAttributesState.audioLang = event.payload.selectedAudioTrack.language;
+        this._playbackAttributesState.audioLanguage = event.payload.selectedAudioTrack.language;
         this._markActiveTrack(event.payload.selectedAudioTrack);
         return this.dispatchEvent(event);
       });
       this._eventManager.listen(this._engine, CustomEvents.TEXT_TRACK_CHANGED, (event: FakeEvent) => {
-        this._playbackAttributesState.textLang = event.payload.selectedTextTrack.language;
+        this._playbackAttributesState.textLanguage = event.payload.selectedTextTrack.language;
         this._markActiveTrack(event.payload.selectedTextTrack);
         return this.dispatchEvent(event);
       });
@@ -1310,8 +1310,8 @@ export default class Player extends FakeEventTarget {
 
     this.hideTextTrack();
 
-    let currentOrConfiguredTextLang = this._playbackAttributesState.textLang || this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT);
-    let currentOrConfiguredAudioLang = this._playbackAttributesState.audioLang || playbackConfig.audioLanguage;
+    let currentOrConfiguredTextLang = this._playbackAttributesState.textLanguage || this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT);
+    let currentOrConfiguredAudioLang = this._playbackAttributesState.audioLanguage || playbackConfig.audioLanguage;
     this._setDefaultTrack(TrackTypes.TEXT, currentOrConfiguredTextLang, offTextTrack);
     this._setDefaultTrack(TrackTypes.AUDIO, currentOrConfiguredAudioLang, activeTracks.audio);
   }

--- a/src/player.js
+++ b/src/player.js
@@ -702,11 +702,11 @@ export default class Player extends FakeEventTarget {
   /**
    * Select a track
    * @function selectTrack
-   * @param {Track} track - the track to select
+   * @param {?Track} track - the track to select
    * @returns {void}
    * @public
    */
-  selectTrack(track: Track): void {
+  selectTrack(track: ?Track): void {
     if (this._engine) {
       if (track instanceof VideoTrack) {
         this._engine.selectVideoTrack(track);

--- a/src/player.js
+++ b/src/player.js
@@ -227,11 +227,11 @@ export default class Player extends FakeEventTarget {
    */
   _streamType: string;
   /**
-   * The current playback options state
+   * The current playback attributes state
    * @type {Object}
    * @private
    */
-  _playbackOptionsState: { [option: string]: any } = {
+  _playbackAttributesState: { [attribute: string]: any } = {
     MUTED: undefined,
     VOLUME: undefined,
     RATE: undefined,
@@ -387,7 +387,7 @@ export default class Player extends FakeEventTarget {
     this._streamType = '';
     this._readyPromise = null;
     this._firstPlay = true;
-    this._playbackOptionsState = {};
+    this._playbackAttributesState = {};
     if (this._el) {
       Utils.Dom.removeChild(this._el.parentNode, this._el);
     }
@@ -715,7 +715,7 @@ export default class Player extends FakeEventTarget {
       } else if (track instanceof TextTrack) {
         if (track.language === OFF) {
           this.hideTextTrack();
-          this._playbackOptionsState.TEXT_LANG = OFF;
+          this._playbackAttributesState.TEXT_LANG = OFF;
         } else {
           this._engine.selectTextTrack(track);
         }
@@ -1019,12 +1019,12 @@ export default class Player extends FakeEventTarget {
         return this.dispatchEvent(event);
       });
       this._eventManager.listen(this._engine, CustomEvents.AUDIO_TRACK_CHANGED, (event: FakeEvent) => {
-        this._playbackOptionsState.AUDIO_LANG = event.payload.selectedAudioTrack.language;
+        this._playbackAttributesState.AUDIO_LANG = event.payload.selectedAudioTrack.language;
         this._markActiveTrack(event.payload.selectedAudioTrack);
         return this.dispatchEvent(event);
       });
       this._eventManager.listen(this._engine, CustomEvents.TEXT_TRACK_CHANGED, (event: FakeEvent) => {
-        this._playbackOptionsState.TEXT_LANG = event.payload.selectedTextTrack.language;
+        this._playbackAttributesState.TEXT_LANG = event.payload.selectedTextTrack.language;
         this._markActiveTrack(event.payload.selectedTextTrack);
         return this.dispatchEvent(event);
       });
@@ -1033,11 +1033,11 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this, Html5Events.PLAY, this._onPlay.bind(this));
       this._eventManager.listen(this, Html5Events.ENDED, this._onEnded.bind(this));
       this._eventManager.listen(this, Html5Events.VOLUME_CHANGE, () => {
-        this._playbackOptionsState.MUTED = this.muted;
-        this._playbackOptionsState.VOLUME = this.volume;
+        this._playbackAttributesState.MUTED = this.muted;
+        this._playbackAttributesState.VOLUME = this.volume;
       });
       this._eventManager.listen(this, Html5Events.RATE_CHANGE, () => {
-        this._playbackOptionsState.RATE = this.playbackRate;
+        this._playbackAttributesState.RATE = this.playbackRate;
       });
     }
   }
@@ -1049,13 +1049,13 @@ export default class Player extends FakeEventTarget {
    */
   _handlePlaybackOptions(): void {
     this._config.playback = this._config.playback || {};
-    if (typeof this._playbackOptionsState.MUTED === 'boolean') {
-      this.muted = this._playbackOptionsState.MUTED;
+    if (typeof this._playbackAttributesState.MUTED === 'boolean') {
+      this.muted = this._playbackAttributesState.MUTED;
     } else if (typeof this._config.playback.muted === 'boolean') {
       this.muted = this._config.playback.muted;
     }
-    if (typeof this._playbackOptionsState.VOLUME === 'number') {
-      this.volume = this._playbackOptionsState.VOLUME;
+    if (typeof this._playbackAttributesState.VOLUME === 'number') {
+      this.volume = this._playbackAttributesState.VOLUME;
     } else if (typeof this._config.playback.volume === 'number') {
       this.volume = this._config.playback.volume;
     }
@@ -1139,8 +1139,8 @@ export default class Player extends FakeEventTarget {
       this._firstPlay = false;
       this.dispatchEvent(new FakeEvent(CustomEvents.FIRST_PLAY));
       this._posterManager.hide();
-      if (typeof this._playbackOptionsState.RATE === 'number') {
-        this.playbackRate = this._playbackOptionsState.RATE;
+      if (typeof this._playbackAttributesState.RATE === 'number') {
+        this.playbackRate = this._playbackAttributesState.RATE;
       }
     }
   }
@@ -1308,8 +1308,8 @@ export default class Player extends FakeEventTarget {
 
     this.hideTextTrack();
 
-    this._setDefaultTrack(TrackTypes.TEXT, this._playbackOptionsState.TEXT_LANG, this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT), offTextTrack);
-    this._setDefaultTrack(TrackTypes.AUDIO, this._playbackOptionsState.AUDIO_LANG, playbackConfig.audioLanguage, activeTracks.audio);
+    this._setDefaultTrack(TrackTypes.TEXT, this._playbackAttributesState.TEXT_LANG, this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT), offTextTrack);
+    this._setDefaultTrack(TrackTypes.AUDIO, this._playbackAttributesState.AUDIO_LANG, playbackConfig.audioLanguage, activeTracks.audio);
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -232,11 +232,11 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _playbackAttributesState: { [attribute: string]: any } = {
-    MUTED: undefined,
-    VOLUME: undefined,
-    RATE: undefined,
-    AUDIO_LANG: "",
-    TEXT_LANG: ""
+    muted: undefined,
+    volume: undefined,
+    rate: undefined,
+    audioLang: "",
+    textLang: ""
   };
 
 
@@ -715,7 +715,7 @@ export default class Player extends FakeEventTarget {
       } else if (track instanceof TextTrack) {
         if (track.language === OFF) {
           this.hideTextTrack();
-          this._playbackAttributesState.TEXT_LANG = OFF;
+          this._playbackAttributesState.textLang = OFF;
         } else {
           this._engine.selectTextTrack(track);
         }
@@ -1019,12 +1019,12 @@ export default class Player extends FakeEventTarget {
         return this.dispatchEvent(event);
       });
       this._eventManager.listen(this._engine, CustomEvents.AUDIO_TRACK_CHANGED, (event: FakeEvent) => {
-        this._playbackAttributesState.AUDIO_LANG = event.payload.selectedAudioTrack.language;
+        this._playbackAttributesState.audioLang = event.payload.selectedAudioTrack.language;
         this._markActiveTrack(event.payload.selectedAudioTrack);
         return this.dispatchEvent(event);
       });
       this._eventManager.listen(this._engine, CustomEvents.TEXT_TRACK_CHANGED, (event: FakeEvent) => {
-        this._playbackAttributesState.TEXT_LANG = event.payload.selectedTextTrack.language;
+        this._playbackAttributesState.textLang = event.payload.selectedTextTrack.language;
         this._markActiveTrack(event.payload.selectedTextTrack);
         return this.dispatchEvent(event);
       });
@@ -1033,13 +1033,13 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this, Html5Events.PLAY, this._onPlay.bind(this));
       this._eventManager.listen(this, Html5Events.ENDED, this._onEnded.bind(this));
       this._eventManager.listen(this, CustomEvents.MUTE_CHANGE, () => {
-        this._playbackAttributesState.MUTED = this.muted;
+        this._playbackAttributesState.muted = this.muted;
       });
       this._eventManager.listen(this, Html5Events.VOLUME_CHANGE, () => {
-        this._playbackAttributesState.VOLUME = this.volume;
+        this._playbackAttributesState.volume = this.volume;
       });
       this._eventManager.listen(this, Html5Events.RATE_CHANGE, () => {
-        this._playbackAttributesState.RATE = this.playbackRate;
+        this._playbackAttributesState.rate = this.playbackRate;
       });
     }
   }
@@ -1051,13 +1051,13 @@ export default class Player extends FakeEventTarget {
    */
   _handlePlaybackOptions(): void {
     this._config.playback = this._config.playback || {};
-    if (typeof this._playbackAttributesState.MUTED === 'boolean') {
-      this.muted = this._playbackAttributesState.MUTED;
+    if (typeof this._playbackAttributesState.muted === 'boolean') {
+      this.muted = this._playbackAttributesState.muted;
     } else if (typeof this._config.playback.muted === 'boolean') {
       this.muted = this._config.playback.muted;
     }
-    if (typeof this._playbackAttributesState.VOLUME === 'number') {
-      this.volume = this._playbackAttributesState.VOLUME;
+    if (typeof this._playbackAttributesState.volume === 'number') {
+      this.volume = this._playbackAttributesState.volume;
     } else if (typeof this._config.playback.volume === 'number') {
       this.volume = this._config.playback.volume;
     }
@@ -1141,8 +1141,8 @@ export default class Player extends FakeEventTarget {
       this._firstPlay = false;
       this.dispatchEvent(new FakeEvent(CustomEvents.FIRST_PLAY));
       this._posterManager.hide();
-      if (typeof this._playbackAttributesState.RATE === 'number') {
-        this.playbackRate = this._playbackAttributesState.RATE;
+      if (typeof this._playbackAttributesState.rate === 'number') {
+        this.playbackRate = this._playbackAttributesState.rate;
       }
     }
   }
@@ -1310,8 +1310,8 @@ export default class Player extends FakeEventTarget {
 
     this.hideTextTrack();
 
-    this._setDefaultTrack(TrackTypes.TEXT, this._playbackAttributesState.TEXT_LANG, this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT), offTextTrack);
-    this._setDefaultTrack(TrackTypes.AUDIO, this._playbackAttributesState.AUDIO_LANG, playbackConfig.audioLanguage, activeTracks.audio);
+    this._setDefaultTrack(TrackTypes.TEXT, this._playbackAttributesState.textLang, this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT), offTextTrack);
+    this._setDefaultTrack(TrackTypes.AUDIO, this._playbackAttributesState.audioLang, playbackConfig.audioLanguage, activeTracks.audio);
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -1066,6 +1066,11 @@ export default class Player extends FakeEventTarget {
     }
   }
 
+  /**
+   * Handles preload.
+   * @returns {void}
+   * @private
+   */
   _handlePreload(): void {
     if (this._config.playback.preload === "auto") {
       /**
@@ -1080,6 +1085,11 @@ export default class Player extends FakeEventTarget {
     }
   }
 
+  /**
+   * Handles auto play.
+   * @returns {void}
+   * @private
+   */
   _handleAutoPlay(): void {
     if (this._canAutoPlay()) {
       this.play();

--- a/src/player.js
+++ b/src/player.js
@@ -1343,14 +1343,14 @@ export default class Player extends FakeEventTarget {
   /**
    * Sets a specific default track.
    * @param {string} type - The track type.
-   * @param {string} language - The language of config or the current (in case of change media).
+   * @param {string} language - The track language.
    * @param {?Track} defaultTrack - The default track to set in case there is no language configured.
    * @returns {void}
    * @private
    */
   _setDefaultTrack(type: string, language: string, defaultTrack: ?Track): void {
     const track: ?Track = this._getTracksByType(type).find(track => Track.langComparer(language, track.language));
-    if (language) {
+    if (track) {
       this.selectTrack(track);
     } else {
       this.selectTrack(defaultTrack);

--- a/src/player.js
+++ b/src/player.js
@@ -1032,8 +1032,10 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEvents.ABR_MODE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this, Html5Events.PLAY, this._onPlay.bind(this));
       this._eventManager.listen(this, Html5Events.ENDED, this._onEnded.bind(this));
-      this._eventManager.listen(this, Html5Events.VOLUME_CHANGE, () => {
+      this._eventManager.listen(this, CustomEvents.MUTE_CHANGE, () => {
         this._playbackAttributesState.MUTED = this.muted;
+      });
+      this._eventManager.listen(this, Html5Events.VOLUME_CHANGE, () => {
         this._playbackAttributesState.VOLUME = this.volume;
       });
       this._eventManager.listen(this, Html5Events.RATE_CHANGE, () => {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1822,7 +1822,7 @@ describe('configure', function () {
       });
     });
 
-    it('should load the previous playback config and initiate the new one on updating sources', function (done) {
+    it('should load the initial config and initiate the new one on updating sources', function (done) {
       player = new Player({
         sources: sourcesConfig.MultipleSources,
         playback: {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1785,19 +1785,56 @@ describe('configure', function () {
       player.muted.should.be.true;
     });
 
-    it('should load the initial playback config and initiate the new one on updating sources', function (done) {
+    it('should load the previous playback config and initiate the new one on updating sources', function (done) {
       player = new Player({
         sources: sourcesConfig.MultipleSources,
         playback: {
           muted: true,
-          volume: 0,
+          volume: 0.5
         }
       });
       player.load();
-      player.volume.should.equals(0);
+      player.volume.should.equals(0.5);
       player.muted.should.be.true;
+      player.config.playback.volume.should.equals(0.5);
       player.config.playback.muted.should.be.true;
-      player.config.playback.volume.should.equals(0);
+      player.ready().then(() => {
+        player.src.should.equals(window.location.origin + sourcesConfig.MultipleSources.progressive[0].url);
+        player.addEventListener(player.Event.VOLUME_CHANGE, () => {
+          let newProgressiveConfig = {
+            progressive: [sourcesConfig.MultipleSources.progressive[1]]
+          };
+          player.configure({
+            sources: newProgressiveConfig
+          });
+          player.load();
+          player.volume.should.equals(1);
+          player.muted.should.be.false;
+          player.config.playback.volume.should.equals(0.5);
+          player.config.playback.muted.should.be.true;
+          player.ready().then(() => {
+            player.src.should.equals(window.location.origin + newProgressiveConfig.progressive[0].url);
+            done();
+          });
+        });
+        player.muted = false;
+        player.volume = 1;
+      });
+    });
+
+    it('should load the previous playback config and initiate the new one on updating sources', function (done) {
+      player = new Player({
+        sources: sourcesConfig.MultipleSources,
+        playback: {
+          muted: true,
+          volume: 1,
+        }
+      });
+      player.load();
+      player.volume.should.equals(1);
+      player.muted.should.be.true;
+      player.config.playback.volume.should.equals(1);
+      player.config.playback.muted.should.be.true;
       player.ready().then(() => {
         player.src.should.equals(window.location.origin + sourcesConfig.MultipleSources.progressive[0].url);
         player.configure({
@@ -1806,21 +1843,22 @@ describe('configure', function () {
             volume: 0.5
           }
         });
-        player.volume.should.equals(0);
+        player.volume.should.equals(1);
         player.muted.should.be.true;
-        player.config.playback.muted.should.be.false;
         player.config.playback.volume.should.equals(0.5);
+        player.config.playback.muted.should.be.false;
         let newProgressiveConfig = {
           progressive: [sourcesConfig.MultipleSources.progressive[1]]
         };
+        player._playbackAttributesState = {};
         player.configure({
           sources: newProgressiveConfig
         });
         player.load();
         player.volume.should.equals(0.5);
         player.muted.should.be.false;
-        player.config.playback.muted.should.be.false;
         player.config.playback.volume.should.equals(0.5);
+        player.config.playback.muted.should.be.false;
         player.ready().then(() => {
           player.src.should.equals(window.location.origin + newProgressiveConfig.progressive[0].url);
           done();


### PR DESCRIPTION
### Description of the Changes
on change media we are considering the player config but not to the current state of the following player attributes: 
* muted
* volume
* text language
* audio language
* playback rate

the solution is: 
* saving the state of the attributes above
* considering them (on change media) before player config  
 
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
