### PR TITLE
fix: remove default metadata object

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,10 +31,7 @@ var config = {
         options: {}
     },
     plugins: {},
-    metadata: {
-        description: "",
-        poster: ""
-    },
+    metadata: {},
     playback: {
         audioLanguage: "",
         textLanguage: "",
@@ -227,12 +224,9 @@ var config = {
 >    description: string
 >}
 >```
->##### Default: 
+>##### Default:
 >```js
->{
->    poster: "",
->    description: ""
->}
+>{}
 >```
 >##### Description: Defines the media metadata.
 >The poster field refers to the poster URL, which the player displays before playback begins.

--- a/src/player-config.json
+++ b/src/player-config.json
@@ -8,10 +8,7 @@
     "options": {}
   },
   "plugins": {},
-  "metadata": {
-    "poster": "",
-    "description": ""
-  },
+  "metadata": {},
   "playback": {
     "audioLanguage": "",
     "textLanguage": "",

--- a/src/player.js
+++ b/src/player.js
@@ -381,7 +381,7 @@ export default class Player extends FakeEventTarget {
    * @param {Object} config - The configuration for the player instance.
    * @returns {void}
    */
-  configure(config: Object): void {
+  configure(config: Object = {}): void {
     if (config.logLevel && LogLevel[config.logLevel]) {
       setLogLevel(LogLevel[config.logLevel]);
     }


### PR DESCRIPTION
### Description of the Changes

When merging the player config with the media config, in case we didn't received any poster from the user,  we want that the merge result will be the poster from media config.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
