### PR TITLE
fix(FEC-7937): video first frame is displayed before pre-roll ad starts

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -50,3 +50,9 @@
   left: 0;
 }
 
+.playkit-black-cover {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: black;
+}

--- a/src/player.js
+++ b/src/player.js
@@ -1291,14 +1291,15 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   _appendDomElements(): void {
+    // Append playkit-subtitles
     this._textDisplayEl = Utils.Dom.createElement("div");
     Utils.Dom.addClassName(this._textDisplayEl, SUBTITLES_CLASS_NAME);
     Utils.Dom.appendChild(this._el, this._textDisplayEl);
-
+    // Append playkit-black-cover
     this._blackCoverEl = Utils.Dom.createElement("div");
     Utils.Dom.addClassName(this._blackCoverEl, BLACK_COVER_CLASS_NAME);
     Utils.Dom.appendChild(this._el, this._blackCoverEl);
-
+    // Append playkit-poster
     const el = this._posterManager.getElement();
     Utils.Dom.addClassName(el, POSTER_CLASS_NAME);
     Utils.Dom.appendChild(this._el, el);

--- a/src/player.js
+++ b/src/player.js
@@ -640,10 +640,8 @@ export default class Player extends FakeEventTarget {
     this._resetStateFlags();
     this._playbackAttributesState = {};
     if (this._el) {
-      while (this._el.firstChild) {
-        Utils.Dom.removeChild(this._el, this._el.firstChild);
-      }
       Utils.Dom.removeChild(this._el.parentNode, this._el);
+      this._el = null;
     }
     this._destroyed = true;
     this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_DESTROY));

