### PR TITLE
feat: handle native selection of tracks

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -213,7 +213,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    */
   _onLoadedData(resolve: Function): void {
     const parseTracksAndResolve = () => {
-      this._parseTracks()
+      this._playerTracks = this._parseTracks();
       this._addNativeAudioTrackChangeListener();
       this._addNativeTextTrackChangeListener();
       NativeAdapter._logger.debug('The source has been loaded successfully');
@@ -259,14 +259,14 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   /**
    * Get the parsed tracks
    * @function _parseTracks
-   * @returns {void}
+   * @returns {Array<Track>} - The parsed tracks
    * @private
    */
-  _parseTracks(): void {
+  _parseTracks(): Array<Track> {
     const videoTracks = this._getParsedVideoTracks();
     const audioTracks = this._getParsedAudioTracks();
     const textTracks = this._getParsedTextTracks();
-    this._playerTracks = videoTracks.concat(audioTracks).concat(textTracks);
+    return videoTracks.concat(audioTracks).concat(textTracks);
   }
 
   /**

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -211,16 +211,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     return this._loadPromise;
   }
 
-  _addNativeTrackChangeListeners(): void {
-    this._addNativeAudioTrackChangeListener();
-    this._addNativeTextTrackChangeListener();
-  }
-
-  _removeNativeTrackChangeListeners(): void {
-    this._removeNativeAudioTrackChangeListener();
-    this._removeNativeTextTrackChangeListener();
-  }
-
   /**
    * Loaded data event handler.
    * @param {Function} resolve - The resolve promise function.
@@ -230,7 +220,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   _onLoadedData(resolve: Function): void {
     const parseTracksAndResolve = () => {
       let data = {tracks: this._getParsedTracks()};
-      this._addNativeTrackChangeListeners();
       NativeAdapter._logger.debug('The source has been loaded successfully');
       resolve(data);
     };
@@ -263,6 +252,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     return super.destroy().then(() => {
       this._eventManager.destroy();
       this._progressiveSources = [];
+      this._removeNativeAudioTrackChangeListener();
+      this._removeNativeTextTrackChangeListener();
       this._loadPromise = null;
       if (NativeAdapter._drmProtocol) {
         NativeAdapter._drmProtocol.destroy();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -213,7 +213,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    */
   _onLoadedData(resolve: Function): void {
     const parseTracksAndResolve = () => {
-      this._playerTracks = this._parseTracks();
+      this._playerTracks = this._getParsedTracks();
       this._addNativeAudioTrackChangeListener();
       this._addNativeTextTrackChangeListener();
       NativeAdapter._logger.debug('The source has been loaded successfully');
@@ -258,11 +258,11 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
 
   /**
    * Get the parsed tracks
-   * @function _parseTracks
+   * @function _getParsedTracks
    * @returns {Array<Track>} - The parsed tracks
    * @private
    */
-  _parseTracks(): Array<Track> {
+  _getParsedTracks(): Array<Track> {
     const videoTracks = this._getParsedVideoTracks();
     const audioTracks = this._getParsedAudioTracks();
     const textTracks = this._getParsedTextTracks();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -248,8 +248,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     return super.destroy().then(() => {
       this._eventManager.destroy();
       this._progressiveSources = [];
-      this._removeNativeAudioTrackChangeListener();
-      this._removeNativeTextTrackChangeListener();
       this._loadPromise = null;
       if (NativeAdapter._drmProtocol) {
         NativeAdapter._drmProtocol.destroy();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -219,9 +219,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    */
   _onLoadedData(resolve: Function): void {
     const parseTracksAndResolve = () => {
-      let data = {tracks: this._getParsedTracks()};
+      this._addNativeAudioTrackChangeListener();
+      this._addNativeTextTrackChangeListener();
       NativeAdapter._logger.debug('The source has been loaded successfully');
-      resolve(data);
+      resolve({tracks: this._getParsedTracks()});
     };
     if (this._videoElement.textTracks.length > 0) {
       parseTracksAndResolve();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -506,11 +506,11 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    */
   _onNativeAudioTrackChange(): void {
     const pkAudioTracks = this._playerTracks.filter(track => track instanceof AudioTrack);
-    const getActivePKAudioTracksIndex = () => {
+    const getActivePKAudioTrackIndex = () => {
       const activeAudioTrack = pkAudioTracks.find(track => track.active === true);
       return (activeAudioTrack ? activeAudioTrack.index : -1);
     };
-    const getActiveVidAudioTracksIndex = () => {
+    const getActiveVidAudioTrackIndex = () => {
       for (let i = 0; i < this._videoElement.audioTracks.length; i++) {
         const audioTrack = this._videoElement.audioTracks[i];
         if (audioTrack.enabled) {
@@ -520,8 +520,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       return -1;
     };
     NativeAdapter._logger.debug('Video element audio track change');
-    const vidIndex = getActiveVidAudioTracksIndex();
-    const pkIndex = getActivePKAudioTracksIndex();
+    const vidIndex = getActiveVidAudioTrackIndex();
+    const pkIndex = getActivePKAudioTrackIndex();
     if (vidIndex !== pkIndex) {
       const pkAudioTrack = pkAudioTracks.find(track => track.index === vidIndex);
       if (pkAudioTrack) {
@@ -582,11 +582,11 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   _onNativeTextTrackChange(): void {
     const pkTextTracks = this._playerTracks.filter(track => track instanceof PKTextTrack);
     const pkOffTrack = pkTextTracks.find(track => track.language === 'off');
-    const getActivePKTextTracksIndex = () => {
+    const getActivePKTextTrackIndex = () => {
       const activeTextTrack = pkTextTracks.find(track => track.active === true);
       return (activeTextTrack ? activeTextTrack.index : -1);
     };
-    const getActiveVidTextTracksIndex = () => {
+    const getActiveVidTextTrackIndex = () => {
       for (let i = 0; i < this._videoElement.textTracks.length; i++) {
         const textTrack = this._videoElement.textTracks[i];
         if (textTrack.mode === 'showing') {
@@ -596,8 +596,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       return -1;
     };
     NativeAdapter._logger.debug('Video element text track change');
-    const vidIndex = getActiveVidTextTracksIndex();
-    const pkIndex = getActivePKTextTracksIndex();
+    const vidIndex = getActiveVidTextTrackIndex();
+    const pkIndex = getActivePKTextTrackIndex();
     if (vidIndex !== pkIndex) {
       // In case no text track with 'showing' mode
       // we need to set the off track
@@ -608,7 +608,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         }
       } else {
         // In case the text track on the video element is
-        // differnr then the text track of the player
+        // different then the text track of the player
         // we need to set the correct one
         const pkTextTrack = pkTextTracks.find(track => track.index === vidIndex);
         if (pkTextTrack) {


### PR DESCRIPTION
### Description of the Changes

On iOS, when choosing from the native player (AVPlayer) audio track or text track, the player UI wasn't updated. 
This PR bring sync between the player UI and the native UI.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
