### PR TITLE
fix(FEC-7564): durationchange not triggered while live playback - safari

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -196,6 +196,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._eventManager.listen(this._mediaSourceAdapter, CustomEvents.ABR_MODE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, CustomEvents.TEXT_CUE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, Html5Events.ERROR, (event: FakeEvent) => this.dispatchEvent(event));
+      this._eventManager.listen(this._mediaSourceAdapter, Html5Events.DURATION_CHANGE, (event: FakeEvent) => this.dispatchEvent(event));
     }
   }
 

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -81,6 +81,18 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _playerTracks: Array<Track>;
+  /**
+   * The id of _liveDurationChangeInterval
+   * @member {?number} - _liveDurationChangeInterval
+   * @private
+   */
+  _liveDurationChangeInterval: ?number;
+  /**
+   * The live edge value
+   * @member {number} - _liveEdge
+   * @private
+   */
+  _liveEdge: number;
 
   /**
    * Checks if NativeAdapter can play a given mime type.
@@ -143,6 +155,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     this._eventManager = new EventManager();
     this._maybeSetDrmPlayback();
     this._progressiveSources = config.sources.progressive;
+    this._liveEdge = 0;
   }
 
   /**
@@ -229,6 +242,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       this._addNativeTextTrackChangeListener();
       NativeAdapter._logger.debug('The source has been loaded successfully');
       resolve({tracks: this._playerTracks});
+      if (this.isLive()) {
+        this._handleLiveDurationChange();
+      }
     };
     if (this._videoElement.textTracks.length > 0) {
       parseTracksAndResolve();
@@ -259,6 +275,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       this._eventManager.destroy();
       this._progressiveSources = [];
       this._loadPromise = null;
+      this._liveEdge = 0;
+      clearInterval(this._liveDurationChangeInterval);
+      this._liveDurationChangeInterval = null;
       if (NativeAdapter._drmProtocol) {
         NativeAdapter._drmProtocol.destroy();
         NativeAdapter._drmProtocol = null;
@@ -741,6 +760,22 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    */
   isLive(): boolean {
     return this._videoElement.duration === Infinity;
+  }
+
+  /**
+   * Handling live duration change (as safari doesn't trigger durationchange event on live playback)
+   * @function _handleLiveDurationChange
+   * @returns {void}
+   * @private
+   */
+  _handleLiveDurationChange(): void {
+    this._liveDurationChangeInterval = setInterval(() => {
+      const liveEdge = this._getLiveEdge();
+      if (this._liveEdge !== liveEdge) {
+        this._liveEdge = liveEdge;
+        this._trigger(Html5Events.DURATION_CHANGE);
+      }
+    }, 2000);
   }
 
   /**

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -276,8 +276,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       this._progressiveSources = [];
       this._loadPromise = null;
       this._liveEdge = 0;
-      clearInterval(this._liveDurationChangeInterval);
-      this._liveDurationChangeInterval = null;
+      if (this._liveDurationChangeInterval) {
+        clearInterval(this._liveDurationChangeInterval);
+        this._liveDurationChangeInterval = null;
+      }
       if (NativeAdapter._drmProtocol) {
         NativeAdapter._drmProtocol.destroy();
         NativeAdapter._drmProtocol = null;
@@ -773,7 +775,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       const liveEdge = this._getLiveEdge();
       if (this._liveEdge !== liveEdge) {
         this._liveEdge = liveEdge;
-        this._trigger(Html5Events.DURATION_CHANGE);
+        this._trigger(Html5Events.DURATION_CHANGE, {});
       }
     }, 2000);
   }

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -227,6 +227,8 @@ describe('NativeAdapter: destroy', function () {
       nativeInstance.destroy().then(() => {
         (!nativeInstance._loadPromise).should.be.true;
         (!nativeInstance._sourceObj).should.be.true;
+        nativeInstance._liveEdge.should.equal(0);
+        (!nativeInstance._liveDurationChangeInterval).should.be.true;
         done();
       });
     });
@@ -680,6 +682,34 @@ describe('NativeAdapter: seekToLiveEdge', () => {
       nativeInstance.seekToLiveEdge();
       video.currentTime.should.equal(nativeInstance.duration);
       done();
+    }).catch(() => {
+      done();
+    });
+  });
+});
+
+describe('NativeAdapter: _handleLiveDurationChange', () => {
+  let video, nativeInstance;
+
+  beforeEach(() => {
+    video = document.createElement("video");
+  });
+
+  afterEach(() => {
+    nativeInstance.destroy();
+    nativeInstance = null;
+  });
+
+  after(() => {
+    removeVideoElementsFromTestPage();
+  });
+
+  it('should trigger durationchange for live', (done) => {
+    nativeInstance = NativeAdapter.createAdapter(video, sourcesConfig.Live.hls[0], {sources: {}});
+    nativeInstance.load().then(() => {
+      nativeInstance.addEventListener('durationchange', () => {
+        done();
+      });
     }).catch(() => {
       done();
     });

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -224,6 +224,7 @@ describe('NativeAdapter: destroy', function () {
     nativeInstance.load().then(() => {
       nativeInstance._loadPromise.should.be.exist;
       Utils.Object.isEmptyObject(nativeInstance._sourceObj).should.be.false;
+      nativeInstance._liveDurationChangeInterval = 20;
       nativeInstance.destroy().then(() => {
         (!nativeInstance._loadPromise).should.be.true;
         (!nativeInstance._sourceObj).should.be.true;


### PR DESCRIPTION
### Description of the Changes

Safari doesn't trigger `durationchange` while live playback. 
we need to trigger it by ourself. 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
