### PR TITLE
fix(FEC-7355): don't show poster when autoplaying is on

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,4 @@
-gitlet webpackConfig = require('./webpack.config.js');
+let webpackConfig = require('./webpack.config.js');
 //Need to remove externals otherwise they won't be included in test
 delete webpackConfig.externals;
 

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -39,6 +39,7 @@
   background-size: contain;
   background-position: center center;
   background-repeat: no-repeat;
+  background-color: #000;
 }
 
 .playkit-subtitles {

--- a/src/player.js
+++ b/src/player.js
@@ -346,8 +346,6 @@ export default class Player extends FakeEventTarget {
       }
       if (this._selectEngineByPriority()) {
         this._appendEngineEl();
-        this._posterManager.setSrc(this._config.metadata.poster);
-        this._posterManager.show();
         this._attachMedia();
         this._handlePlaybackOptions();
         this._handleAutoPlay();
@@ -1271,17 +1269,16 @@ export default class Player extends FakeEventTarget {
           .then((capabilities) => {
             if (capabilities.autoplay) {
               Player._logger.debug("Start autoplay");
-              this._posterManager.hide();
               this.play();
             } else {
               if (allowMutedAutoPlay) {
                 Player._logger.debug("Fallback to muted autoplay");
                 this.muted = true;
-                this._posterManager.hide();
                 this.play();
                 this.dispatchEvent(new FakeEvent(CustomEvents.FALLBACK_TO_MUTED_AUTOPLAY));
               } else {
                 Player._logger.warn("Autoplay failed, pause player");
+                this._posterManager.setAndShow(this._config.metadata.poster);
                 this.load();
                 this.ready().then(() => this.pause());
                 this.dispatchEvent(new FakeEvent(CustomEvents.AUTOPLAY_FAILED));
@@ -1289,6 +1286,8 @@ export default class Player extends FakeEventTarget {
             }
           });
       }
+    } else {
+      this._posterManager.setAndShow(this._config.metadata.poster);
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -320,8 +320,8 @@ export default class Player extends FakeEventTarget {
     this._textStyle = new TextStyle();
     this._createReadyPromise();
     this._createPlayerContainer();
+    this._appendPosterEl();
     this.configure(config);
-    (this.config.playback && !this.config.playback.autoplay) && this._appendPosterEl();
     this._repositionCuesTimeout = false;
   }
 
@@ -1271,11 +1271,13 @@ export default class Player extends FakeEventTarget {
           .then((capabilities) => {
             if (capabilities.autoplay) {
               Player._logger.debug("Start autoplay");
+              this._posterManager.hide();
               this.play();
             } else {
               if (allowMutedAutoPlay) {
                 Player._logger.debug("Fallback to muted autoplay");
                 this.muted = true;
+                this._posterManager.hide();
                 this.play();
                 this.dispatchEvent(new FakeEvent(CustomEvents.FALLBACK_TO_MUTED_AUTOPLAY));
               } else {

--- a/src/player.js
+++ b/src/player.js
@@ -320,8 +320,8 @@ export default class Player extends FakeEventTarget {
     this._textStyle = new TextStyle();
     this._createReadyPromise();
     this._createPlayerContainer();
-    this._appendPosterEl();
     this.configure(config);
+    (this.config.playback && !this.config.playback.autoplay) && this._appendPosterEl();
     this._repositionCuesTimeout = false;
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -348,6 +348,7 @@ export default class Player extends FakeEventTarget {
         this._appendEngineEl();
         this._attachMedia();
         this._handlePlaybackOptions();
+        this._posterManager.setSrc(this._config.metadata.poster);
         this._handleAutoPlay();
         if (receivedSourcesWhenHasEngine) {
           Player._logger.debug('Change source ended');
@@ -1278,7 +1279,7 @@ export default class Player extends FakeEventTarget {
                 this.dispatchEvent(new FakeEvent(CustomEvents.FALLBACK_TO_MUTED_AUTOPLAY));
               } else {
                 Player._logger.warn("Autoplay failed, pause player");
-                this._posterManager.setAndShow(this._config.metadata.poster);
+                this._posterManager.show();
                 this.load();
                 this.ready().then(() => this.pause());
                 this.dispatchEvent(new FakeEvent(CustomEvents.AUTOPLAY_FAILED));
@@ -1287,7 +1288,7 @@ export default class Player extends FakeEventTarget {
           });
       }
     } else {
-      this._posterManager.setAndShow(this._config.metadata.poster);
+      this._posterManager.show();
     }
   }
 

--- a/src/utils/poster-manager.js
+++ b/src/utils/poster-manager.js
@@ -76,6 +76,17 @@ class PosterManager {
   }
 
   /**
+   * set src & Show the poster image
+   * @public
+   * @param {string} posterUrl - the poster image URL
+   * @returns {void}
+   */
+  setAndShow(posterUrl: ?string): void {
+    this.setSrc(posterUrl);
+    this.show;
+  }
+
+  /**
    * Show the poster image
    * @public
    * @private

--- a/src/utils/poster-manager.js
+++ b/src/utils/poster-manager.js
@@ -28,8 +28,8 @@ class PosterManager {
   setSrc(posterUrl: ?string): void {
     if (posterUrl) {
       this._posterUrl = posterUrl;
-      Utils.Dom.setStyle(this._el, "background-color", "black");
       Utils.Dom.setStyle(this._el, "background-image", `url("${this._posterUrl}")`);
+      this.hide();
     }
   }
 
@@ -73,17 +73,6 @@ class PosterManager {
     if (this._el) {
       Utils.Dom.removeChild(this._el.parentNode, this._el);
     }
-  }
-
-  /**
-   * set src & Show the poster image
-   * @public
-   * @param {string} posterUrl - the poster image URL
-   * @returns {void}
-   */
-  setAndShow(posterUrl: ?string): void {
-    this.setSrc(posterUrl);
-    this.show;
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

When autoplay is on, the poster might be shown for few miliseconds, which looks buggy.
If autoplay is on & the browser is capable of doing it, I am hiding the poster element .


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
