### PR TITLE
fix(FEC-8554): update captions on resize event

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -95,6 +95,13 @@ const AUTO: string = 'auto';
 const OFF: string = 'off';
 
 /**
+ * The resize event string
+ *  *  @type {string}
+ *  @const
+ */
+const RESIZE: string = 'resize';
+
+/**
  *  The duration offset, for seeking to duration safety.
  *  @type {number}
  *  @const
@@ -1495,6 +1502,9 @@ export default class Player extends FakeEventTarget {
         this._resetTextCuesAndReposition();
       });
       this._eventManager.listen(this, CustomEventType.EXIT_FULLSCREEN, () => {
+        this._resetTextCuesAndReposition();
+      });
+      this._eventManager.listen(window, RESIZE, () => {
         this._resetTextCuesAndReposition();
       });
       this._eventManager.listen(this._engine, CustomEventType.MEDIA_RECOVERED, () => {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2857,6 +2857,32 @@ describe('Player', function() {
     });
   });
 
+  describe('on resize event', function() {
+    let config, player, sandbox;
+
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      config = getConfigStructure();
+      config.sources = sourcesConfig.Mp4;
+      player = new Player(config);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      player.destroy();
+    });
+
+    it('should call _resetTextCuesAndReposition function', done => {
+      let spy = sandbox.spy(player, '_resetTextCuesAndReposition');
+      const event = new Event('resize');
+      window.dispatchEvent(event);
+      setTimeout(() => {
+        spy.should.have.been.calledOnce;
+        done();
+      }, 500);
+    });
+  });
+
   describe('logger', () => {
     it('should return the current log level', () => {
       const player = new Player();


### PR DESCRIPTION
### Description of the Changes

Added resize listener to the window, and updated the captions accordingly.
The `_resetTextCuesAndReposition` function acts as a `debounce` function, which will update the captions only after the last resize.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
