### PR TITLE
fix(FEC-7380, FEC-7381): there are captions displayed when the captions are supposed to be 'off'

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -299,6 +299,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _repositionCuesTimeout: any;
+
   /**
    * @param {Object} config - The configuration for the player instance.
    * @constructor
@@ -1498,7 +1499,7 @@ export default class Player extends FakeEventTarget {
 
     this.hideTextTrack();
 
-    let currentOrConfiguredTextLang = this._playbackAttributesState.textLanguage || this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT);
+    let currentOrConfiguredTextLang = this._playbackAttributesState.textLanguage || this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT) || OFF;
     let currentOrConfiguredAudioLang = this._playbackAttributesState.audioLanguage || playbackConfig.audioLanguage;
     this._setDefaultTrack(TrackTypes.TEXT, currentOrConfiguredTextLang, offTextTrack);
     this._setDefaultTrack(TrackTypes.AUDIO, currentOrConfiguredAudioLang, activeTracks.audio);

--- a/src/player.js
+++ b/src/player.js
@@ -1499,7 +1499,7 @@ export default class Player extends FakeEventTarget {
 
     this.hideTextTrack();
 
-    let currentOrConfiguredTextLang = this._playbackAttributesState.textLanguage || this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT) || OFF;
+    let currentOrConfiguredTextLang = this._playbackAttributesState.textLanguage || this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackTypes.TEXT);
     let currentOrConfiguredAudioLang = this._playbackAttributesState.audioLanguage || playbackConfig.audioLanguage;
     this._setDefaultTrack(TrackTypes.TEXT, currentOrConfiguredTextLang, offTextTrack);
     this._setDefaultTrack(TrackTypes.AUDIO, currentOrConfiguredAudioLang, activeTracks.audio);

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -15,7 +15,7 @@ export default class Track {
     try {
       inputLang = inputLang.toLowerCase();
       trackLang = trackLang.toLowerCase();
-      return inputLang.startsWith(trackLang) || trackLang.startsWith(inputLang);
+      return inputLang ? (inputLang.startsWith(trackLang) || trackLang.startsWith(inputLang)) : false;
     } catch (e) {
       return false;
     }

--- a/test/src/track/track.spec.js
+++ b/test/src/track/track.spec.js
@@ -15,5 +15,9 @@ describe('Track', () => {
       Track.langComparer('es', 'ita').should.be.false;
       Track.langComparer('ita', 'es').should.be.false;
     });
+
+    it('should return false if the input lang is empty', () => {
+      Track.langComparer('', 'rus').should.be.false;
+    });
   });
 });


### PR DESCRIPTION
### Description of the Changes

If the lang comparer receives an empty string as the input lang, it should always returns false (startsWith method will always return true for empty string...)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
