### PR TITLE
revert: "filter empty video element text tracks (#150)"

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -333,7 +333,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _getParsedTextTracks(): Array<Track> {
-    let textTracks = this._filterVideoElementTextTracks();
+    let textTracks = this._videoElement.textTracks;
     let parsedTracks = [];
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
@@ -344,26 +344,12 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           language: textTracks[i].language,
           index: i
         };
-        parsedTracks.push(new PKTextTrack(settings));
+        if (settings.language || settings.label) {
+          parsedTracks.push(new PKTextTrack(settings));
+        }
       }
     }
     return parsedTracks;
-  }
-
-  /**
-   * Filtered empty text tracks from the video element.
-   * @returns {Array} - The filtered text tracks array.
-   * @private
-   */
-  _filterVideoElementTextTracks() {
-    let textTracks = [];
-    for (let i = 0; i < this._videoElement.textTracks.length; i++) {
-      let vidTextTrack = this._videoElement.textTracks[i];
-      if (vidTextTrack.language || vidTextTrack.label) {
-        textTracks.push(vidTextTrack);
-      }
-    }
-    return textTracks;
   }
 
   /**


### PR DESCRIPTION
This reverts commit 58ada7c707343fb73b9a75cade133988b8ecb8fc.

### Description of the Changes

the filter fix is wrong. 
we have to promote the `index` also for "non valid" track (without language or label) since we consider the `index` in `selectTextTrack`, when we enable the desired track from the video element tracks list which contains the "non valid" track also.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
