### PR TITLE
fix(FEC-7504): explicit language is not working on production env 

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -759,9 +759,9 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       if (this._config.playback.useNativeTextTrack) {
         textTrackEl.mode = "showing";
       } else {
+        textTrackEl.oncuechange = (e) => this._onCueChange(e);
         textTrackEl.mode = this._showTextTrackFirstTime[textTrack.index] ? "hidden" : "showing";
         this._showTextTrackFirstTime[textTrack.index] = true;
-        textTrackEl.oncuechange = (e) => this._onCueChange(e);
       }
     }
   }


### PR DESCRIPTION
### Description of the Changes

Sometimes the cuechange event fired before we set the oncuechange handler to the selected text track element.
The solution is first to set the handler and then to change the text track mode.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
