### PR TITLE
feat(error): expose error class via player instance

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2169,5 +2169,13 @@ export default class Player extends FakeEventTarget {
     return AdTagType;
   }
 
+  /**
+   * Gets the player error object.
+   * @returns {PKError} - The player error object.
+   * @public
+   */
+  get Error(): PKAdTagTypes {
+    return PKError;
+  }
   // </editor-fold>
 }

--- a/src/player.js
+++ b/src/player.js
@@ -2174,7 +2174,7 @@ export default class Player extends FakeEventTarget {
    * @returns {PKError} - The player error object.
    * @public
    */
-  get Error(): PKAdTagTypes {
+  get Error(): PKError {
     return PKError;
   }
   // </editor-fold>

--- a/src/player.js
+++ b/src/player.js
@@ -2221,7 +2221,7 @@ export default class Player extends FakeEventTarget {
    * @returns {PKError} - The player error object.
    * @public
    */
-  get Error(): PKError {
+  get Error(): Error {
     return PKError;
   }
   // </editor-fold>

--- a/src/player.js
+++ b/src/player.js
@@ -2217,11 +2217,11 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
-   * Gets the player error object.
-   * @returns {PKError} - The player error object.
+   * Gets the player static error class.
+   * @returns {PKError} - The player static error class.
    * @public
    */
-  get Error(): Error {
+  get Error(): typeof PKError {
     return PKError;
   }
   // </editor-fold>


### PR DESCRIPTION
### Description of the Changes

expose error class via player instance to access error enums where playkit-js isn't a dependency.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
