### PR TITLE
fix(FEC-8180): when video starts fallback muted and user select to change media the Unmute icon is not displayed although video still muted

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -400,6 +400,12 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _destroyed: boolean;
+  /**
+   * Fallback to muted auto play mode indicator.
+   * @type {boolean}
+   * @private
+   */
+  _fallbackToMutedAutoPlay: boolean;
 
   /**
    * @param {Object} config - The configuration for the player instance.
@@ -418,6 +424,7 @@ export default class Player extends FakeEventTarget {
     this._playbackStarted = false;
     this._reset = true;
     this._destroyed = false;
+    this._fallbackToMutedAutoPlay = false;
     this._config = Player._defaultConfig;
     this._eventManager = new EventManager();
     this._posterManager = new PosterManager();
@@ -782,6 +789,9 @@ export default class Player extends FakeEventTarget {
     if (this._engine) {
       this._engine.muted = mute;
       this.dispatchEvent(new FakeEvent(CustomEventType.MUTE_CHANGE, {mute: mute}));
+      if (mute === false) {
+        this._fallbackToMutedAutoPlay = mute;
+      }
     }
   }
 
@@ -1544,6 +1554,9 @@ export default class Player extends FakeEventTarget {
   _handleAutoPlay(): void {
     if (this._config.playback.autoplay === true) {
       if (!this._firstPlayInCurrentSession) {
+        if (this._fallbackToMutedAutoPlay) {
+          this.dispatchEvent(new FakeEvent(CustomEventType.FALLBACK_TO_MUTED_AUTOPLAY));
+        }
         this.play();
       } else {
         const allowMutedAutoPlay = this._config.playback.allowMutedAutoPlay;
@@ -1553,11 +1566,17 @@ export default class Player extends FakeEventTarget {
               Player._logger.debug("Start autoplay");
               this.play();
             } else {
-              if (allowMutedAutoPlay && capabilities.mutedAutoPlay) {
-                Player._logger.debug("Fallback to muted autoplay");
-                this.muted = true;
-                this.play();
-                this.dispatchEvent(new FakeEvent(CustomEventType.FALLBACK_TO_MUTED_AUTOPLAY));
+              if (capabilities.mutedAutoPlay) {
+                if (this.muted) {
+                  Player._logger.debug("Start muted autoplay");
+                  this.play();
+                } else if (allowMutedAutoPlay) {
+                  Player._logger.debug("Fallback to muted autoplay");
+                  this._fallbackToMutedAutoPlay = true;
+                  this.muted = true;
+                  this.dispatchEvent(new FakeEvent(CustomEventType.FALLBACK_TO_MUTED_AUTOPLAY));
+                  this.play();
+                }
               } else {
                 Player._logger.warn("Autoplay failed, pause player");
                 this._posterManager.show();


### PR DESCRIPTION
### Description of the Changes

1. Keep fallback to muted autoplay state.
2. In case user changed the mute value to false we are canceling the fallback to muted state.
3. In case of change media and fallback to mute state is on, fire the fallback to muted event.
4. Handle regular muted autoplay action.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
