### PR TITLE
fix(FEC-7371): video fails to play on old browsers or browsers with data saver mode on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. See [standa
 ### Bug Fixes
 
 * operations order on change media ([#192](https://github.com/kaltura/playkit-js/issues/192)) ([601e0ff](https://github.com/kaltura/playkit-js/commit/601e0ff))
-* **FEC-7813:** the captions are OFF in the menu, despite explicit captions configured and shown on iOS ([#196](https://github.com/kaltura/playkit-js/issues/196)) ([8548a9e](https://github.com/kaltura/playkit-js/commit/8548a9e))
+* **FEC-7813, FEC-7918:** the captions are OFF in the menu, despite explicit captions configured and shown on iOS ([#196](https://github.com/kaltura/playkit-js/issues/196)) ([8548a9e](https://github.com/kaltura/playkit-js/commit/8548a9e))
 * **FEC-7907, FEC-7872:** No play button when preload=auto and ima plugin enabled ([#193](https://github.com/kaltura/playkit-js/issues/193)) ([2975fdc](https://github.com/kaltura/playkit-js/commit/2975fdc))
 
 

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -8,7 +8,7 @@ const WAIT_TIME: number = 500;
 const testVideoElement: HTMLVideoElement = Utils.Dom.createElement('video');
 testVideoElement.src = EncodingSources.Base64Mp4Source;
 // For iOS devices needs to turn the playsinline attribute on
-testVideoElement.setAttribute('playsinline', 'playsinline');
+testVideoElement.setAttribute('playsinline', '');
 
 export default class Html5AutoPlayCapability implements ICapability {
   static _playPromiseResult: Promise<*>;
@@ -34,7 +34,7 @@ export default class Html5AutoPlayCapability implements ICapability {
         } else {
           testVideoElement.muted = true;
           // For some iOS devices needs to use the setAttribute API
-          testVideoElement.setAttribute('muted', 'muted');
+          testVideoElement.setAttribute('muted', '');
           Html5AutoPlayCapability.runCapability();
         }
       });

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -7,6 +7,8 @@ const WAIT_TIME: number = 500;
 
 const testVideoElement: HTMLVideoElement = Utils.Dom.createElement('video');
 testVideoElement.src = EncodingSources.Base64Mp4Source;
+// For iOS devices needs to turn the playsinline attribute on
+testVideoElement.setAttribute('playsinline', 'playsinline');
 
 export default class Html5AutoPlayCapability implements ICapability {
   static _playPromiseResult: Promise<*>;
@@ -24,13 +26,15 @@ export default class Html5AutoPlayCapability implements ICapability {
           if (testVideoElement.muted) {
             resolve({autoplay: false, mutedAutoPlay: true});
           } else {
-            resolve({autoplay: true, mutedAutoPlay: true})
+            resolve({autoplay: true, mutedAutoPlay: true});
           }
         }).catch(() => {
         if (testVideoElement.muted) {
           resolve({autoplay: false, mutedAutoPlay: false});
         } else {
           testVideoElement.muted = true;
+          // For some iOS devices needs to use the setAttribute API
+          testVideoElement.setAttribute('muted', 'muted');
           Html5AutoPlayCapability.runCapability();
         }
       });

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -1,10 +1,15 @@
 // @flow
 import * as Utils from '../../../utils/util'
 import * as EncodingSources from '../../../assets/encoding-sources.json'
+import {Html5EventType} from '../../../event/event-type'
+
+const WAIT_TIME: number = 500;
+
+const testVideoElement: HTMLVideoElement = Utils.Dom.createElement('video');
+testVideoElement.src = EncodingSources.Base64Mp4Source;
 
 export default class Html5AutoPlayCapability implements ICapability {
-  static _vid: HTMLVideoElement = Utils.Dom.createElement('video');
-  static _promise: Promise<*>;
+  static _playPromiseResult: Promise<*>;
 
   /***
    * Runs the test for autoplay capability.
@@ -13,12 +18,23 @@ export default class Html5AutoPlayCapability implements ICapability {
    * @returns {void}
    */
   static runCapability(): void {
-    try {
-      Html5AutoPlayCapability._vid.src = EncodingSources.Base64Mp4Source;
-      Html5AutoPlayCapability._promise = Html5AutoPlayCapability._vid.play() || Promise.resolve();
-    } catch (e) {
-      Html5AutoPlayCapability._promise = Promise.reject();
-    }
+    Html5AutoPlayCapability._playPromiseResult = new Promise((resolve) => {
+      (testVideoElement.play() || Html5AutoPlayCapability._forcePromiseReturnValue())
+        .then(() => {
+          if (testVideoElement.muted) {
+            resolve({autoplay: false, mutedAutoPlay: true});
+          } else {
+            resolve({autoplay: true, mutedAutoPlay: true})
+          }
+        }).catch(() => {
+        if (testVideoElement.muted) {
+          resolve({autoplay: false, mutedAutoPlay: false});
+        } else {
+          testVideoElement.muted = true;
+          Html5AutoPlayCapability.runCapability();
+        }
+      });
+    });
   }
 
   /**
@@ -28,8 +44,29 @@ export default class Html5AutoPlayCapability implements ICapability {
    * @public
    */
   static getCapability(): Promise<CapabilityResult> {
-    return Html5AutoPlayCapability._promise
-      .then(() => ({autoplay: true}))
-      .catch(() => ({autoplay: false}));
+    return Html5AutoPlayCapability._playPromiseResult;
+  }
+
+  /**
+   * For browsers which are not supported promise return value from play()
+   * request we are simulate the same behaviour.
+   * @return {Promise<any>} - Play promise which resolved or rejected.
+   * @private
+   * @static
+   */
+  static _forcePromiseReturnValue() {
+    return new Promise((resolve, reject) => {
+      const supported = setTimeout(() => {
+        reject();
+      }, WAIT_TIME);
+      testVideoElement.addEventListener(Html5EventType.PLAYING, () => {
+        clearTimeout(supported);
+        resolve();
+      });
+      testVideoElement.addEventListener(Html5EventType.ERROR, () => {
+        clearTimeout(supported);
+        reject();
+      });
+    });
   }
 }

--- a/src/player.js
+++ b/src/player.js
@@ -1404,7 +1404,7 @@ export default class Player extends FakeEventTarget {
               Player._logger.debug("Start autoplay");
               this.play();
             } else {
-              if (allowMutedAutoPlay) {
+              if (allowMutedAutoPlay && capabilities.mutedAutoPlay) {
                 Player._logger.debug("Fallback to muted autoplay");
                 this.muted = true;
                 this.play();


### PR DESCRIPTION
### Description of the Changes

If autoplay capability test fails, try to run muted autoplay and add it to the capability result. 
This will fix also the error message we had in the console if the autoplay failed.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
