### PR TITLE
fix: canPreload check logic is not accurate

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1331,7 +1331,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _canPreload(): boolean {
-    return (!this._config.playback.autoplay && this._config.playback.preload === "auto" && this._config.plugins && !this._config.plugins.ima);
+    return (!this._config.playback.autoplay && this._config.playback.preload === "auto" && (!this._config.plugins || (this._config.plugins && !this._config.plugins.ima)));
   }
 
   /**


### PR DESCRIPTION
made the check for ima more accurate. there is nothing wrong with having plugins, it's the just ima plugin we want to avoid

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
