### PR TITLE
fix(FEC-7872): need to click one more time on player area in order to start playback

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -411,6 +411,8 @@ export default class Player extends FakeEventTarget {
   play(): void {
     if (this._engine) {
       this._playbackMiddleware.play(this._play.bind(this));
+    } else {
+      this._eventManager.listenOnce(this, this.Event.SOURCE_SELECTED, () => this.play());
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

Problem:
Player V3: Player stuck in case of multirequest is not fully loaded (need to click one more time on player area in order to start playback)

Solution:
In case play() has been called before engine is selected wait for SOURCE_SELECTED event and then trigger play() again.

Now we can perform safely calls to play() even if its too early.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
