### PR TITLE
chore: use one webpack.config for test and build

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,7 @@
+let webpackConfig = require('./webpack.config.js');
+//Need to remove externals otherwise they won't be included in test
+delete webpackConfig.externals;
+
 const isWindows = /^win/.test(process.platform);
 const isMacOS = /^darwin/.test(process.platform);
 // Create custom launcher in case running with Travis
@@ -54,26 +58,7 @@ module.exports = function (config) {
       'progress',
       'coverage'
     ],
-    webpack: {
-      devtool: 'inline-source-map',
-      module: {
-        rules: [{
-          test: /\.js$/,
-          use: [{
-            loader: "babel-loader"
-          }],
-          exclude: [
-            /node_modules/
-          ]
-        }, {
-          test: /\.css$/,
-          use: [
-            {loader: "style-loader"},
-            {loader: "css-loader"}
-          ]
-        }]
-      }
-    },
+    webpack: webpackConfig,
     webpackServer: {
       noInfo: true
     },


### PR DESCRIPTION
### Description of the Changes

use one `webpack.config.js` for both dev|build|test - saves boilerplate code and a change will be propagated to all places

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
