### PR TITLE
feat: clear metadata and sources on reset

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -435,6 +435,7 @@ export default class Player extends FakeEventTarget {
         Player._logger.debug('Change source started');
         this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_STARTED));
       }
+      this._reset = false;
       if (this._selectEngineByPriority()) {
         this._appendEngineEl();
         this._attachMedia();
@@ -571,6 +572,8 @@ export default class Player extends FakeEventTarget {
   reset(): void {
     if (this._reset) return;
     this.pause();
+    this._config.metadata = {};
+    this._resetSource();
     this._eventManager.removeAll();
     this._createReadyPromise();
     this._activeTextCues = [];
@@ -585,6 +588,17 @@ export default class Player extends FakeEventTarget {
     this._engine.reset();
     this._reset = true;
     this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET));
+  }
+
+  /**
+   * Resets the source config
+   * @private
+   * @returns {void}
+   */
+  _resetSource(): void {
+    this._config.sources.dash = {};
+    this._config.sources.hls = {};
+    this._config.sources.progressive = {};
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -426,15 +426,15 @@ export default class Player extends FakeEventTarget {
     if (config.logLevel && LogLevel[config.logLevel]) {
       setLogLevel(LogLevel[config.logLevel]);
     }
-    Utils.Object.mergeDeep(this._config, config);
-    this._configureOrLoadPlugins(config.plugins);
     if (this._hasSources(config.sources)) {
+      this._configureOrLoadPlugins(config.plugins);
       const receivedSourcesWhenHasEngine: boolean = !!this._engine;
       if (receivedSourcesWhenHasEngine) {
         this.reset();
         Player._logger.debug('Change source started');
         this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_STARTED));
       }
+      Utils.Object.mergeDeep(this._config, config);
       this._reset = false;
       if (this._selectEngineByPriority()) {
         this._appendEngineEl();
@@ -448,6 +448,9 @@ export default class Player extends FakeEventTarget {
           this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_ENDED));
         }
       }
+    } else {
+      Utils.Object.mergeDeep(this._config, config);
+      this._configureOrLoadPlugins(config.plugins);
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -572,8 +572,7 @@ export default class Player extends FakeEventTarget {
   reset(): void {
     if (this._reset) return;
     this.pause();
-    this._config.metadata = {};
-    this._resetSource();
+    this._resetSourceData();
     this._eventManager.removeAll();
     this._createReadyPromise();
     this._activeTextCues = [];
@@ -595,7 +594,8 @@ export default class Player extends FakeEventTarget {
    * @private
    * @returns {void}
    */
-  _resetSource(): void {
+  _resetSourceData(): void {
+    this._config.metadata = {};
     this._config.sources.dash = {};
     this._config.sources.hls = {};
     this._config.sources.progressive = {};


### PR DESCRIPTION
### Description of the Changes

Reset the sources and metadata objects on player reset.
This enables setting metadata by application between change media.
In general if loadMedia is called player will always prefer the data that comes form the API.
If application wants to supply it's own data it needs to:
```javascript
player.reset();
player.configure({
   metadata: {
      poster: "MY_POSTER_URL"
   }
});
player.loadMedia(...)
```
And in this way player will know that new metadata is required by application and won't prefer data from the API response.

This change also enables calling reset after initial load, that wasn't possible till now, until play was initiated.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
