### PR TITLE
fix(FEC-8319): When starting to play an mp4 video, a TEXT_TRACK_CHANGED event is sent twice

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1006,7 +1006,7 @@ export default class Player extends FakeEventTarget {
       const textTrack = textTracks.find(track => track.language === OFF);
       if (textTrack) {
         textTrack.active = true;
-        this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}))
+        this._maybeDispatchTracksChanged(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}));
       }
     }
   }
@@ -1409,12 +1409,12 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEventType.AUDIO_TRACK_CHANGED, (event: FakeEvent) => {
         this.ready().then(() => this._playbackAttributesState.audioLanguage = event.payload.selectedAudioTrack.language);
         this._markActiveTrack(event.payload.selectedAudioTrack);
-        return this.dispatchEvent(event);
+        this._maybeDispatchTracksChanged(event);
       });
       this._eventManager.listen(this._engine, CustomEventType.TEXT_TRACK_CHANGED, (event: FakeEvent) => {
         this.ready().then(() => this._playbackAttributesState.textLanguage = event.payload.selectedTextTrack.language);
         this._markActiveTrack(event.payload.selectedTextTrack);
-        return this.dispatchEvent(event);
+        this._maybeDispatchTracksChanged(event);
       });
       this._eventManager.listen(this._engine, CustomEventType.TRACKS_CHANGED, (event: FakeEvent) => this._onTracksChanged(event));
       this._eventManager.listen(this._engine, CustomEventType.TEXT_CUE_CHANGED, (event: FakeEvent) => this._onCueChange(event));
@@ -1444,6 +1444,18 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEventType.MEDIA_RECOVERED, () => {
         this._handleRecovered();
       });
+    }
+  }
+
+  /**
+   * Dispatches track changed event only if we already started playing.
+   * @param {FakeEvent} e - The track changed event.
+   * @private
+   * @returns {void}
+   */
+  _maybeDispatchTracksChanged(e: FakeEvent): void {
+    if (this._playbackStarted) {
+      this.dispatchEvent(e);
     }
   }
 
@@ -1873,9 +1885,7 @@ export default class Player extends FakeEventTarget {
     const activeTracks = this.getActiveTracks();
     const playbackConfig = this.config.playback;
     const offTextTrack: ?Track = this._getTracksByType(TrackType.TEXT).find(track => TextTrack.langComparer(OFF, track.language));
-
     this.hideTextTrack();
-
     let currentOrConfiguredTextLang = this._playbackAttributesState.textLanguage || this._getLanguage(playbackConfig.textLanguage, activeTracks.text, TrackType.TEXT);
     let currentOrConfiguredAudioLang = this._playbackAttributesState.audioLanguage || playbackConfig.audioLanguage;
     this._setDefaultTrack(TrackType.TEXT, currentOrConfiguredTextLang, offTextTrack);
@@ -1918,7 +1928,7 @@ export default class Player extends FakeEventTarget {
     const track: ?Track = this._getTracksByType(type).find(track => Track.langComparer(language, track.language));
     if (track) {
       this.selectTrack(track);
-    } else if (defaultTrack && !defaultTrack.active) {
+    } else {
       this.selectTrack(defaultTrack);
     }
   }

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -946,7 +946,7 @@ describe('Player', function () {
     });
 
     it('should select a new subtitles track', (done) => {
-      player.ready().then(() => {
+      player.addEventListener(Html5EventType.PLAYING, () => {
         player.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, (event) => {
           (event.payload.selectedTextTrack instanceof TextTrack).should.be.true;
           event.payload.selectedTextTrack.index.should.equal(1);
@@ -965,12 +965,11 @@ describe('Player', function () {
         tracks[1].active.should.be.false;
         player.selectTrack(new TextTrack({index: 1, kind: 'subtitles'}));
       });
-      player.load();
+      player.play();
     });
 
     it('should select a new captions track', (done) => {
-      player.load();
-      player.ready().then(() => {
+      player.addEventListener(Html5EventType.PLAYING, () => {
         player.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, (event) => {
           (event.payload.selectedTextTrack instanceof TextTrack).should.be.true;
           event.payload.selectedTextTrack.index.should.equal(1);
@@ -989,8 +988,8 @@ describe('Player', function () {
         tracks[1].active.should.be.false;
         player.selectTrack(new TextTrack({index: 1, kind: 'captions'}));
       });
+      player.play();
     });
-
 
     it('should not change the selected text track', (done) => {
       player.ready().then(() => {
@@ -3063,4 +3062,5 @@ describe('Player', function () {
       });
     });
   });
-});
+})
+;


### PR DESCRIPTION
### Description of the Changes

Do not dispatch text and audio tracks event before start playing.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
