### PR TITLE
feat(FEC-7330): enable setting custom track labels by app

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1693,7 +1693,7 @@ export default class Player extends FakeEventTarget {
       type = TrackType.TEXT;
     }
     if (type) {
-      let tracks = this._getTracksByType(type);
+      const tracks = this._getTracksByType(type);
       for (let i = 0; i < tracks.length; i++) {
         tracks[i].active = track.index === i;
       }

--- a/src/player.js
+++ b/src/player.js
@@ -491,10 +491,10 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   _maybeSetTracksLabels() {
-    const labelsCallbacks = this._config.customLabels;
-    if (labelsCallbacks) {
-      for (let callbackType in labelsCallbacks) {
-        this._setTracksCustomLabels(this._getTracksByType(LabelToTrackMap[callbackType]), labelsCallbacks[callbackType]);
+    const customLabels = this._config.customLabels;
+    if (customLabels) {
+      for (let callbackType in customLabels) {
+        this._setTracksCustomLabels(this._getTracksByType(LabelToTrackMap[callbackType]), customLabels[callbackType]);
       }
     }
   }
@@ -508,8 +508,10 @@ export default class Player extends FakeEventTarget {
    */
   _setTracksCustomLabels(tracks: Array<Track>, callback: Function) {
     tracks.forEach(track => {
-      const callbackResult = callback(Utils.Object.copyDeep(track));
-      track.label = typeof callbackResult === 'string' ? callbackResult : track.label;
+      const result = callback(Utils.Object.copyDeep(track));
+      if (result){
+        track.label = result;
+      }
     })
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -25,6 +25,7 @@ import type {StateTypes} from './state/state-type'
 import {StateType} from './state/state-type'
 import type {TrackTypes} from './track/track-type'
 import {TrackType} from './track/track-type'
+import {LabelToTrackMap} from './track/label-to-track-map'
 import type {StreamTypes} from './engines/stream-type'
 import {StreamType} from './engines/stream-type'
 import type {EngineTypes} from './engines/engine-type'
@@ -493,17 +494,7 @@ export default class Player extends FakeEventTarget {
     const labelsCallbacks = this._config.customLabels;
     if (labelsCallbacks) {
       for (let callbackType in labelsCallbacks) {
-        switch (callbackType) {
-          case 'captions':
-            this._setTracksCustomLabels(this._getTracksByType(TrackType.TEXT), labelsCallbacks[callbackType]);
-            break;
-          case 'audio':
-            this._setTracksCustomLabels(this._getTracksByType(TrackType.AUDIO), labelsCallbacks[callbackType]);
-            break;
-          case 'qualities':
-            this._setTracksCustomLabels(this._getTracksByType(TrackType.VIDEO), labelsCallbacks[callbackType]);
-            break;
-        }
+        this._setTracksCustomLabels(this._getTracksByType(LabelToTrackMap[callbackType]), labelsCallbacks[callbackType]);
       }
     }
   }
@@ -518,7 +509,12 @@ export default class Player extends FakeEventTarget {
   _setTracksCustomLabels(tracks: Array<Track>, callback: Function) {
     tracks.forEach(track => {
       const callbackResult = callback(Utils.Object.copyDeep(track));
-      track.label = typeof callbackResult === 'string' ? callbackResult : track.label();
+      if (track instanceof VideoTrack) {
+        track.qualityLabel = typeof callbackResult === 'string' ? callbackResult : track.qualityLabel;
+      } else {
+        track.label = typeof callbackResult === 'string' ? callbackResult : track.label;
+      }
+
     })
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -472,6 +472,7 @@ export default class Player extends FakeEventTarget {
       let startTime = this._config.playback.startTime;
       this._engine.load(startTime).then((data) => {
         this._updateTracks(data.tracks);
+        this._customizeLabels();
         this._setDefaultTracks();
         this.dispatchEvent(new FakeEvent(CustomEventType.TRACKS_CHANGED, {tracks: this._tracks}));
         resetFlags();
@@ -479,6 +480,31 @@ export default class Player extends FakeEventTarget {
         this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
         resetFlags();
       });
+    }
+  }
+
+  /**
+   * Checks for callbacks that should change the tracks, and call them on the
+   * respective track group (audio/text/video)
+   * @private
+   * @returns {void}
+   */
+  _customizeLabels() {
+    const labelCallbacks = this._config.playback.labelCallbacks;
+    if (labelCallbacks) {
+      for (let callback in labelCallbacks) {
+        switch (callback) {
+          case TrackType.TEXT:
+            labelCallbacks.text(this._getTracksByType(TrackType.TEXT));
+            break;
+          case TrackType.AUDIO:
+            labelCallbacks.audio(this._getTracksByType(TrackType.AUDIO));
+            break;
+          case TrackType.VIDEO:
+            labelCallbacks.video(this._getTracksByType(TrackType.VIDEO));
+            break;
+        }
+      }
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -473,7 +473,7 @@ export default class Player extends FakeEventTarget {
       let startTime = this._config.playback.startTime;
       this._engine.load(startTime).then((data) => {
         this._updateTracks(data.tracks);
-        this._customizeLabels();
+        this._maybeSetTracksLabels();
         this._setDefaultTracks();
         this.dispatchEvent(new FakeEvent(CustomEventType.TRACKS_CHANGED, {tracks: this._tracks}));
         resetFlags();
@@ -490,7 +490,7 @@ export default class Player extends FakeEventTarget {
    * @private
    * @returns {void}
    */
-  _customizeLabels() {
+  _maybeSetTracksLabels() {
     const labelsCallbacks = this._config.customLabels;
     if (labelsCallbacks) {
       for (let callbackType in labelsCallbacks) {

--- a/src/player.js
+++ b/src/player.js
@@ -509,7 +509,7 @@ export default class Player extends FakeEventTarget {
   _setTracksCustomLabels(tracks: Array<Track>, callback: Function) {
     tracks.forEach(track => {
       const result = callback(Utils.Object.copyDeep(track));
-      if (result){
+      if (result) {
         track.label = result;
       }
     })

--- a/src/player.js
+++ b/src/player.js
@@ -509,12 +509,7 @@ export default class Player extends FakeEventTarget {
   _setTracksCustomLabels(tracks: Array<Track>, callback: Function) {
     tracks.forEach(track => {
       const callbackResult = callback(Utils.Object.copyDeep(track));
-      if (track instanceof VideoTrack) {
-        track.qualityLabel = typeof callbackResult === 'string' ? callbackResult : track.qualityLabel;
-      } else {
-        track.label = typeof callbackResult === 'string' ? callbackResult : track.label;
-      }
-
+      track.label = typeof callbackResult === 'string' ? callbackResult : track.label;
     })
   }
 

--- a/src/track/label-options.js
+++ b/src/track/label-options.js
@@ -1,0 +1,9 @@
+// @flow
+
+const LabelOptions = {
+  AUDIO: 'audio',
+  CAPTIONS: 'captions',
+  QUALITIES: 'qualities'
+};
+
+export {LabelOptions};

--- a/src/track/label-to-track-map.js
+++ b/src/track/label-to-track-map.js
@@ -1,0 +1,10 @@
+// @flow
+import {TrackType} from './track-type'
+
+const LabelToTrackMap = {
+  "audio": TrackType.AUDIO,
+  "captions": TrackType.TEXT,
+  "qualities": TrackType.VIDEO
+};
+
+export {LabelToTrackMap};

--- a/src/track/label-to-track-map.js
+++ b/src/track/label-to-track-map.js
@@ -2,9 +2,10 @@
 import {TrackType} from './track-type'
 import {LabelOptions} from './label-options'
 
-const LabelToTrackMap = {};
-LabelToTrackMap[LabelOptions.AUDIO] = TrackType.AUDIO;
-LabelToTrackMap[LabelOptions.CAPTIONS] = TrackType.TEXT;
-LabelToTrackMap[LabelOptions.QUALITIES] = TrackType.VIDEO;
+const LabelToTrackMap = {
+  [LabelOptions.AUDIO]: TrackType.AUDIO,
+  [LabelOptions.CAPTIONS]: TrackType.TEXT,
+  [LabelOptions.QUALITIES]: TrackType.VIDEO
+};
 
 export {LabelToTrackMap};

--- a/src/track/label-to-track-map.js
+++ b/src/track/label-to-track-map.js
@@ -1,10 +1,10 @@
 // @flow
 import {TrackType} from './track-type'
+import {LabelOptions} from './label-options'
 
-const LabelToTrackMap = {
-  "audio": TrackType.AUDIO,
-  "captions": TrackType.TEXT,
-  "qualities": TrackType.VIDEO
-};
+const LabelToTrackMap = {};
+LabelToTrackMap[LabelOptions.AUDIO] = TrackType.AUDIO;
+LabelToTrackMap[LabelOptions.CAPTIONS] = TrackType.TEXT;
+LabelToTrackMap[LabelOptions.QUALITIES] = TrackType.VIDEO;
 
 export {LabelToTrackMap};

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -112,6 +112,15 @@ export default class Track {
   }
 
   /**
+   * Setter for the label of the track.
+   * @public
+   * @param {string} value - The label of the track.
+   */
+  set label(value: string) {
+    this._label = value;
+  }
+
+  /**
    * @constructor
    * @param {Object} settings - The track settings object.
    */

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -41,7 +41,7 @@ export default class Track {
    * @type {string}
    * @private
    */
-  _label: string;
+  _label: ?string;
   /**
    * The language of the track.
    * @member
@@ -89,7 +89,7 @@ export default class Track {
    * @public
    * @returns {string} - The label of the track.
    */
-  get label(): string {
+  get label(): ?string {
     return this._label;
   }
 

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -121,6 +121,24 @@ export default class Track {
   }
 
   /**
+   * Setter for the qualityLabel of the track.
+   * @public
+   * @param {string} value - The qualityLabel of the track.
+   */
+  set qualityLabel(value: string) {
+    this._qualityLabel = value;
+  }
+
+  /**
+   * Getter for the qualityLabel of the track.
+   * @public
+   * @returns {string} - The qualityLabel of the track.
+   */
+  get qualityLabel(): string {
+    return this._qualityLabel;
+  }
+
+  /**
    * @constructor
    * @param {Object} settings - The track settings object.
    */
@@ -130,5 +148,6 @@ export default class Track {
     this._label = settings.label;
     this._language = settings.language;
     this._index = settings.index;
+    this._qualityLabel = settings.qualityLabel;
   }
 }

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -121,24 +121,6 @@ export default class Track {
   }
 
   /**
-   * Setter for the qualityLabel of the track.
-   * @public
-   * @param {string} value - The qualityLabel of the track.
-   */
-  set qualityLabel(value: string) {
-    this._qualityLabel = value;
-  }
-
-  /**
-   * Getter for the qualityLabel of the track.
-   * @public
-   * @returns {string} - The qualityLabel of the track.
-   */
-  get qualityLabel(): string {
-    return this._qualityLabel;
-  }
-
-  /**
    * @constructor
    * @param {Object} settings - The track settings object.
    */
@@ -148,6 +130,5 @@ export default class Track {
     this._label = settings.label;
     this._language = settings.language;
     this._index = settings.index;
-    this._qualityLabel = settings.qualityLabel;
   }
 }

--- a/src/track/video-track.js
+++ b/src/track/video-track.js
@@ -28,13 +28,6 @@ export default class VideoTrack extends Track {
   _height: number;
 
   /**
-   * @member {string} _qualityLabel - The _qualityLabel of the video track
-   * @type {string}
-   * @private
-   */
-  _qualityLabel: string;
-
-  /**
    * @public
    * @returns {number} - The bandwidth of the video track
    */
@@ -59,24 +52,6 @@ export default class VideoTrack extends Track {
   }
 
   /**
-   * Setter for the qualityLabel of the track.
-   * @public
-   * @param {string} value - The qualityLabel of the track.
-   */
-  set qualityLabel(value: string) {
-    this._qualityLabel = value;
-  }
-
-  /**
-   * Getter for the qualityLabel of the track.
-   * @public
-   * @returns {string} - The qualityLabel of the track.
-   */
-  get qualityLabel(): string {
-    return this._qualityLabel;
-  }
-
-  /**
    * @constructor
    * @param {Object} settings - The track settings object
    */
@@ -85,6 +60,6 @@ export default class VideoTrack extends Track {
     this._bandwidth = settings.bandwidth;
     this._width = settings.width;
     this._height = settings.height;
-    this._qualityLabel = settings.qualityLabel;
+    this._label = this._height ? this._height + 'p' : undefined;
   }
 }

--- a/src/track/video-track.js
+++ b/src/track/video-track.js
@@ -28,6 +28,13 @@ export default class VideoTrack extends Track {
   _height: number;
 
   /**
+   * @member {string} _qualityLabel - The _qualityLabel of the video track
+   * @type {string}
+   * @private
+   */
+  _qualityLabel: string;
+
+  /**
    * @public
    * @returns {number} - The bandwidth of the video track
    */
@@ -52,6 +59,24 @@ export default class VideoTrack extends Track {
   }
 
   /**
+   * Setter for the qualityLabel of the track.
+   * @public
+   * @param {string} value - The qualityLabel of the track.
+   */
+  set qualityLabel(value: string) {
+    this._qualityLabel = value;
+  }
+
+  /**
+   * Getter for the qualityLabel of the track.
+   * @public
+   * @returns {string} - The qualityLabel of the track.
+   */
+  get qualityLabel(): string {
+    return this._qualityLabel;
+  }
+
+  /**
    * @constructor
    * @param {Object} settings - The track settings object
    */
@@ -60,5 +85,6 @@ export default class VideoTrack extends Track {
     this._bandwidth = settings.bandwidth;
     this._width = settings.width;
     this._height = settings.height;
+    this._qualityLabel = settings.qualityLabel;
   }
 }

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -102,6 +102,34 @@ describe("load", function () {
       })
     });
   });
+
+  it("should load with callback label function, and change the label of audio for 'custom_label'", (done) => {
+    player.configure(getConfigStructureWithLabelCallback());
+    player._tracks = [
+      new AudioTrack()
+    ];
+    player.load();
+    player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
+      player.getTracks().forEach(t => {
+        t.label.should.equal('custom_label');
+        done();
+      })
+    });
+  });
+
+  it("should load with callback label function, and change the label of text for 'custom_label'", (done) => {
+    player.configure(getConfigStructureWithLabelCallback());
+    player._tracks = [
+      new TextTrack()
+    ];
+    player.load();
+    player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
+      player.getTracks().forEach(t => {
+        t.label.should.equal('custom_label');
+        done();
+      })
+    });
+  });
 });
 
 describe("play", function () {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -7,7 +7,13 @@ import Track from '../../src/track/track'
 import VideoTrack from '../../src/track/video-track'
 import AudioTrack from '../../src/track/audio-track'
 import TextTrack from '../../src/track/text-track'
-import {createElement, getConfigStructure, removeElement, removeVideoElementsFromTestPage} from './utils/test-utils'
+import {
+  createElement,
+  getConfigStructure,
+  removeElement,
+  removeVideoElementsFromTestPage,
+  getConfigStructureWithLabelCallback
+} from './utils/test-utils'
 import PluginManager from '../../src/plugin/plugin-manager'
 import ColorsPlugin from './plugin/test-plugins/colors-plugin'
 import NumbersPlugin from './plugin/test-plugins/numbers-plugin'
@@ -81,6 +87,20 @@ describe("load", function () {
     });
     player.load();
     player.load();
+  });
+
+  it("should load with callback label function, and change the label of video for 'custom_label'", (done) => {
+    player.configure(getConfigStructureWithLabelCallback());
+    player._tracks = [
+      new VideoTrack()
+    ];
+    player.load();
+    player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
+      player.getTracks().forEach(t => {
+        t.label.should.equal('custom_label');
+        done();
+      })
+    });
   });
 });
 

--- a/test/src/utils/test-utils.js
+++ b/test/src/utils/test-utils.js
@@ -28,6 +28,24 @@ function getConfigStructure() {
 }
 
 /**
+ * Configuration structure of the player with label Callback for video.
+ * @returns {Object} - The configuration structure of the player.
+ */
+function getConfigStructureWithLabelCallback(): Object {
+  const videoLabelCallback = tracks => {
+    tracks.forEach(track => {
+      track;
+      track.label = "custom_label";
+    })
+  };
+  let config = getConfigStructure();
+  config.playback["labelCallbacks"] = {
+    "video": videoLabelCallback
+  };
+  return config;
+}
+
+/**
  * Creates a dom element.
  * @param {string} type - The element type.
  * @param {string} id - The element id.
@@ -155,5 +173,6 @@ export {
   createVideoTrackButtons,
   createElement,
   removeElement,
-  getConfigStructure
+  getConfigStructure,
+  getConfigStructureWithLabelCallback
 };

--- a/test/src/utils/test-utils.js
+++ b/test/src/utils/test-utils.js
@@ -32,15 +32,14 @@ function getConfigStructure() {
  * @returns {Object} - The configuration structure of the player.
  */
 function getConfigStructureWithLabelCallback(): Object {
-  const videoLabelCallback = tracks => {
-    tracks.forEach(track => {
-      track;
-      track.label = "custom_label";
-    })
+  const labelCallback = () => {
+    return "custom_label";
   };
   let config = getConfigStructure();
-  config.playback["labelCallbacks"] = {
-    "video": videoLabelCallback
+  config["customLabels"] = {
+    "qualities": labelCallback,
+    "audio": labelCallback,
+    "captions": labelCallback
   };
   return config;
 }


### PR DESCRIPTION
### Description of the Changes

adding label change callback support
added handling in player.js for customizing the labels.
addded label setter in track.js
updated tests

basic usage would be:
```
 config = {
   customLabels: {
      audio: function(audioTrack) {...},
      captions: function(textTrack) {...},
      qualities: function(videoTrack) {...}
   }
}
```

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
