### PR TITLE
fix(FEC-7939): 'off' option appears twice after change media

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -427,13 +427,14 @@ export default class Player extends FakeEventTarget {
       this._loading = true;
       let startTime = this._config.playback.startTime;
       this._engine.load(startTime).then((data) => {
-        this._loading = false;
         this._updateTracks(data.tracks);
         this._setDefaultTracks();
         this.dispatchEvent(new FakeEvent(CustomEventType.TRACKS_CHANGED, {tracks: this._tracks}));
       }).catch((error) => {
-        this._loading = false;
         this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
+      // $FlowFixMe
+      }).finally(() => {
+        this._loading = false;
       });
     }
   }

--- a/src/player.js
+++ b/src/player.js
@@ -332,13 +332,18 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _repositionCuesTimeout: any;
-
   /**
    * Whether a load media request has sent, the player should wait to media.
    * @type {boolean}
    * @private
    */
   _loadingMedia: boolean;
+  /**
+   * Whether the player is loading a source.
+   * @type {boolean}
+   * @private
+   */
+  _loading: boolean;
 
   /**
    * @param {Object} config - The configuration for the player instance.
@@ -364,6 +369,7 @@ export default class Player extends FakeEventTarget {
     this.configure(config);
     this._repositionCuesTimeout = false;
     this._loadingMedia = false;
+    this._loading = false;
   }
 
   // <editor-fold desc="Public API">
@@ -417,7 +423,8 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   load(): void {
-    if (this._engine) {
+    if (this._engine && !this.src && !this._loading) {
+      this._loading = true;
       let startTime = this._config.playback.startTime;
       this._engine.load(startTime).then((data) => {
         this._updateTracks(data.tracks);
@@ -425,6 +432,8 @@ export default class Player extends FakeEventTarget {
         this.dispatchEvent(new FakeEvent(CustomEventType.TRACKS_CHANGED, {tracks: this._tracks}));
       }).catch((error) => {
         this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
+      }).finally(() => {
+        this._loading = false;
       });
     }
   }
@@ -1505,6 +1514,7 @@ export default class Player extends FakeEventTarget {
     this._activeTextCues = [];
     this._updateTextDisplay([]);
     this._tracks = [];
+    this._loading = false;
     this._firstPlay = true;
     this._firstPlayInCurrentSession = false;
     this._loadingMedia = false;

--- a/src/player.js
+++ b/src/player.js
@@ -427,13 +427,13 @@ export default class Player extends FakeEventTarget {
       this._loading = true;
       let startTime = this._config.playback.startTime;
       this._engine.load(startTime).then((data) => {
+        this._loading = false;
         this._updateTracks(data.tracks);
         this._setDefaultTracks();
         this.dispatchEvent(new FakeEvent(CustomEventType.TRACKS_CHANGED, {tracks: this._tracks}));
       }).catch((error) => {
-        this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
-      }).finally(() => {
         this._loading = false;
+        this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
       });
     }
   }

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -49,7 +49,7 @@ describe("load", function () {
 
   it("should't load if no engine", (done) => {
     player._engine = null;
-    setTimeout(done, 1000);
+    setTimeout(done, 300);
     player.ready().then(() => {
       done(new Error('fail'));
     });
@@ -61,20 +61,20 @@ describe("load", function () {
     setTimeout(() => {
       loadCounter.should.equal(1);
       done();
-    }, 300);
+    }, 1000);
     player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
       loadCounter++;
-      setTimeout(() => player.load(), 0);
+      setTimeout(() => player.load(), 200);
     });
     player.load();
   });
 
-  it.only("should't load if is in loading process", (done) => {
+  it("should't load if is in loading process", (done) => {
     let loadCounter = 0;
     setTimeout(() => {
       loadCounter.should.equal(1);
       done();
-    }, 300);
+    }, 1000);
     player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
       loadCounter++;
     });

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -17,6 +17,72 @@ import Error from '../../src/error/error'
 
 const targetId = 'player-placeholder_player.spec';
 
+describe("load", function () {
+  let config, player, playerContainer;
+
+  before(() => {
+    playerContainer = createElement('DIV', targetId);
+    config = getConfigStructure();
+    config.sources = sourcesConfig.Mp4;
+  });
+
+  beforeEach(() => {
+    player = new Player(config);
+    playerContainer.appendChild(player.getView());
+  });
+
+  afterEach(() => {
+    player.destroy();
+  });
+
+  after(() => {
+    removeVideoElementsFromTestPage();
+    removeElement(targetId);
+  });
+
+  it("should load if no source", (done) => {
+    player.ready().then(() => {
+      done();
+    });
+    player.load();
+  });
+
+  it("should't load if no engine", (done) => {
+    player._engine = null;
+    setTimeout(done, 1000);
+    player.ready().then(() => {
+      done(new Error('fail'));
+    });
+    player.load();
+  });
+
+  it("should't load if source already exists", (done) => {
+    let loadCounter = 0;
+    setTimeout(() => {
+      loadCounter.should.equal(1);
+      done();
+    }, 300);
+    player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
+      loadCounter++;
+      setTimeout(() => player.load(), 0);
+    });
+    player.load();
+  });
+
+  it.only("should't load if is in loading process", (done) => {
+    let loadCounter = 0;
+    setTimeout(() => {
+      loadCounter.should.equal(1);
+      done();
+    }, 300);
+    player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
+      loadCounter++;
+    });
+    player.load();
+    player.load();
+  });
+});
+
 describe("play", function () {
   let config, player, playerContainer;
 


### PR DESCRIPTION
### Description of the Changes
Raising a flag when the `load` process is starting and blocking another `load` call

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
