### PR TITLE
feat(FEC-8083): add setCapability API to allow app to set player capabilities

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -162,19 +162,41 @@ export default class Player extends FakeEventTarget {
    * @public
    * @static
    */
-  static getCapabilities(engineType: ?string): Promise<Object> {
+  static getCapabilities(engineType: ?string): Promise<{ [name: string]: any }> {
+    const resolveCapabilities = (engineType: ?string): Promise<Object> => {
+      const result = (engineType ? Player._playerCapabilities[engineType] : Player._playerCapabilities);
+      return Utils.Object.copyDeep(result);
+    };
     Player._logger.debug("Get player capabilities", engineType);
     if (Player._playerCapabilities) {
-      return (engineType ? Promise.resolve(Player._playerCapabilities[engineType]) : Promise.resolve(Player._playerCapabilities));
+      return Promise.resolve(resolveCapabilities(engineType));
     }
-    let promises = [];
+    const promises = [];
     Player._engines.forEach(Engine => promises.push(Engine.getCapabilities()));
     return Promise.all(promises)
       .then((arrayOfResults) => {
         Player._playerCapabilities = {};
         arrayOfResults.forEach(res => Object.assign(Player._playerCapabilities, res));
-        return (engineType ? Promise.resolve(Player._playerCapabilities[engineType]) : Promise.resolve(Player._playerCapabilities));
+        return Promise.resolve(resolveCapabilities(engineType));
       });
+  }
+
+  /**
+   * Sets the engines capabilities.
+   * @param {string} engineType - The engine type.
+   * @param {Object} capabilities - the engine capabilities.
+   * @return {void}
+   * @public
+   * @static
+   */
+  static setCapabilities(engineType: string, capabilities: { [name: string]: any }): void {
+    Player._logger.debug("Set player capabilities", engineType, capabilities);
+    Player.getCapabilities().then(() => {
+      if (!Player._playerCapabilities[engineType]) {
+        Player._playerCapabilities[engineType] = {};
+      }
+      Utils.Object.mergeDeep(Player._playerCapabilities[engineType], capabilities);
+    });
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -181,20 +181,25 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
-   * Sets the engines capabilities.
+   * Sets an engine capabilities.
    * @param {string} engineType - The engine type.
-   * @param {Object} capabilities - the engine capabilities.
-   * @return {void}
+   * @param {Object} capabilities - The engine capabilities.
+   * @return {Promise<*>} - Empty promise which resolved when the operation ends.
    * @public
    * @static
    */
-  static setCapabilities(engineType: string, capabilities: { [name: string]: any }): void {
+  static setCapabilities(engineType: string, capabilities: { [name: string]: any }): Promise<*> {
     Player._logger.debug("Set player capabilities", engineType, capabilities);
-    Player.getCapabilities().then(() => {
-      if (!Player._playerCapabilities[engineType]) {
-        Player._playerCapabilities[engineType] = {};
-      }
-      Utils.Object.mergeDeep(Player._playerCapabilities[engineType], capabilities);
+    return new Promise((resolve, reject) => {
+      Player.getCapabilities().then(() => {
+        if (!Player._playerCapabilities[engineType]) {
+          Player._playerCapabilities[engineType] = {};
+        }
+        Utils.Object.mergeDeep(Player._playerCapabilities[engineType], capabilities);
+        resolve();
+      }).catch(e => {
+        reject(e)
+      });
     });
   }
 

--- a/src/playkit.js
+++ b/src/playkit.js
@@ -71,7 +71,8 @@ export {BaseDrmProtocol};
 
 // Export the player capabilities
 const getCapabilities = Player.getCapabilities;
-export {getCapabilities};
+const setCapabilities = Player.setCapabilities;
+export {getCapabilities, setCapabilities};
 
 // Export enums
 export {EventType, StateType, TrackType, EngineType, MediaType, StreamType, AbrMode, LogLevelType};

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2836,6 +2836,7 @@ describe('setCapabilities', () => {
 
   it('should not change the original capabilities by reference', (done) => {
     Player.getCapabilities().then((c1) => {
+      c1.should.deep.equal(initialOrigCapabilities);
       c1.html5.autoplay = 'some value';
       Player.getCapabilities().then((c2) => {
         c2.html5.autoplay.should.equal(initialOrigCapabilities.html5.autoplay);
@@ -2865,6 +2866,7 @@ describe('setCapabilities', () => {
       isSupported: 5
     };
     Player.getCapabilities().then((c1) => {
+      c1.should.deep.equal(initialOrigCapabilities);
       Player.setCapabilities('html5', newCapabilities).then(() => {
         Player.getCapabilities().then((c2) => {
           c2.html5.should.deep.equal(newCapabilities);

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -14,6 +14,7 @@ import NumbersPlugin from './plugin/test-plugins/numbers-plugin'
 import Locale from '../../src/utils/locale'
 import Html5 from '../../src/engines/html5/html5'
 import Error from '../../src/error/error'
+import {Object} from '../../src/utils/util'
 
 const targetId = 'player-placeholder_player.spec';
 
@@ -2818,14 +2819,58 @@ describe('logger', () => {
   });
 });
 
-describe('playbackRate', () => {
-  it('should return the possible playback rates of the player', () => {
-    const player = new Player();
-    player.playbackRates.should.deep.equal([0.5, 1, 2, 4]);
+describe('setCapabilities', () => {
+  let initialOrigCapabilities;
+
+  before((done) => {
+    Player.runCapabilities();
+    Player.getCapabilities().then(capabilities => {
+      initialOrigCapabilities = capabilities;
+      done();
+    })
   });
 
-  it('should return the default playback rate of the player', () => {
-    const player = new Player();
-    player.defaultPlaybackRate.should.equal(1);
+  afterEach(() => {
+    Player._playerCapabilities = Object.copyDeep(initialOrigCapabilities);
+  });
+
+  it('should not change the original capabilities by reference', (done) => {
+    Player.getCapabilities().then((c1) => {
+      c1.html5.autoplay = 'some value';
+      Player.getCapabilities().then((c2) => {
+        c2.html5.autoplay.should.equal(initialOrigCapabilities.html5.autoplay);
+        done();
+      });
+    });
+  });
+
+  it('should set custom capabilities successfully', (done) => {
+    let newCapabilities = {
+      autoplay: 1,
+      mutedAutoPlay: 2,
+      isSupported: 3
+    };
+    Player.setCapabilities('html5', newCapabilities).then(() => {
+      Player.getCapabilities().then((c2) => {
+        c2.html5.should.deep.equal(newCapabilities);
+        done();
+      });
+    });
+  });
+
+  it('should set custom capabilities successfully after getCapabilities() call', (done) => {
+    let newCapabilities = {
+      autoplay: 3,
+      mutedAutoPlay: 4,
+      isSupported: 5
+    };
+    Player.getCapabilities().then((c1) => {
+      Player.setCapabilities('html5', newCapabilities).then(() => {
+        Player.getCapabilities().then((c2) => {
+          c2.html5.should.deep.equal(newCapabilities);
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
### Description of the Changes

Enable overrding the default player capability results

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
