### PR TITLE
feat: emit CHANGE_SOURCE_ENDED on first media load as well

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -419,12 +419,9 @@ export default class Player extends FakeEventTarget {
     }
     if (this._hasSources(config.sources)) {
       this._configureOrLoadPlugins(config.plugins);
-      const receivedSourcesWhenHasEngine: boolean = !!this._engine;
-      if (receivedSourcesWhenHasEngine) {
-        this.reset();
-        Player._logger.debug('Change source started');
-        this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_STARTED));
-      }
+      this.reset();
+      Player._logger.debug('Change source started');
+      this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_STARTED));
       Utils.Object.mergeDeep(this._config, config);
       this._reset = false;
       if (this._selectEngineByPriority()) {
@@ -433,10 +430,8 @@ export default class Player extends FakeEventTarget {
         this._posterManager.setSrc(this._config.sources.poster);
         this._handlePreload();
         this._handleAutoPlay();
-        if (receivedSourcesWhenHasEngine) {
-          Player._logger.debug('Change source ended');
-          this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_ENDED));
-        }
+        Player._logger.debug('Change source ended');
+        this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_ENDED));
       }
     } else {
       Utils.Object.mergeDeep(this._config, config);


### PR DESCRIPTION
### Description of the Changes

always emit the CHANGE_SOURCE_ENDED event so we can have consistent event to get before engine is selected to load a source

relates to FEC-8517

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
