### PR TITLE
feat(FEC-8079): add reset API to player and use it for change media

### DIFF
--- a/flow-typed/interfaces/engine.js
+++ b/flow-typed/interfaces/engine.js
@@ -18,6 +18,7 @@ declare interface IEngine {
   pause(): void;
   load(startTime: ?number): Promise<Object>;
   ready(): void;
+  reset(): void;
   selectVideoTrack(videoTrack: VideoTrack): void;
   selectAudioTrack(audioTrack: AudioTrack): void;
   selectTextTrack(textTrack: TextTrack): void;

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -157,6 +157,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   constructor(source: PKMediaSourceObject, config: Object) {
     super();
     this._eventManager = new EventManager();
+    this._canLoadMediaSourceAdapterPromise = Promise.resolve();
     this._createVideoElement();
     this._init(source, config);
   }
@@ -179,6 +180,10 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   reset(): void {
     this.detach();
     this._eventManager.removeAll();
+    if (this._mediaSourceAdapter) {
+      this._canLoadMediaSourceAdapterPromise = this._mediaSourceAdapter.destroy();
+      this._mediaSourceAdapter = null;
+    }
     if (this._el && this._el.src) {
       Utils.Dom.setAttribute(this._el, 'src', '');
       Utils.Dom.removeAttribute(this._el, 'src');
@@ -264,9 +269,10 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     const error = new Error(
       Error.Severity.CRITICAL,
       Error.Category.MEDIA,
-      Error.Code.VIDEO_ERROR,
-      {
-        code: code, extended: extended, message: message
+      Error.Code.VIDEO_ERROR, {
+        code: code,
+        extended: extended,
+        message: message
       });
     this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
   }
@@ -822,8 +828,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   _init(source: PKMediaSourceObject, config: Object): void {
     this._config = config;
-    this._canLoadMediaSourceAdapterPromise = (this._mediaSourceAdapter ? this._mediaSourceAdapter.destroy() : Promise.resolve());
-    this._mediaSourceAdapter = null;
     this._loadMediaSourceAdapter(source);
     this.attach();
   }
@@ -931,4 +935,3 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     return null;
   }
 }
-

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -2,7 +2,7 @@
 import FakeEventTarget from '../../event/fake-event-target'
 import FakeEvent from '../../event/fake-event'
 import EventManager from '../../event/event-manager'
-import {Html5EventType, CustomEventType} from '../../event/event-type'
+import {CustomEventType, Html5EventType} from '../../event/event-type'
 import MediaSourceProvider from './media-source/media-source-provider'
 import VideoTrack from '../../track/video-track'
 import AudioTrack from '../../track/audio-track'
@@ -168,12 +168,21 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @returns {void}
    */
   restore(source: PKMediaSourceObject, config: Object): void {
+    this.reset();
+    this._init(source, config);
+  }
+
+  /**
+   * Resets the engine.
+   * @returns {void}
+   */
+  reset(): void {
     this.detach();
     this._eventManager.removeAll();
-    if (this._el) {
+    if (this._el && this._el.src) {
+      Utils.Dom.setAttribute(this._el, 'src', '');
       Utils.Dom.removeAttribute(this._el, 'src');
     }
-    this._init(source, config);
   }
 
   /**

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -1,6 +1,6 @@
 //@flow
 import EventManager from '../../../../event/event-manager'
-import {Html5EventType, CustomEventType} from '../../../../event/event-type'
+import {CustomEventType, Html5EventType} from '../../../../event/event-type'
 import Track from '../../../../track/track'
 import VideoTrack from '../../../../track/video-track'
 import AudioTrack from '../../../../track/audio-track'
@@ -796,15 +796,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._videoElement.dispatchEvent(new window.Event(Html5EventType.DURATION_CHANGE));
       }
     }, 2000);
-  }
-
-  /**
-   * Getter for the src that the adapter plays on the video element.
-   * @public
-   * @returns {string} - The src url.
-   */
-  get src(): string {
-    return this._videoElement.src;
   }
 
   /**

--- a/src/engines/html5/media-source/base-media-source-adapter.js
+++ b/src/engines/html5/media-source/base-media-source-adapter.js
@@ -160,10 +160,6 @@ export default class BaseMediaSourceAdapter extends FakeEventTarget implements I
     });
   }
 
-  get src(): string {
-    return BaseMediaSourceAdapter._throwNotImplementedError('get src');
-  }
-
   getStartTimeOfDvrWindow(): number {
     return BaseMediaSourceAdapter._throwNotImplementedError('getStartTimeOfDvrWindow');
   }
@@ -214,5 +210,18 @@ export default class BaseMediaSourceAdapter extends FakeEventTarget implements I
     } else {
       return this._videoElement.duration;
     }
+  }
+
+  /**
+   * Getter for the src that the adapter plays on the video element.
+   * In case the adapter preformed a load it will return the manifest url.
+   * @public
+   * @returns {string} - The src url.
+   */
+  get src(): string {
+    if (this._loadPromise && this._sourceObj) {
+      return this._sourceObj.url;
+    }
+    return "";
   }
 }

--- a/src/event/event-type.js
+++ b/src/event/event-type.js
@@ -96,79 +96,95 @@ const Html5EventType: EventTypes = {
 
 const CustomEventType: EventTypes = {
   /**
-   * Fires when the player enters fullscreen
+   * Fires when the player starts reset operation.
+   */
+  RESET_STARTED: 'resetstarted',
+  /**
+   * Fires when the player ends reset operation.
+   */
+  RESET_ENDED: 'resetended',
+  /**
+   * Fires when the player starts destroy operation.
+   */
+  DESTROY_STARTED: 'destroystarted',
+  /**
+   * Fires when the player ends destroy operation.
+   */
+  DESTROY_ENDED: 'destroyended',
+  /**
+   * Fires when the player enters fullscreen.
    */
   ENTER_FULLSCREEN: 'enterfullscreen',
   /**
-   * Fires when the player exits fullscreen
+   * Fires when the player exits fullscreen.
    */
   EXIT_FULLSCREEN: 'exitfullscreen',
   /**
-   * Fires when the player received a request to enter fullscreen
+   * Fires when the player received a request to enter fullscreen.
    */
   REQUESTED_ENTER_FULLSCREEN: 'requestedenterfullscreen',
   /**
-   * Fires when the player received a request to exit fullscreen
+   * Fires when the player received a request to exit fullscreen.
    */
   REQUESTED_EXIT_FULLSCREEN: 'requestedexitfullscreen',
   /**
-   * Fires when browser fails to autoplay with sound
+   * Fires when browser fails to autoplay with sound.
    */
   AUTOPLAY_FAILED: 'autoplayfailed',
   /**
-   * Fires when browser fails to autoplay with sound but start muted autoplay instead
+   * Fires when browser fails to autoplay with sound but start muted autoplay instead.
    */
   FALLBACK_TO_MUTED_AUTOPLAY: 'fallbacktomutedautoplay',
   /**
-   * Fires when change source flow started
+   * Fires when change source flow started.
    */
   CHANGE_SOURCE_STARTED: 'changesourcestarted',
   /**
-   * Fires when change source flow ended
+   * Fires when change source flow ended.
    */
   CHANGE_SOURCE_ENDED: 'changesourceended',
   /**
-   * Fires when the volume has been muted/unmute
+   * Fires when the volume has been muted/unmute.
    */
   MUTE_CHANGE: 'mutechange',
   /**
-   * Fires when the active video track has been changed
+   * Fires when the active video track has been changed.
    */
   VIDEO_TRACK_CHANGED: 'videotrackchanged',
   /**
-   * Fires when the active audio track has been changed
+   * Fires when the active audio track has been changed.
    */
   AUDIO_TRACK_CHANGED: 'audiotrackchanged',
   /**
-   * Fires when the active text track has been changed
+   * Fires when the active text track has been changed.
    */
   TEXT_TRACK_CHANGED: 'texttrackchanged',
   /**
-   * Fires when the active text track cue has changed
+   * Fires when the active text track cue has changed.
    */
   TEXT_CUE_CHANGED: 'textcuechanged',
   /**
-   * Fires when the player tracks have been changed
+   * Fires when the player tracks have been changed.
    */
   TRACKS_CHANGED: 'trackschanged',
   /**
-   * Fires when the abr mode change from 'auto' to 'manual' or vice versa
+   * Fires when the abr mode change from 'auto' to 'manual' or vice versa.
    */
   ABR_MODE_CHANGED: 'abrmodechanged',
   /**
-   * Fires when the player state has been changed
+   * Fires when the player state has been changed.
    */
   PLAYER_STATE_CHANGED: 'playerstatechanged',
   /**
-   * Fires on the first play
+   * Fires on the first play.
    */
   FIRST_PLAY: 'firstplay',
   /**
-   * Fires when the player has selected the source to play
+   * Fires when the player has selected the source to play.
    */
   SOURCE_SELECTED: 'sourceselected',
   /**
-   * Fires when the text track style has changed
+   * Fires when the text track style has changed.
    */
   TEXT_STYLE_CHANGED: 'textstylechanged',
   /**

--- a/src/event/event-type.js
+++ b/src/event/event-type.js
@@ -98,19 +98,19 @@ const CustomEventType: EventTypes = {
   /**
    * Fires when the player starts reset operation.
    */
-  RESET_STARTED: 'resetstarted',
+  PLAYER_RESET_STARTED: 'playerresetstarted',
   /**
    * Fires when the player ends reset operation.
    */
-  RESET_ENDED: 'resetended',
+  PLAYER_RESET_ENDED: 'playerresetended',
   /**
    * Fires when the player starts destroy operation.
    */
-  DESTROY_STARTED: 'destroystarted',
+  PLAYER_DESTROY_STARTED: 'playerdestroystarted',
   /**
    * Fires when the player ends destroy operation.
    */
-  DESTROY_ENDED: 'destroyended',
+  PLAYER_DESTROY_ENDED: 'playerdestroyended',
   /**
    * Fires when the player enters fullscreen.
    */

--- a/src/event/event-type.js
+++ b/src/event/event-type.js
@@ -96,21 +96,13 @@ const Html5EventType: EventTypes = {
 
 const CustomEventType: EventTypes = {
   /**
-   * Fires when the player starts reset operation.
-   */
-  PLAYER_RESET_STARTED: 'playerresetstarted',
-  /**
    * Fires when the player ends reset operation.
    */
-  PLAYER_RESET_ENDED: 'playerresetended',
-  /**
-   * Fires when the player starts destroy operation.
-   */
-  PLAYER_DESTROY_STARTED: 'playerdestroystarted',
+  PLAYER_RESET: 'playerreset',
   /**
    * Fires when the player ends destroy operation.
    */
-  PLAYER_DESTROY_ENDED: 'playerdestroyended',
+  PLAYER_DESTROY: 'playerdestroy',
   /**
    * Fires when the player enters fullscreen.
    */

--- a/src/player.js
+++ b/src/player.js
@@ -509,17 +509,14 @@ export default class Player extends FakeEventTarget {
    */
   reset(): void {
     if (this._reset) return;
-    this.dispatchEvent(new FakeEvent(CustomEventType.RESET_STARTED));
     this.pause();
+    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET_STARTED));
     this._eventManager.removeAll();
     this._createReadyPromise();
     this._activeTextCues = [];
     this._updateTextDisplay([]);
     this._tracks = [];
-    this._loading = false;
-    this._firstPlay = true;
-    this._firstPlayInCurrentSession = false;
-    this._loadingMedia = false;
+    this._resetStateFlags();
     this._engineType = '';
     this._streamType = '';
     this._posterManager.reset();
@@ -527,7 +524,7 @@ export default class Player extends FakeEventTarget {
     this._pluginManager.reset();
     this._engine.reset();
     this._reset = true;
-    this.dispatchEvent(new FakeEvent(CustomEventType.RESET_ENDED));
+    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET_ENDED));
   }
 
   /**
@@ -537,7 +534,7 @@ export default class Player extends FakeEventTarget {
    */
   destroy(): void {
     if (this._destroyed) return;
-    this.dispatchEvent(new FakeEvent(CustomEventType.DESTROY_STARTED));
+    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_DESTROY_STARTED));
     if (this._engine) {
       this._engine.destroy();
     }
@@ -552,13 +549,13 @@ export default class Player extends FakeEventTarget {
     this._engineType = '';
     this._streamType = '';
     this._readyPromise = null;
-    this._firstPlay = true;
+    this._resetStateFlags();
     this._playbackAttributesState = {};
     if (this._el) {
       Utils.Dom.removeChild(this._el.parentNode, this._el);
     }
     this._destroyed = true;
-    this.dispatchEvent(new FakeEvent(CustomEventType.DESTROY_ENDED));
+    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_DESTROY_ENDED));
   }
 
   /**
@@ -1549,6 +1546,18 @@ export default class Player extends FakeEventTarget {
     if (!this.paused) {
       this._pause();
     }
+  }
+
+  /**
+   * Resets the state flags of the player.
+   * @returns {void}
+   * @private
+   */
+  _resetStateFlags(): void {
+    this._loading = false;
+    this._firstPlay = true;
+    this._firstPlayInCurrentSession = false;
+    this._loadingMedia = false;
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -4,10 +4,12 @@ import EventManager from './event/event-manager'
 import PosterManager from './utils/poster-manager'
 import FakeEvent from './event/fake-event'
 import FakeEventTarget from './event/fake-event-target'
-import {EventType, Html5EventType, CustomEventType} from './event/event-type'
+import type {EventTypes} from './event/event-type'
+import {CustomEventType, EventType, Html5EventType} from './event/event-type'
 import * as Utils from './utils/util'
 import Locale from './utils/locale'
-import getLogger, {LogLevel, getLogLevel, setLogLevel} from './utils/logger'
+import type {LogLevels, LogLevelTypes} from './utils/logger'
+import getLogger, {getLogLevel, LogLevel, LogLevelType, setLogLevel} from './utils/logger'
 import Html5 from './engines/html5/html5'
 import PluginManager from './plugin/plugin-manager'
 import BasePlugin from './plugin/base-plugin'
@@ -19,24 +21,21 @@ import TextTrack from './track/text-track'
 import TextStyle from './track/text-style'
 import {Cue} from './track/vtt-cue'
 import {processCues} from './track/text-track-display'
+import type {StateTypes} from './state/state-type'
 import {StateType} from './state/state-type'
+import type {TrackTypes} from './track/track-type'
 import {TrackType} from './track/track-type'
+import type {StreamTypes} from './engines/stream-type'
 import {StreamType} from './engines/stream-type'
+import type {EngineTypes} from './engines/engine-type'
 import {EngineType} from './engines/engine-type'
+import type {MediaTypes} from './media-type'
 import {MediaType} from './media-type'
+import type {AbrModes} from './track/abr-mode-type'
 import {AbrMode} from './track/abr-mode-type'
-import {LogLevelType} from './utils/logger'
 import PlaybackMiddleware from './middleware/playback-middleware'
 import DefaultPlayerConfig from './player-config.json'
 import './assets/style.css'
-import type {EventTypes} from './event/event-type'
-import type {TrackTypes} from './track/track-type'
-import type {LogLevels, LogLevelTypes} from './utils/logger'
-import type {AbrModes} from './track/abr-mode-type'
-import type {MediaTypes} from './media-type'
-import type {StreamTypes} from './engines/stream-type'
-import type {EngineTypes} from './engines/engine-type'
-import type {StateTypes} from './state/state-type'
 import PKError from './error/error'
 
 /**
@@ -344,6 +343,18 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _loading: boolean;
+  /**
+   * Reset indicator state.
+   * @type {boolean}
+   * @private
+   */
+  _reset: boolean;
+  /**
+   * Destroyed indicator state.
+   * @type {boolean}
+   * @private
+   */
+  _destroyed: boolean;
 
   /**
    * @param {Object} config - The configuration for the player instance.
@@ -356,6 +367,11 @@ export default class Player extends FakeEventTarget {
     this._firstPlay = true;
     this._fullscreen = false;
     this._firstPlayInCurrentSession = true;
+    this._repositionCuesTimeout = false;
+    this._loadingMedia = false;
+    this._loading = false;
+    this._reset = true;
+    this._destroyed = false;
     this._config = Player._defaultConfig;
     this._eventManager = new EventManager();
     this._posterManager = new PosterManager();
@@ -367,9 +383,6 @@ export default class Player extends FakeEventTarget {
     this._createPlayerContainer();
     this._appendPosterEl();
     this.configure(config);
-    this._repositionCuesTimeout = false;
-    this._loadingMedia = false;
-    this._loading = false;
   }
 
   // <editor-fold desc="Public API">
@@ -390,7 +403,7 @@ export default class Player extends FakeEventTarget {
     if (this._hasSources(config.sources)) {
       const receivedSourcesWhenHasEngine: boolean = !!this._engine;
       if (receivedSourcesWhenHasEngine) {
-        this._reset();
+        this.reset();
         Player._logger.debug('Change source started');
         this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_STARTED));
       }
@@ -423,6 +436,10 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   load(): void {
+    const resetFlags = () => {
+      this._loading = false;
+      this._reset = false;
+    };
     if (this._engine && !this.src && !this._loading) {
       this._loading = true;
       let startTime = this._config.playback.startTime;
@@ -430,11 +447,10 @@ export default class Player extends FakeEventTarget {
         this._updateTracks(data.tracks);
         this._setDefaultTracks();
         this.dispatchEvent(new FakeEvent(CustomEventType.TRACKS_CHANGED, {tracks: this._tracks}));
-      }).catch((error) => {
+        resetFlags();
+      }).catch(error => {
         this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
-      // $FlowFixMe
-      }).finally(() => {
-        this._loading = false;
+        resetFlags();
       });
     }
   }
@@ -487,11 +503,41 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
+   * Resets the necessary components before change media.
+   * @private
+   * @returns {void}
+   */
+  reset(): void {
+    if (this._reset) return;
+    this.dispatchEvent(new FakeEvent(CustomEventType.RESET_STARTED));
+    this.pause();
+    this._eventManager.removeAll();
+    this._createReadyPromise();
+    this._activeTextCues = [];
+    this._updateTextDisplay([]);
+    this._tracks = [];
+    this._loading = false;
+    this._firstPlay = true;
+    this._firstPlayInCurrentSession = false;
+    this._loadingMedia = false;
+    this._engineType = '';
+    this._streamType = '';
+    this._posterManager.reset();
+    this._stateManager.reset();
+    this._pluginManager.reset();
+    this._engine.reset();
+    this._reset = true;
+    this.dispatchEvent(new FakeEvent(CustomEventType.RESET_ENDED));
+  }
+
+  /**
    * Destroys the player.
    * @returns {void}
    * @public
    */
   destroy(): void {
+    if (this._destroyed) return;
+    this.dispatchEvent(new FakeEvent(CustomEventType.DESTROY_STARTED));
     if (this._engine) {
       this._engine.destroy();
     }
@@ -511,6 +557,8 @@ export default class Player extends FakeEventTarget {
     if (this._el) {
       Utils.Dom.removeChild(this._el.parentNode, this._el);
     }
+    this._destroyed = true;
+    this.dispatchEvent(new FakeEvent(CustomEventType.DESTROY_ENDED));
   }
 
   /**
@@ -1501,29 +1549,6 @@ export default class Player extends FakeEventTarget {
     if (!this.paused) {
       this._pause();
     }
-  }
-
-  /**
-   * Resets the necessary components before change media.
-   * @private
-   * @returns {void}
-   */
-  _reset(): void {
-    this.pause();
-    this._eventManager.removeAll();
-    this._createReadyPromise();
-    this._activeTextCues = [];
-    this._updateTextDisplay([]);
-    this._tracks = [];
-    this._loading = false;
-    this._firstPlay = true;
-    this._firstPlayInCurrentSession = false;
-    this._loadingMedia = false;
-    this._engineType = '';
-    this._streamType = '';
-    this._posterManager.reset();
-    this._stateManager.reset();
-    this._pluginManager.reset();
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -510,7 +510,6 @@ export default class Player extends FakeEventTarget {
   reset(): void {
     if (this._reset) return;
     this.pause();
-    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET_STARTED));
     this._eventManager.removeAll();
     this._createReadyPromise();
     this._activeTextCues = [];
@@ -524,7 +523,7 @@ export default class Player extends FakeEventTarget {
     this._pluginManager.reset();
     this._engine.reset();
     this._reset = true;
-    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET_ENDED));
+    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET));
   }
 
   /**
@@ -534,7 +533,6 @@ export default class Player extends FakeEventTarget {
    */
   destroy(): void {
     if (this._destroyed) return;
-    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_DESTROY_STARTED));
     if (this._engine) {
       this._engine.destroy();
     }
