### PR TITLE
fix: adding external captions default ability

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,7 @@ var config = {
 >>  url: string,
 >>  label: string,
 >>  language: string,
+>>  default?: string,
 >>  type?: string
 >>}
 >>```
@@ -281,6 +282,7 @@ var config = {
 >>      {
 >>        url: "www.path.to/your/captions/file",
 >>        type: "vtt",
+>>        default: true,        
 >>        language: "en",
 >>        label: "English"
 >>      }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,6 +133,7 @@ var config = {
 >>  url: string,
 >>  label: string,
 >>  language: string,
+>>  default?: boolean, 
 >>  type?: string
 >>}
 >>```
@@ -282,6 +283,7 @@ var config = {
 >>        url: "www.path.to/your/captions/file",
 >>        type: "vtt",
 >>        language: "en",
+>>        default: true,
 >>        label: "English"
 >>      }
 >>    ]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,7 +133,6 @@ var config = {
 >>  url: string,
 >>  label: string,
 >>  language: string,
->>  default?: boolean, 
 >>  type?: string
 >>}
 >>```
@@ -283,7 +282,6 @@ var config = {
 >>        url: "www.path.to/your/captions/file",
 >>        type: "vtt",
 >>        language: "en",
->>        default: true,
 >>        label: "English"
 >>      }
 >>    ]

--- a/flow-typed/types/external-caption-object.js
+++ b/flow-typed/types/external-caption-object.js
@@ -3,5 +3,6 @@ declare type PKExternalCaptionObject = {
   url: string,
   label: string,
   language: string,
+  default: ?boolean,
   type: ?string
 }

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -126,7 +126,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     const newTextTracks = [];
     captions.forEach(caption => {
       const track = new TextTrack({
-        active: caption.default ? true : false,
+        active: !!caption.default,
         index: textTracksLength++,
         kind: "subtitles",
         label: caption.label,
@@ -295,7 +295,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    */
   _handleCaptionOnTimeUpdate(track: TextTrack): void {
     const currentTime = this._player.currentTime;
-    if (currentTime){
+    if (currentTime) {
       if (this._activeTextCues.length > 0 && currentTime < this._activeTextCues[this._activeTextCues.length - 1].startTime) {
         this._activeTextCues = [];
         this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_CUE_CHANGED, {cues: []}));

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -126,7 +126,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     const newTextTracks = [];
     captions.forEach(caption => {
       const track = new TextTrack({
-        active: false,
+        active: caption.default ? true : false,
         index: textTracksLength++,
         kind: "subtitles",
         label: caption.label,


### PR DESCRIPTION
### Description of the Changes

checking the 'default' attribute when adding a caption.

updated the docs / type.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
