### PR TITLE
feat(FEC-8244): do not throw plugin load errors on main thread

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1308,7 +1308,7 @@ export default class Player extends FakeEventTarget {
           if (!this._engine) {
             try {
               this._pluginManager.load(name, this, plugins[name]);
-            } catch(e){
+            } catch (e) {
               //bounce the plugin load error up
               this.dispatchEvent(e);
             }

--- a/src/player.js
+++ b/src/player.js
@@ -1306,7 +1306,12 @@ export default class Player extends FakeEventTarget {
         } else {
           // We allow to load plugins as long as the player has no engine
           if (!this._engine) {
-            this._pluginManager.load(name, this, plugins[name]);
+            try {
+              this._pluginManager.load(name, this, plugins[name]);
+            } catch(e){
+              //bounce the plugin load error up
+              this.dispatchEvent(e);
+            }
             let plugin = this._pluginManager.get(name);
             if (plugin) {
               this._config.plugins[name] = plugin.getConfig();

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -42,7 +42,8 @@ export default class PluginManager {
    */
   static register(name: string, handler: Function): boolean {
     if (typeof handler !== 'function' || handler.prototype instanceof BasePlugin === false) {
-      throw new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.RUNTIME_ERROR_NOT_VALID_HANDLER, name);
+      logger.error(`Plugin <${name}> registration failed, either plugin is not an instance of BasePlugin or plugin handler is not a function`);
+      return false;
     }
     if (!PluginManager._registry.has(name)) {
       PluginManager._registry.set(name, handler);
@@ -77,7 +78,8 @@ export default class PluginManager {
    */
   load(name: string, player: Player, config: Object = {}): boolean {
     if (!PluginManager._registry.has(name)) {
-      throw new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.RUNTIME_ERROR_NOT_REGISTERED_PLUGIN, name);
+      logger.warn(`Plugin <${name}> loading failed, plugin is not registered`);
+      throw new Error(Error.Severity.RECOVERABLE, Error.Category.PLAYER, Error.Code.RUNTIME_ERROR_NOT_REGISTERED_PLUGIN, name);
     }
     let pluginClass = PluginManager._registry.get(name);
     if (pluginClass && pluginClass.isValid()) {

--- a/test/src/plugin/plugin-manager.spec.js
+++ b/test/src/plugin/plugin-manager.spec.js
@@ -29,18 +29,14 @@ describe('PluginManager.registry', () => {
   });
 
   it('shouldn\'t register the plugin because handler is not a function', () => {
-    const registered = PluginManager.register("numbers", {});
-    const plugin = PluginManager.get("numbers");
-    plugin.should.be.undefined;
-    registered.should.be.false;
+    PluginManager.register("numbers", {}).should.be.false;
+    PluginManager._registry.get("numbers").should.be.undefined;
   });
 
   it('shouldn\'t register the plugin because handler isn\'t derived from BasePlugin', () => {
-    const registered = PluginManager.register("numbers", function () {
-    });
-    const plugin = PluginManager.get("numbers");
-    plugin.should.be.undefined;
-    registered.should.be.false;
+    PluginManager.register("numbers", function () {
+    }).should.be.false;
+    PluginManager._registry.get("numbers").should.be.undefined;
   });
 
   it('should register new plugins', () => {

--- a/test/src/plugin/plugin-manager.spec.js
+++ b/test/src/plugin/plugin-manager.spec.js
@@ -29,14 +29,16 @@ describe('PluginManager.registry', () => {
   });
 
   it('shouldn\'t register the plugin because handler is not a function', () => {
+    unRegisterAll();
     PluginManager.register("numbers", {}).should.be.false;
-    PluginManager._registry.get("numbers").should.be.undefined;
+    (PluginManager._registry.get("numbers") === undefined).should.be.true;
   });
 
   it('shouldn\'t register the plugin because handler isn\'t derived from BasePlugin', () => {
+    unRegisterAll();
     PluginManager.register("numbers", function () {
     }).should.be.false;
-    PluginManager._registry.get("numbers").should.be.undefined;
+    (PluginManager._registry.get("numbers") === undefined).should.be.true;
   });
 
   it('should register new plugins', () => {

--- a/test/src/plugin/plugin-manager.spec.js
+++ b/test/src/plugin/plugin-manager.spec.js
@@ -29,28 +29,18 @@ describe('PluginManager.registry', () => {
   });
 
   it('shouldn\'t register the plugin because handler is not a function', () => {
-    let exceptionOccurred = false;
-    try {
-      PluginManager.register("numbers", {});
-    } catch (e) {
-      exceptionOccurred = true;
-      e.code.should.equals(7005);
-      e.data.should.equals("numbers");
-    }
-    exceptionOccurred.should.be.true;
+    const registered = PluginManager.register("numbers", {});
+    const plugin = PluginManager.get("numbers");
+    plugin.should.be.undefined;
+    registered.should.be.false;
   });
 
   it('shouldn\'t register the plugin because handler isn\'t derived from BasePlugin', () => {
-    let exceptionOccurred = false;
-    try {
-      PluginManager.register("numbers", function () {
-      });
-    } catch (e) {
-      exceptionOccurred = true;
-      e.code.should.equals(7005);
-      e.data.should.equals("numbers");
-    }
-    exceptionOccurred.should.be.true;
+    const registered = PluginManager.register("numbers", function () {
+    });
+    const plugin = PluginManager.get("numbers");
+    plugin.should.be.undefined;
+    registered.should.be.false;
   });
 
   it('should register new plugins', () => {


### PR DESCRIPTION
### Description of the Changes

Plugin registration fails with error throwing or loading a plugin which was not registered.
This leads to application crash.
Changing this to only alert vie error event and console.info 


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
