### PR TITLE
fix(FEC-7335): reset subtitle display on player reset

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1252,6 +1252,7 @@ export default class Player extends FakeEventTarget {
     this._pluginManager.reset();
     this._eventManager.removeAll();
     this._activeTextCues = [];
+    this._updateTextDisplay([]);
     this._tracks = [];
     this._firstPlay = true;
     this._firstPlayInCurrentSession = false;

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2362,6 +2362,7 @@ describe('_reset', function () {
     let eventMgrSpy = sandbox.spy(player._eventManager, 'removeAll');
     let pluginMgrSpy = sandbox.spy(player._pluginManager, 'reset');
     let stateMgrSpy = sandbox.spy(player._stateManager, 'reset');
+    let _updateTextDisplay = sandbox.spy(player, '_updateTextDisplay');
     player._reset();
     player.paused.should.be.true;
     posterMgrSpy.should.have.been.calledOnce;
@@ -2369,8 +2370,8 @@ describe('_reset', function () {
     pluginMgrSpy.should.have.been.calledOnce;
     stateMgrSpy.should.have.been.calledOnce;
     player._activeTextCues.should.be.empty;
-    player._updateTextDisplay.should.have.been.calledOnce;
-    player._updateTextDisplay.should.have.been.calledWith([]);
+    _updateTextDisplay.should.have.been.calledOnce;
+    _updateTextDisplay.should.have.been.calledWith([]);
     player._config.should.not.be.empty;
     player._tracks.should.be.empty;
     player._engineType.should.be.empty;

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2369,6 +2369,8 @@ describe('_reset', function () {
     pluginMgrSpy.should.have.been.calledOnce;
     stateMgrSpy.should.have.been.calledOnce;
     player._activeTextCues.should.be.empty;
+    player._updateTextDisplay.should.have.been.calledOnce;
+    player._updateTextDisplay.should.have.been.calledWith([]);
     player._config.should.not.be.empty;
     player._tracks.should.be.empty;
     player._engineType.should.be.empty;


### PR DESCRIPTION
### Description of the Changes

subtitle persist after setting new sources, need to reset the subtitle display state on reset

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
