### PR TITLE
fix(FEC-7933): Default language in IE11 is not the same as configured…

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1275,12 +1275,12 @@ export default class Player extends FakeEventTarget {
         return this.dispatchEvent(event);
       });
       this._eventManager.listen(this._engine, CustomEventType.AUDIO_TRACK_CHANGED, (event: FakeEvent) => {
-        this._playbackAttributesState.audioLanguage = event.payload.selectedAudioTrack.language;
+        this.ready().then(() => this._playbackAttributesState.audioLanguage = event.payload.selectedAudioTrack.language);
         this._markActiveTrack(event.payload.selectedAudioTrack);
         return this.dispatchEvent(event);
       });
       this._eventManager.listen(this._engine, CustomEventType.TEXT_TRACK_CHANGED, (event: FakeEvent) => {
-        this._playbackAttributesState.textLanguage = event.payload.selectedTextTrack.language;
+        this.ready().then(() => this._playbackAttributesState.textLanguage = event.payload.selectedTextTrack.language);
         this._markActiveTrack(event.payload.selectedTextTrack);
         return this.dispatchEvent(event);
       });


### PR DESCRIPTION
… as explicit

### Description of the Changes
The root cause of this issue is https://github.com/kaltura/playkit-js-hls/pull/50, since we wait to `loadedmetadata` for ready, meanwhile hlsjs selects the default audio language and this saved in the playback attributes object, and the configured language ignored.
The solution is to not save in the playback attributes object language which selected before the ready promise.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