--- a/src/player.js
+++ b/src/player.js
@@ -277,10 +277,10 @@ export default class Player extends FakeEventTarget {
   _firstPlay: boolean;
   /**
    * The player DOM element container.
-   * @type {HTMLDivElement}
+   * @type {?HTMLDivElement}
    * @private
    */
-  _el: HTMLDivElement;
+  _el: ?HTMLDivElement;
   /**
    * The player text DOM element container.
    * @type {HTMLDivElement}

--- a/src/player.js
+++ b/src/player.js
@@ -640,6 +640,9 @@ export default class Player extends FakeEventTarget {
     this._resetStateFlags();
     this._playbackAttributesState = {};
     if (this._el) {
+      while (this._el.firstChild) {
+        Utils.Dom.removeChild(this._el, this._el.firstChild);
+      }
       Utils.Dom.removeChild(this._el.parentNode, this._el);
     }
     this._destroyed = true;

--- a/src/player.js
+++ b/src/player.js
@@ -52,7 +52,12 @@ const PLAYBACK_RATES = [0.5, 1, 2, 4];
  * @const
  */
 const DEFAULT_PLAYBACK_RATE = 1;
-
+/**
+ * The black cover class name.
+ * @type {string}
+ * @const
+ */
+const BLACK_COVER_CLASS_NAME: string = 'playkit-black-cover';
 /**
  * The player container class name.
  * @type {string}
@@ -283,6 +288,12 @@ export default class Player extends FakeEventTarget {
    */
   _textDisplayEl: HTMLDivElement;
   /**
+   * The player black cover div.
+   * @type {HTMLDivElement}
+   * @private
+   */
+  _blackCoverEl: HTMLDivElement;
+  /**
    * The player DOM id.
    * @type {string}
    * @private
@@ -409,7 +420,7 @@ export default class Player extends FakeEventTarget {
     this._textStyle = new TextStyle();
     this._createReadyPromise();
     this._createPlayerContainer();
-    this._appendPosterEl();
+    this._appendDomElements();
     this.configure(config);
   }
 
@@ -588,6 +599,7 @@ export default class Player extends FakeEventTarget {
     this._stateManager.reset();
     this._pluginManager.reset();
     this._engine.reset();
+    this._showBlackCover();
     this._reset = true;
     this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET));
   }
@@ -1255,19 +1267,6 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
-   * Appends the poster element to the player's div container.
-   * @private
-   * @returns {void}
-   */
-  _appendPosterEl(): void {
-    if (this._el) {
-      let el: HTMLDivElement = this._posterManager.getElement();
-      Utils.Dom.addClassName(el, POSTER_CLASS_NAME);
-      Utils.Dom.appendChild(this._el, el);
-    }
-  }
-
-  /**
    * Appends the engine's video element to the player's div container.
    * @private
    * @returns {void}
@@ -1281,6 +1280,28 @@ export default class Player extends FakeEventTarget {
       Utils.Dom.addClassName(engineEl, classnameWithId);
       Utils.Dom.prependTo(engineEl, this._el);
     }
+  }
+
+  /**
+   * Appends DOM elements by the following priority:
+   * 1. poster (strongest)
+   * 2. black screen
+   * 3. subtitles (weakest)
+   * @private
+   * @returns {void}
+   */
+  _appendDomElements(): void {
+    this._textDisplayEl = Utils.Dom.createElement("div");
+    Utils.Dom.addClassName(this._textDisplayEl, SUBTITLES_CLASS_NAME);
+    Utils.Dom.appendChild(this._el, this._textDisplayEl);
+
+    this._blackCoverEl = Utils.Dom.createElement("div");
+    Utils.Dom.addClassName(this._blackCoverEl, BLACK_COVER_CLASS_NAME);
+    Utils.Dom.appendChild(this._el, this._blackCoverEl);
+
+    const el = this._posterManager.getElement();
+    Utils.Dom.addClassName(el, POSTER_CLASS_NAME);
+    Utils.Dom.appendChild(this._el, el);
   }
 
   /**
@@ -1618,9 +1639,32 @@ export default class Player extends FakeEventTarget {
       this._firstPlay = false;
       this.dispatchEvent(new FakeEvent(CustomEventType.FIRST_PLAY));
       this._posterManager.hide();
+      this._hideBlackCover();
       if (typeof this._playbackAttributesState.rate === 'number') {
         this.playbackRate = this._playbackAttributesState.rate;
       }
+    }
+  }
+
+  /**
+   * Hides the black cover div.
+   * @private
+   * @returns {void}
+   */
+  _hideBlackCover(): void {
+    if (this._blackCoverEl) {
+      this._blackCoverEl.style.visibility = 'hidden';
+    }
+  }
+
+  /**
+   * Shows the black cover div.
+   * @private
+   * @returns {void}
+   */
+  _showBlackCover(): void {
+    if (this._blackCoverEl) {
+      this._blackCoverEl.style.visibility = 'visible';
     }
   }
 
@@ -1764,11 +1808,6 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   _updateTextDisplay(cues: Array<Cue>): void {
-    if (this._textDisplayEl === undefined) {
-      this._textDisplayEl = Utils.Dom.createElement("div");
-      Utils.Dom.addClassName(this._textDisplayEl, SUBTITLES_CLASS_NAME);
-      Utils.Dom.appendChild(this._el, this._textDisplayEl);
-    }
     processCues(window, cues, this._textDisplayEl);
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -277,10 +277,10 @@ export default class Player extends FakeEventTarget {
   _firstPlay: boolean;
   /**
    * The player DOM element container.
-   * @type {?HTMLDivElement}
+   * @type {HTMLDivElement}
    * @private
    */
-  _el: ?HTMLDivElement;
+  _el: HTMLDivElement;
   /**
    * The player text DOM element container.
    * @type {HTMLDivElement}
@@ -641,7 +641,6 @@ export default class Player extends FakeEventTarget {
     this._playbackAttributesState = {};
     if (this._el) {
       Utils.Dom.removeChild(this._el.parentNode, this._el);
-      this._el = null;
     }
     this._destroyed = true;
     this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_DESTROY));

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -7,12 +7,7 @@ import Track from '../../src/track/track'
 import VideoTrack from '../../src/track/video-track'
 import AudioTrack from '../../src/track/audio-track'
 import TextTrack from '../../src/track/text-track'
-import {
-  createElement,
-  getConfigStructure,
-  removeElement,
-  removeVideoElementsFromTestPage
-} from './utils/test-utils'
+import {createElement, getConfigStructure, removeElement, removeVideoElementsFromTestPage} from './utils/test-utils'
 import PluginManager from '../../src/plugin/plugin-manager'
 import ColorsPlugin from './plugin/test-plugins/colors-plugin'
 import NumbersPlugin from './plugin/test-plugins/numbers-plugin'
@@ -2681,7 +2676,7 @@ describe('destroy', function () {
     player._streamType.should.be.empty;
     (player._readyPromise === null).should.be.true;
     player._firstPlay.should.be.true;
-    player._el.childNodes.should.be.empty;
+    (player._el === null).should.be.true;
   });
 });
 

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2676,7 +2676,6 @@ describe('destroy', function () {
     player._streamType.should.be.empty;
     (player._readyPromise === null).should.be.true;
     player._firstPlay.should.be.true;
-    (player._el === null).should.be.true;
   });
 });
 


### PR DESCRIPTION
### Description of the Changes

Add black cover div which relays under the poster div and displayed as long as first play didn't happened.
Also, this refactor the way were handled the layers of the playkit container.
The correct layers priority now is (from strongest to weakest):
1. Ads/plugins
2. Poster
3. Black cover
4. Subtitles
5. Video frames

Which gives priority for each layer with no need for use of z-index.

This generated DOM for this order under playkit-container is:
```
<video>
<div class="playkit-subtitles">
<div class="playkit-black-cover">
<div class="playkit-poster">
<div class="playkit-ads-container">

```
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
