### PR TITLE
fix(FEC-8413): on change media with data saver on the player is stuck on the poster

### DIFF
--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -22,18 +22,14 @@ export default class Html5AutoPlayCapability implements ICapability {
   static runCapability(): void {
     Html5AutoPlayCapability._playPromiseResult = new Promise(resolve => {
       Html5AutoPlayCapability._setMuted(false);
-      if (Html5AutoPlayCapability._isDataSaverMode()) {
-        resolve({autoplay: false, mutedAutoPlay: false});
-      } else {
-        Html5AutoPlayCapability._getPlayPromise()
-          .then(() => resolve({autoplay: true, mutedAutoPlay: true}))
-          .catch(() => {
-            Html5AutoPlayCapability._setMuted(true);
-            Html5AutoPlayCapability._getPlayPromise()
-              .then(() => resolve({autoplay: false, mutedAutoPlay: true}))
-              .catch(() => resolve({autoplay: false, mutedAutoPlay: false}));
-          });
-      }
+      Html5AutoPlayCapability._getPlayPromise()
+        .then(() => resolve({autoplay: true, mutedAutoPlay: true}))
+        .catch(() => {
+          Html5AutoPlayCapability._setMuted(true);
+          Html5AutoPlayCapability._getPlayPromise()
+            .then(() => resolve({autoplay: false, mutedAutoPlay: true}))
+            .catch(() => resolve({autoplay: false, mutedAutoPlay: false}));
+        });
     });
   }
 
@@ -52,19 +48,6 @@ export default class Html5AutoPlayCapability implements ICapability {
       }
       return res;
     });
-  }
-
-  /**
-   * Checks if the device is in data saver mode.
-   * @returns {boolean} - If the device is in data saver mode.
-   * @private
-   */
-  static _isDataSaverMode(): boolean {
-    if ('connection' in navigator) {
-      // $FlowFixMe
-      return navigator.connection.saveData === true;
-    }
-    return false;
   }
 
   /**


### PR DESCRIPTION
Sometimes returning false for autoplay when data saver is on its too strict.
On change media, chrome will allow autoplay even if the data saver is on - on the second media.

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
