### PR TITLE
fix(FEC-7594): native adapter does not raise an error in case network disconnects.

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -243,6 +243,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._eventManager.listen(this._mediaSourceAdapter, Html5EventType.ERROR, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, Html5EventType.TIME_UPDATE, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, Html5EventType.PLAYING, (event: FakeEvent) => this.dispatchEvent(event));
+      this._eventManager.listen(this._mediaSourceAdapter, Html5EventType.WAITING, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.MEDIA_RECOVERED, (event: FakeEvent) => this.dispatchEvent(event));
     }
   }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -102,6 +102,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
 
   _loadPromiseReject: ?Function;
 
+  _lastTimeUpdate: ?number;
+
   /**
    * Checks if NativeAdapter can play a given mime type.
    * @function canPlayType
@@ -237,13 +239,15 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   load(startTime: ?number): Promise<Object> {
     if (!this._loadPromise) {
       this._loadPromise = new Promise((resolve, reject) => {
+        this._lastTimeUpdate = startTime || 0;
         this._loadPromiseReject = reject;
         this._eventManager.listenOnce(this._videoElement, Html5EventType.LOADED_DATA, () => this._onLoadedData(resolve, startTime));
-        this._eventManager.listen(this._videoElement, Html5EventType.TIME_UPDATE, () => this._resetHeartbeatTimeout());
+        this._eventManager.listen(this._videoElement, Html5EventType.TIME_UPDATE, () => this._onTimeUpdate());
         this._eventManager.listen(this._videoElement, Html5EventType.PLAY, () => this._resetHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.PAUSE, () => this._clearHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.ENDED, () => this._clearHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.ABORT, () => this._clearHeartbeatTimeout());
+        this._eventManager.listen(this._videoElement, Html5EventType.SEEKED, () => this._onSeeked());
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();
         }
@@ -296,7 +300,18 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     }
   }
 
+  _onTimeUpdate(): void {
+    if (this._videoElement.currentTime > this._lastTimeUpdate) {
+      this._resetHeartbeatTimeout();
+    }
+  }
+
+  _onSeeked(): void {
+    this._lastTimeUpdate = this._videoElement.currentTime;
+  }
+
   _resetHeartbeatTimeout(): void {
+    this._lastTimeUpdate = this._videoElement.currentTime;
     this._clearHeartbeatTimeout();
     const onTimeout = () => {
       this._clearHeartbeatTimeout();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -102,7 +102,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
 
   _loadPromiseReject: ?Function;
 
-  _lastTimeUpdate: ?number;
+  _lastTimeUpdate: number = 0;
 
   _waitingEventTriggered: ?boolean = false;
 


### PR DESCRIPTION
### Description of the Changes

When network disconnects, IE triggers `stall` event, and after the buffer ends it keeps trigger `timeupdate` events (until the network comes back online.. or until forever...) this fix checks if the current time update is greater than the last one - so we know we aren't stuck, and raise an Error.

IE also doesn't change it's state to paused / buffering so we also fire `waiting` event if we are still on playing state but the current time of the player does not change. We trigger `playing` once the player resume playing

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