@@ -555,7 +553,7 @@ export default class Player extends FakeEventTarget {
       Utils.Dom.removeChild(this._el.parentNode, this._el);
     }
     this._destroyed = true;
-    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_DESTROY_ENDED));
+    this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_DESTROY));
   }
 
   /**

--- a/test/src/event/event-type.spec.js
+++ b/test/src/event/event-type.spec.js
@@ -28,10 +28,10 @@ describe('events', () => {
       WAITING: 'waiting',
     });
     CustomEventType.should.deep.equals({
-      RESET_STARTED: 'resetstarted',
-      RESET_ENDED: 'resetended',
-      DESTROY_STARTED: 'destroystarted',
-      DESTROY_ENDED: 'destroyended',
+      PLAYER_RESET_STARTED: 'resetstarted',
+      PLAYER_RESET_ENDED: 'resetended',
+      PLAYER_DESTROY_STARTED: 'destroystarted',
+      PLAYER_DESTROY_ENDED: 'destroyended',
       ENTER_FULLSCREEN: 'enterfullscreen',
       EXIT_FULLSCREEN: 'exitfullscreen',
       REQUESTED_ENTER_FULLSCREEN: 'requestedenterfullscreen',

--- a/test/src/event/event-type.spec.js
+++ b/test/src/event/event-type.spec.js
@@ -1,4 +1,4 @@
-import {EventType, Html5EventType, CustomEventType} from '../../../src/event/event-type'
+import {CustomEventType, EventType, Html5EventType} from '../../../src/event/event-type'
 import {Object as ObjectUtils} from '../../../src/utils/util'
 
 describe('events', () => {
@@ -28,6 +28,10 @@ describe('events', () => {
       WAITING: 'waiting',
     });
     CustomEventType.should.deep.equals({
+      RESET_STARTED: 'resetstarted',
+      RESET_ENDED: 'resetended',
+      DESTROY_STARTED: 'destroystarted',
+      DESTROY_ENDED: 'destroyended',
       ENTER_FULLSCREEN: 'enterfullscreen',
       EXIT_FULLSCREEN: 'exitfullscreen',
       REQUESTED_ENTER_FULLSCREEN: 'requestedenterfullscreen',

--- a/test/src/event/event-type.spec.js
+++ b/test/src/event/event-type.spec.js
@@ -28,10 +28,8 @@ describe('events', () => {
       WAITING: 'waiting',
     });
     CustomEventType.should.deep.equals({
-      PLAYER_RESET_STARTED: 'resetstarted',
-      PLAYER_RESET_ENDED: 'resetended',
-      PLAYER_DESTROY_STARTED: 'destroystarted',
-      PLAYER_DESTROY_ENDED: 'destroyended',
+      PLAYER_RESET: 'playerreset',
+      PLAYER_DESTROY: 'playerdestroy',
       ENTER_FULLSCREEN: 'enterfullscreen',
       EXIT_FULLSCREEN: 'exitfullscreen',
       REQUESTED_ENTER_FULLSCREEN: 'requestedenterfullscreen',

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1,13 +1,13 @@
 import TextStyle from '../../src/track/text-style'
 import Player from '../../src/player'
 import {StateType} from '../../src/state/state-type'
-import {Html5EventType, CustomEventType} from '../../src/event/event-type'
+import {CustomEventType, Html5EventType} from '../../src/event/event-type'
 import sourcesConfig from './configs/sources.json'
 import Track from '../../src/track/track'
 import VideoTrack from '../../src/track/video-track'
 import AudioTrack from '../../src/track/audio-track'
 import TextTrack from '../../src/track/text-track'
-import {removeVideoElementsFromTestPage, createElement, removeElement, getConfigStructure} from './utils/test-utils'
+import {createElement, getConfigStructure, removeElement, removeVideoElementsFromTestPage} from './utils/test-utils'
 import PluginManager from '../../src/plugin/plugin-manager'
 import ColorsPlugin from './plugin/test-plugins/colors-plugin'
 import NumbersPlugin from './plugin/test-plugins/numbers-plugin'
@@ -2049,7 +2049,8 @@ describe('configure', function () {
       player.config.playback.volume.should.equals(0.5);
       player.config.playback.muted.should.be.true;
       player.ready().then(() => {
-        player.src.should.equals(window.location.origin + sourcesConfig.MultipleSources.progressive[0].url);
+        player.src.should.equals(sourcesConfig.MultipleSources.progressive[0].url);
+        done();
         player.addEventListener(player.Event.VOLUME_CHANGE, () => {
           let newProgressiveConfig = {
             progressive: [sourcesConfig.MultipleSources.progressive[1]]
@@ -2063,7 +2064,7 @@ describe('configure', function () {
           player.config.playback.volume.should.equals(0.5);
           player.config.playback.muted.should.be.true;
           player.ready().then(() => {
-            player.src.should.equals(window.location.origin + newProgressiveConfig.progressive[0].url);
+            player.src.should.equals(newProgressiveConfig.progressive[0].url);
             done();
           });
         });
@@ -2086,7 +2087,7 @@ describe('configure', function () {
       player.config.playback.volume.should.equals(1);
       player.config.playback.muted.should.be.true;
       player.ready().then(() => {
-        player.src.should.equals(window.location.origin + sourcesConfig.MultipleSources.progressive[0].url);
+        player.src.should.equals(sourcesConfig.MultipleSources.progressive[0].url);
         player.configure({
           playback: {
             muted: false,
@@ -2110,7 +2111,7 @@ describe('configure', function () {
         player.config.playback.volume.should.equals(0.5);
         player.config.playback.muted.should.be.false;
         player.ready().then(() => {
-          player.src.should.equals(window.location.origin + newProgressiveConfig.progressive[0].url);
+          player.src.should.equals(newProgressiveConfig.progressive[0].url);
           done();
         });
       });
@@ -2583,7 +2584,7 @@ describe('destroy', function () {
   });
 });
 
-describe('_reset', function () {
+describe('reset', function () {
   let sandbox, player, config;
 
   before(() => {
@@ -2608,17 +2609,20 @@ describe('_reset', function () {
 
   it('should resets the player', function () {
     player = new Player(config);
+    player._reset = false;
     let posterMgrSpy = sandbox.spy(player._posterManager, 'reset');
+    let engineSpy = sandbox.spy(player._engine, 'reset');
     let eventMgrSpy = sandbox.spy(player._eventManager, 'removeAll');
     let pluginMgrSpy = sandbox.spy(player._pluginManager, 'reset');
     let stateMgrSpy = sandbox.spy(player._stateManager, 'reset');
     let _updateTextDisplay = sandbox.spy(player, '_updateTextDisplay');
-    player._reset();
+    player.reset();
     player.paused.should.be.true;
     posterMgrSpy.should.have.been.calledOnce;
     eventMgrSpy.should.have.been.calledOnce;
     pluginMgrSpy.should.have.been.calledOnce;
     stateMgrSpy.should.have.been.calledOnce;
+    engineSpy.should.have.been.calledOnce;
     player._activeTextCues.should.be.empty;
     _updateTextDisplay.should.have.been.calledOnce;
     _updateTextDisplay.should.have.been.calledWith([]);
@@ -2629,6 +2633,7 @@ describe('_reset', function () {
     player._readyPromise.should.exist;
     player._firstPlay.should.be.true;
     player._el.childNodes.should.not.be.empty;
+    player._reset.should.be.true;
   });
 });
 


### PR DESCRIPTION
### Description of the Changes

* Add reset API to player
* Add reset API to engine
* remove src getter of native adapter and use the same implementation in the base adapter.
* Add 4 new events: reset started/ended, destroy started/ended

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated