### PR TITLE
fix: subtitles font size is too small on mobile

### DIFF
--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -973,7 +973,7 @@ function convertCueToDOMTree(window, cuetext) {
   return parseContent(window, cuetext);
 }
 
-const FONT_SIZE_PERCENT = 0.05;
+const FONT_SIZE_PERCENT = 0.065;
 const FONT_STYLE = 'sans-serif';
 const CUE_BACKGROUND_PADDING = '1.5%';
 


### PR DESCRIPTION
### Description of the Changes

Change the font size percent to be closer to the native.
Fixed also by https://github.com/kaltura/playkit-js-ui/pull/257

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
