### PR TITLE
fix(FEC-8272): sometimes when seeking spinner display constantly in IE11

### DIFF
--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -48,7 +48,7 @@ export default class StateManager {
    */
   _prevState: State | null;
   /**
-   * Holds the time of the last seek
+   * Holds the time of the beginning of the last buffering (waiting event)
    * @member
    * @type {number | null}
    * @private

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -53,7 +53,7 @@ export default class StateManager {
    * @type {number | null}
    * @private
    */
-  _prevSeekTime: number;
+  _lastWaitingTime: number;
   /**
    * Holds the state history of the player.
    * @member
@@ -136,7 +136,9 @@ export default class StateManager {
         }
       },
       [Html5EventType.TIME_UPDATE]: () => {
-        if (this._player && this._player.currentTime !== this._prevSeekTime) {
+        if (this._player && this._player.currentTime !== this._lastWaitingTime
+          && this._prevState && this._prevState.type === StateType.PLAYING) {
+          this._lastWaitingTime = null;
           this._updateState(StateType.PLAYING);
           this._dispatchEvent();
         }

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -48,6 +48,13 @@ export default class StateManager {
    */
   _prevState: State | null;
   /**
+   * Holds the time of the last seek
+   * @member
+   * @type {number | null}
+   * @private
+   */
+  _prevSeekTime: number;
+  /**
    * Holds the state history of the player.
    * @member
    * @type {Array<State>}
@@ -101,6 +108,7 @@ export default class StateManager {
       },
       [Html5EventType.WAITING]: () => {
         this._updateState(StateType.BUFFERING);
+        this._prevSeekTime = this._player.currentTime;
         this._dispatchEvent();
       },
       [Html5EventType.ENDED]: () => {
@@ -123,6 +131,12 @@ export default class StateManager {
       },
       [Html5EventType.SEEKED]: () => {
         if (this._prevState && this._prevState.type === StateType.PLAYING) {
+          this._updateState(StateType.PLAYING);
+          this._dispatchEvent();
+        }
+      },
+      [Html5EventType.TIME_UPDATE]: () => {
+        if (this._player && this._player.currentTime !== this._prevSeekTime) {
           this._updateState(StateType.PLAYING);
           this._dispatchEvent();
         }
@@ -159,6 +173,7 @@ export default class StateManager {
     this._eventManager.listen(this._player, Html5EventType.PAUSE, this._doTransition.bind(this));
     this._eventManager.listen(this._player, Html5EventType.WAITING, this._doTransition.bind(this));
     this._eventManager.listen(this._player, Html5EventType.SEEKED, this._doTransition.bind(this));
+    this._eventManager.listen(this._player, Html5EventType.TIME_UPDATE, this._doTransition.bind(this));
   }
 
   /**

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -53,7 +53,7 @@ export default class StateManager {
    * @type {number | null}
    * @private
    */
-  _lastWaitingTime: number;
+  _lastWaitingTime: ?number | null;
   /**
    * Holds the state history of the player.
    * @member
@@ -136,7 +136,7 @@ export default class StateManager {
         }
       },
       [Html5EventType.TIME_UPDATE]: () => {
-        if (this._player && this._player.currentTime !== this._lastWaitingTime
+        if (this._player.currentTime !== this._lastWaitingTime
           && this._prevState && this._prevState.type === StateType.PLAYING) {
           this._lastWaitingTime = null;
           this._updateState(StateType.PLAYING);

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -108,7 +108,7 @@ export default class StateManager {
       },
       [Html5EventType.WAITING]: () => {
         this._updateState(StateType.BUFFERING);
-        this._prevSeekTime = this._player.currentTime;
+        this._lastWaitingTime = this._player.currentTime;
         this._dispatchEvent();
       },
       [Html5EventType.ENDED]: () => {


### PR DESCRIPTION
### Description of the Changes

Add time update listener to the buffering state

when buffering, if we get a timeupdate event, we need to set the state of the player to playing. (fixes a bug in IE11) the bug is that there is no playing event sent sometimes after it's ended

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
