### PR TITLE
fix(FEC-8419): double captions on ios when toggling fullscreen

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1565,7 +1565,7 @@ export default class Player extends FakeEventTarget {
       clearTimeout(this._repositionCuesTimeout);
     }
     this._repositionCuesTimeout = setTimeout(() => {
-      processCues(window, this._activeTextCues, this._textDisplayEl);
+      this._updateTextDisplay(this._activeTextCues);
       this._repositionCuesTimeout = false;
     }, REPOSITION_CUES_TIMEOUT);
   }

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2845,6 +2845,7 @@ describe('Player', function() {
 
     it('should reset the active text cues', () => {
       player._activeTextCues[0] = {};
+      player._updateTextDisplay = () => {};
       player._resetTextCuesAndReposition();
       let cue = player._activeTextCues[0];
       cue.hasBeenReset.should.equals(true);

--- a/test/src/track/external-captions-handler.spec.js
+++ b/test/src/track/external-captions-handler.spec.js
@@ -276,6 +276,7 @@ describe('ExternalCaptionsHandler', () => {
     beforeEach(() => {
       config = getConfigStructure();
       config.sources = sourcesConfig.MultipleSources;
+      config.playback = {};
       player = new Player(config);
       externalCaptionsHandler = new ExternalCaptionsHandler(player);
       playerContainer.appendChild(player.getView());


### PR DESCRIPTION
### Description of the Changes

instead of calling processCues directly from ` _resetTextCuesAndReposition()`, 
call the `_updateTextDisplay()` because is also checks if we are using native or not.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
