### PR TITLE
fix(FEC-8367): When changing font family the font is not saved

### DIFF
--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -188,6 +188,7 @@ class TextStyle {
     clonedTextStyle.fontOpacity = this.fontOpacity;
     clonedTextStyle.backgroundColor = this.backgroundColor;
     clonedTextStyle.backgroundOpacity = this.backgroundOpacity;
+    clonedTextStyle.fontFamily = this.fontFamily;
     return clonedTextStyle;
   }
 }


### PR DESCRIPTION
### Description of the Changes

added font-family to the cloned object

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
