### PR TITLE
fix: empty captions menu when playing native hls

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -333,7 +333,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _getParsedTextTracks(): Array<Track> {
-    let textTracks = this._filterVideoElementTextTracks();
+    let textTracks = this._videoElement.textTracks;
     let parsedTracks = [];
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
@@ -344,26 +344,12 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           language: textTracks[i].language,
           index: i
         };
-        parsedTracks.push(new PKTextTrack(settings));
+        if (settings.language || settings.label) {
+          parsedTracks.push(new PKTextTrack(settings));
+        }
       }
     }
     return parsedTracks;
-  }
-
-  /**
-   * Filtered empty text tracks from the video element.
-   * @returns {Array} - The filtered text tracks array.
-   * @private
-   */
-  _filterVideoElementTextTracks() {
-    let textTracks = [];
-    for (let i = 0; i < this._videoElement.textTracks.length; i++) {
-      let vidTextTrack = this._videoElement.textTracks[i];
-      if (vidTextTrack.language || vidTextTrack.label) {
-        textTracks.push(vidTextTrack);
-      }
-    }
-    return textTracks;
   }
 
   /**

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -224,7 +224,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @private
    * @returns {void}
    */
-  _onError(reject: Function, error: Event): void {
+  _onError(reject: Function, error: FakeEvent): void {
     NativeAdapter._logger.error(error);
     reject(error);
   }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -180,16 +180,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
       this._loadPromise = new Promise((resolve, reject) => {
-        // We're using 'loadeddata' event for native hls (on 'loadedmetadata' native hls doesn't have tracks yet).
-        this._eventManager.listenOnce(this._videoElement, Html5Events.LOADED_DATA, () => {
-          let data = {tracks: this._getParsedTracks()};
-          NativeAdapter._logger.debug('The source has been loaded successfully');
-          resolve(data);
-        });
-        this._eventManager.listenOnce(this._videoElement, Html5Events.ERROR, (error) => {
-          NativeAdapter._logger.error(error);
-          reject(error);
-        });
+        this._eventManager.listenOnce(this._videoElement, Html5Events.LOADED_DATA, this._onLoadedData.bind(this, resolve));
+        this._eventManager.listenOnce(this._videoElement, Html5Events.ERROR, this._onError.bind(this, reject));
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();
         }
@@ -204,6 +196,37 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       });
     }
     return this._loadPromise;
+  }
+
+  /**
+   * Loaded data event handler.
+   * @param {Function} resolve - The resolve promise function.
+   * @private
+   * @returns {void}
+   */
+  _onLoadedData(resolve: Function): void {
+    const parseTracksAndResolve = () => {
+      let data = {tracks: this._getParsedTracks()};
+      NativeAdapter._logger.debug('The source has been loaded successfully');
+      resolve(data);
+    };
+    if (this._videoElement.textTracks.length > 0) {
+      parseTracksAndResolve();
+    } else {
+      this._eventManager.listenOnce(this._videoElement, Html5Events.CAN_PLAY, parseTracksAndResolve.bind(this));
+    }
+  }
+
+  /**
+   * Error event handler.
+   * @param {Function} reject - The reject promise function.
+   * @param {FakeEvent} error - The error fake event.
+   * @private
+   * @returns {void}
+   */
+  _onError(reject: Function, error: Event): void {
+    NativeAdapter._logger.error(error);
+    reject(error);
   }
 
   /**

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -10,7 +10,7 @@ import {getSuitableSourceForResolution} from '../../../../utils/resolution'
 import * as Utils from '../../../../utils/util'
 import FairPlay from '../../../../drm/fairplay'
 import Env from '../../../../utils/env'
-
+import FakeEvent from '../../../../event/fake-event'
 /**
  * An illustration of media source extension for progressive download
  * @classdesc


### PR DESCRIPTION
### Description of the Changes

Sometimes, when playing native hls on Safari, text tracks are not ready on loadeddata event. If this the case, we will wait for canplay event and parse the tracks right after. 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
