### PR TITLE
fix(FEC-8386): Kava analytics retrieved by default on OTT

### DIFF
--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -98,7 +98,7 @@ export default class PluginManager {
       logger.debug(`Plugin <${name}> has been loaded`);
       return true;
     }
-    logger.debug(`Plugin <${name}> isn\'t loaded, isValid()=${isValidPlugin ? 'true' : 'false'}, disabled=${isDisablePlugin ? 'true' : 'false'}`);
+    logger.debug(`Plugin <${name}> isn\'t loaded, isValid()=${isValidPlugin.toString()}, disabled=${isDisablePlugin.toString()}`);
     return false;
   }
 

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -32,6 +32,8 @@ export default class PluginManager {
   _plugins: Map<string, BasePlugin> = new Map();
   /**
    * Is disabled plugin map.
+   * Maps plugin's name to a boolean.
+   * false means the plugin is disable. true or plugin name doesn't exist in the map means the plugin is not disable.
    * @type {Map}
    * @private
    */
@@ -95,6 +97,7 @@ export default class PluginManager {
     const isValidPlugin = pluginClass ? pluginClass.isValid() : false;
     if (pluginClass && isValidPlugin && !isDisablePlugin) {
       this._plugins.set(name, pluginClass.createPlugin(name, player, config));
+      this._isDisabledPluginMap.set(name, false);
       logger.debug(`Plugin <${name}> has been loaded`);
       return true;
     }

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -91,7 +91,7 @@ export default class PluginManager {
     if (typeof config.disable === "boolean") {
       this._isDisabledPluginMap.set(name, config.disable);
     }
-    const isDisablePlugin = this._isDisabledPluginMap.get(name);
+    const isDisablePlugin = !!this._isDisabledPluginMap.get(name);
     if (pluginClass && pluginClass.isValid() && !isDisablePlugin) {
       this._plugins.set(name, pluginClass.createPlugin(name, player, config));
       logger.debug(`Plugin <${name}> has been loaded`);

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -30,6 +30,12 @@ export default class PluginManager {
    * @private
    */
   _plugins: Map<string, BasePlugin> = new Map();
+  /**
+   * Is disabled plugin map.
+   * @type {Map}
+   * @private
+   */
+  _isDisabledPluginMap: Map<string, boolean> = new Map();
 
   /**
    * Writes the plugin in the registry.
@@ -82,12 +88,16 @@ export default class PluginManager {
       throw new Error(Error.Severity.RECOVERABLE, Error.Category.PLAYER, Error.Code.RUNTIME_ERROR_NOT_REGISTERED_PLUGIN, name);
     }
     let pluginClass = PluginManager._registry.get(name);
-    if (pluginClass && pluginClass.isValid() && !config.disable) {
+    if (typeof config.disable === "boolean") {
+      this._isDisabledPluginMap.set(name, config.disable);
+    }
+    const isDisablePlugin = this._isDisabledPluginMap.get(name);
+    if (pluginClass && pluginClass.isValid() && !isDisablePlugin) {
       this._plugins.set(name, pluginClass.createPlugin(name, player, config));
       logger.debug(`Plugin <${name}> has been loaded`);
       return true;
     }
-    logger.debug(`Plugin <${name}> isn\'t loaded, isValid()=false, disabled=${config.disable}`);
+    logger.debug(`Plugin <${name}> isn\'t loaded, isValid()=${pluginClass.isValid()}, disabled=${isDisablePlugin}`);
     return false;
   }
 

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -92,12 +92,13 @@ export default class PluginManager {
       this._isDisabledPluginMap.set(name, config.disable);
     }
     const isDisablePlugin = !!this._isDisabledPluginMap.get(name);
-    if (pluginClass && pluginClass.isValid() && !isDisablePlugin) {
+    const isValidPlugin = pluginClass ? pluginClass.isValid() : false;
+    if (pluginClass && isValidPlugin && !isDisablePlugin) {
       this._plugins.set(name, pluginClass.createPlugin(name, player, config));
       logger.debug(`Plugin <${name}> has been loaded`);
       return true;
     }
-    logger.debug(`Plugin <${name}> isn\'t loaded, isValid()=${pluginClass.isValid()}, disabled=${isDisablePlugin}`);
+    logger.debug(`Plugin <${name}> isn\'t loaded, isValid()=${isValidPlugin ? 'true' : 'false'}, disabled=${isDisablePlugin ? 'true' : 'false'}`);
     return false;
   }
 

--- a/test/src/plugin/plugin-manager.spec.js
+++ b/test/src/plugin/plugin-manager.spec.js
@@ -70,7 +70,7 @@ describe('PluginManager.registry', () => {
   });
 });
 
-describe.only('PluginManager.plugins', () => {
+describe('PluginManager.plugins', () => {
 
   let pluginManager;
   let sandbox;

--- a/test/src/plugin/plugin-manager.spec.js
+++ b/test/src/plugin/plugin-manager.spec.js
@@ -70,7 +70,7 @@ describe('PluginManager.registry', () => {
   });
 });
 
-describe('PluginManager.plugins', () => {
+describe.only('PluginManager.plugins', () => {
 
   let pluginManager;
   let sandbox;
@@ -112,6 +112,17 @@ describe('PluginManager.plugins', () => {
 
   it('shouldn\'t load() the plugin, plugin is disabled in the config', () => {
     pluginManager.load("colors", {}, {disable: true}).should.be.false;
+  });
+
+  it('shouldn\'t load() the plugin, plugin is disabled in the previous config', () => {
+    pluginManager.load("colors", {}, {disable: true}).should.be.false;
+    pluginManager.load("colors", {}).should.be.false;
+  });
+
+  it('should load() the plugin, plugin is enable after is disabled in the config', () => {
+    pluginManager.load("colors", {}, {disable: true}).should.be.false;
+    pluginManager.load("colors", {}, {disable: false}).should.be.true;
+    pluginManager._plugins.size.should.equal(1);
   });
 
   it('should load() the plugins', () => {


### PR DESCRIPTION
### Description of the Changes

Keep the plugin's `disable` value for the next `load` calls

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
