### PR TITLE
fix(FEC-8411): add protection to validate external text tracks which are added without language

### DIFF
--- a/src/error/code.js
+++ b/src/error/code.js
@@ -86,7 +86,11 @@ const Code: CodeType = {
    * the file that the external captions handler is trying to download could not be determined / unsupported.
    */
   UNKNOWN_FILE_TYPE: 2011,
-
+  /**
+   * The language key in the caption object is empty / does not exist. Language is a mandatory field.
+   * https://github.com/kaltura/playkit-js/blob/master/docs/configuration.md#configsourcescaptions
+   */
+  UNKNOWN_LANGUAGE: 2012,
   /**
    * Some component tried to read past the end of a buffer.  The segment index,
    * init segment, or PSSH may be malformed.

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -149,7 +149,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
       newTextTracks.push(track);
       this._updateTextTracksModel(caption);
     } else {
-      ExternalCaptionsHandler._logger.warn('duplicated language, taking the inbend option. Language: ', sameLangTrack.language);
+      ExternalCaptionsHandler._logger.warn('duplicated language, taking the inband option. Language: ', sameLangTrack.language);
     }
   }
 

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -121,7 +121,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     const newTextTracks = [];
     captions.forEach(caption => {
       if (!caption.language) {
-        const error = new Error(Error.Severity.RECOVERABLE, Error.Category.TEXT, Error.Code.UNKNOWN_LANGUAGE, caption);
+        const error = new Error(Error.Severity.RECOVERABLE, Error.Category.TEXT, Error.Code.UNKNOWN_LANGUAGE, {objectWithMissingLanguage: caption});
         this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
       } else {
         const track = this._createTextTrack(caption, textTracksLength++);
@@ -135,7 +135,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * checking if there is already a track with the same language
    * @param {TextTrack} track - textTrack to be added text tracks array that will be returned to the player
    * @param {PKExternalCaptionObject} caption - caption to be added to the model
-   * @param {Array<TextTrack>} playerTextTracks - player text tracks array
+   * @param {Array<Text>} playerTextTracks - player text tracks array
    * @param {Array<TextTrack>} newTextTracks - text track array that will be returned to the player
    * @returns {void}
    * @private

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -121,7 +121,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     const newTextTracks = [];
     captions.forEach(caption => {
       if (!caption.language) {
-        const error = new Error(Error.Severity.RECOVERABLE, Error.Category.TEXT, Error.Code.UNKNOWN_LANGUAGE, {objectWithMissingLanguage: caption});
+        const error = new Error(Error.Severity.RECOVERABLE, Error.Category.TEXT, Error.Code.UNKNOWN_LANGUAGE, {caption: caption});
         this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
       } else {
         const track = this._createTextTrack(caption, textTracksLength++);

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -116,35 +116,74 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     if (!captions) {
       return [];
     }
-    const textTracks = tracks.filter(track => track instanceof TextTrack);
-    let textTracksLength = textTracks.length || 0;
+    const playerTextTracks = tracks.filter(track => track instanceof TextTrack);
+    let textTracksLength = playerTextTracks.length || 0;
     const newTextTracks = [];
     captions.forEach(caption => {
-      const track = new TextTrack({
-        active: !!caption.default,
-        index: textTracksLength++,
-        kind: 'subtitles',
-        label: caption.label,
-        language: caption.language,
-        external: true
-      });
-      const sameLangTrack = textTracks.find(textTrack => caption.language === textTrack.language);
-      this._textTrackModel[caption.language] = {
-        cuesStatus: CuesStatus.NOT_DOWNLOADED,
-        cues: [],
-        url: caption.url,
-        type: caption.type
-      };
-      if (!sameLangTrack) {
-        if (this._player.config.playback.useNativeTextTrack) {
-          this._addNativeTextTrack(track);
-        }
-        newTextTracks.push(track);
+      if (!caption.language) {
+        const error = new Error(Error.Severity.RECOVERABLE, Error.Category.TEXT, Error.Code.UNKNOWN_LANGUAGE, caption);
+        this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
       } else {
-        ExternalCaptionsHandler._logger.warn('duplicated language, taking the inbend option. Language: ', sameLangTrack.language);
+        const track = this._createTextTrack(caption, textTracksLength++);
+        this._maybeAddTrack(track, caption, playerTextTracks, newTextTracks);
       }
     });
     return newTextTracks;
+  }
+
+  /**
+   * checking if there is already a track with the same language
+   * @param {TextTrack} track - textTrack to be added text tracks array that will be returned to the player
+   * @param {PKExternalCaptionObject} caption - caption to be added to the model
+   * @param {Array<TextTrack>} playerTextTracks - player text tracks array
+   * @param {Array<TextTrack>} newTextTracks - text track array that will be returned to the player
+   * @returns {void}
+   * @private
+   */
+  _maybeAddTrack(track: TextTrack, caption: PKExternalCaptionObject, playerTextTracks: Array<Track>, newTextTracks: Array<TextTrack>): void {
+    const sameLangTrack = playerTextTracks.find(textTrack => caption.language === textTrack.language);
+    if (!sameLangTrack) {
+      if (this._player.config.playback.useNativeTextTrack) {
+        this._addNativeTextTrack(track);
+      }
+      newTextTracks.push(track);
+      this._updateTextTracksModel(caption);
+    } else {
+      ExternalCaptionsHandler._logger.warn('duplicated language, taking the inbend option. Language: ', sameLangTrack.language);
+    }
+  }
+
+  /**
+   * creates a new text track
+   * @param {PKExternalCaptionObject} caption - caption to create the text track with
+   * @param {number} index - index of the text track
+   * @returns {TextTrack} - new text track
+   * @private
+   */
+  _createTextTrack(caption: PKExternalCaptionObject, index: number): TextTrack {
+    return new TextTrack({
+      active: !!caption.default,
+      index: index,
+      kind: 'subtitles',
+      label: caption.label,
+      language: caption.language,
+      external: true
+    });
+  }
+
+  /**
+   * adding the caption to the class texttracks model
+   * @param {PKExternalCaptionObject} caption - the caption to be added
+   * @returns {void}
+   * @private
+   */
+  _updateTextTracksModel(caption: PKExternalCaptionObject): void {
+    this._textTrackModel[caption.language] = {
+      cuesStatus: CuesStatus.NOT_DOWNLOADED,
+      cues: [],
+      url: caption.url,
+      type: caption.type
+    };
   }
 
   /**


### PR DESCRIPTION
*added a check to see if there is no language, and trigger an error in that case
*refactor `getExternalTracks` function

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
