### PR TITLE
fix: this._config.plugins.ima check fails if there are no plugins at all

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1317,7 +1317,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _canPreload(): boolean {
-    return (!this._config.playback.autoplay && this._config.playback.preload === "auto" && !this._config.plugins.ima);
+    return (!this._config.playback.autoplay && this._config.playback.preload === "auto" && this._config.plugins && !this._config.plugins.ima);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

In case the plugins property is undefined (when there are no plugins) the ima check fails, resulting in a load error (which retry resolves! : - ) )

Added protection

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
