### PR TITLE
fix(FEC-7877): in different sizes video has black edges

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -18,7 +18,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  object-fit: contain;
+  object-fit: cover;
 }
 
 .playkit-engine video::-webkit-media-controls-panel,
@@ -36,7 +36,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background-size: contain;
+  background-size: cover;
   background-position: center center;
   background-repeat: no-repeat;
   background-color: #000;


### PR DESCRIPTION
### Description of the Changes

Change css settings of poster and video from `contain` to `cover`.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
