### PR TITLE
fix(FEC-8090): after disabling captions and toggling full screen the last caption frame is displayed

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -948,7 +948,6 @@ export default class Player extends FakeEventTarget {
       } else if (track instanceof TextTrack) {
         if (track.language === OFF) {
           this.hideTextTrack();
-          this._activeTextCues = [];
           this._playbackAttributesState.textLanguage = OFF;
         } else {
           this._engine.selectTextTrack(track);
@@ -971,6 +970,7 @@ export default class Player extends FakeEventTarget {
       textTracks.map(track => track.active = false);
       const textTrack = textTracks.find(track => track.language === OFF);
       if (textTrack) {
+        this._activeTextCues = [];
         textTrack.active = true;
         this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}))
       }

--- a/src/player.js
+++ b/src/player.js
@@ -948,6 +948,7 @@ export default class Player extends FakeEventTarget {
       } else if (track instanceof TextTrack) {
         if (track.language === OFF) {
           this.hideTextTrack();
+          this._activeTextCues = [];
           this._playbackAttributesState.textLanguage = OFF;
         } else {
           this._engine.selectTextTrack(track);

--- a/src/player.js
+++ b/src/player.js
@@ -965,12 +965,12 @@ export default class Player extends FakeEventTarget {
   hideTextTrack(): void {
     if (this._engine) {
       this._engine.hideTextTrack();
+      this._activeTextCues = [];
       this._updateTextDisplay([]);
       const textTracks = this._getTracksByType(TrackType.TEXT);
       textTracks.map(track => track.active = false);
       const textTrack = textTracks.find(track => track.language === OFF);
       if (textTrack) {
-        this._activeTextCues = [];
         textTrack.active = true;
         this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}))
       }


### PR DESCRIPTION
### Description of the Changes

I emptied the _activeTextCues array when switching to 'off' track, so there won't be any captions to show.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
