### PR TITLE
fix: filter empty video element text tracks

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -333,7 +333,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _getParsedTextTracks(): Array<Track> {
-    let textTracks = this._videoElement.textTracks;
+    let textTracks = this._filterVideoElementTextTracks();
     let parsedTracks = [];
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
@@ -344,12 +344,26 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           language: textTracks[i].language,
           index: i
         };
-        if (settings.language || settings.label) {
-          parsedTracks.push(new PKTextTrack(settings));
-        }
+        parsedTracks.push(new PKTextTrack(settings));
       }
     }
     return parsedTracks;
+  }
+
+  /**
+   * Filtered empty text tracks from the video element.
+   * @returns {Array} - The filtered text tracks array.
+   * @private
+   */
+  _filterVideoElementTextTracks() {
+    let textTracks = [];
+    for (let i = 0; i < this._videoElement.textTracks.length; i++) {
+      let vidTextTrack = this._videoElement.textTracks[i];
+      if (vidTextTrack.language || vidTextTrack.label) {
+        textTracks.push(vidTextTrack);
+      }
+    }
+    return textTracks;
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Filter text tracks without language or label.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
