### PR TITLE
fix(FEC-8255): video starts from beginning instead 12th sec

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -211,7 +211,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
       this._loadPromise = new Promise((resolve, reject) => {
-        this._eventManager.listenOnce(this._videoElement, Html5EventType.LOADED_DATA, this._onLoadedData.bind(this, resolve));
+        this._eventManager.listenOnce(this._videoElement, Html5EventType.LOADED_DATA, this._onLoadedData.bind(this, resolve, startTime));
         this._eventManager.listenOnce(this._videoElement, Html5EventType.ERROR, this._onError.bind(this, reject));
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();
@@ -220,10 +220,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           this._videoElement.src = this._sourceObj.url;
           this._trigger(CustomEventType.ABR_MODE_CHANGED, {mode: this._isProgressivePlayback() ? 'manual' : 'auto'});
         }
-        if (startTime && startTime > -1) {
-          this._videoElement.currentTime = startTime;
-        }
-        this._videoElement.load();
       });
     }
     return this._loadPromise;
@@ -232,10 +228,11 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   /**
    * Loaded data event handler.
    * @param {Function} resolve - The resolve promise function.
+   * @param {number} startTime - Optional time to start the video from.
    * @private
    * @returns {void}
    */
-  _onLoadedData(resolve: Function): void {
+  _onLoadedData(resolve: Function, startTime: ?number): void {
     const parseTracksAndResolve = () => {
       this._playerTracks = this._getParsedTracks();
       this._addNativeAudioTrackChangeListener();
@@ -247,6 +244,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._handleLiveDurationChange();
       }
     };
+    if (startTime && startTime > -1) {
+      this._videoElement.currentTime = startTime;
+    }
     if (this._videoElement.textTracks.length > 0) {
       parseTracksAndResolve();
     } else {

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -220,8 +220,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           this._videoElement.src = this._sourceObj.url;
           this._trigger(CustomEventType.ABR_MODE_CHANGED, {mode: this._isProgressivePlayback() ? 'manual' : 'auto'});
         }
+        this._videoElement.load();
       });
-      this._videoElement.load();
     }
     return this._loadPromise;
   }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -221,6 +221,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           this._trigger(CustomEventType.ABR_MODE_CHANGED, {mode: this._isProgressivePlayback() ? 'manual' : 'auto'});
         }
       });
+      this._videoElement.load();
     }
     return this._loadPromise;
   }


### PR DESCRIPTION
### Description of the Changes

set the current time just after loadeddata event is raised.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
