### PR TITLE
chore: reduce clutter of package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,27 +5,19 @@
   "scripts": {
     "clean": "rm -rf ./dist",
     "prebuild": "npm run clean",
-    "build:prod": "NODE_ENV=production webpack",
-    "build": "webpack",
-    "dev": "webpack --progress --colors --watch",
+    "build": "NODE_ENV=production webpack",
+    "dev": "webpack-dev-server",
+    "watch": "webpack --progress --colors --watch",
     "test": "NODE_ENV=test karma start --color",
-    "test:chrome": "NODE_ENV=test karma start --color --browsers Chrome",
-    "test:chrome:dots": "NODE_ENV=test karma start --color --browsers Chrome --reporters dots",
-    "test:firefox": "NODE_ENV=test karma start --color --browsers Firefox",
-    "test:safari": "NODE_ENV=test karma start --color --browsers Safari",
-    "test:watch": "NODE_ENV=test karma start --color --auto-watch",
-    "start": "webpack-dev-server",
-    "release:dry-run": "standard-version --dry-run",
     "release": "standard-version",
     "publish": "git push --follow-tags --no-verify origin master",
     "eslint": "eslint . --color",
     "flow": "flow check",
-    "eslint:flow:test": "npm run eslint && npm run flow && npm run test",
     "commit:dist": "git add --force --all dist && (git commit -m 'chore: update dist' || exit 0)"
   },
   "standard-version": {
     "scripts": {
-      "postbump": "yarn run build && yarn run build:prod && npm run commit:dist"
+      "postbump": "yarn run build && npm run commit:dist"
     }
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ if (PROD) {
 
 module.exports = {
   context: __dirname + "/src",
-  entry: PROD ? {"playkit.min": "playkit.js"} : {"playkit": "playkit.js"},
+  entry: {"playkit": "playkit.js"},
   output: {
     path: __dirname + "/dist",
     filename: '[name].js',


### PR DESCRIPTION
### Description of the Changes

reduce clutter in the package.json scripts, removing convenience scripts that were used during initial dev.
For testing browsers use either the karma.conf or define targets in the IDE

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
