### PR TITLE
feat(FEC-7808): added the option to disable cap level on fps drop

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,8 @@ var config = {
   },
   abr: {
     fpsDroppedFramesInterval: 5000,
-    fpsDroppedMonitoringThreshold: 0.2
+    fpsDroppedMonitoringThreshold: 0.2,
+    capLevelOnFPSDrop: true
   }
 };
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,8 @@ var player = playkit.core.loadPlayer(config);
   sources: PKSourcesConfigObject,
   session: PKSessionConfigObject,
   plugins: PKPluginsConfigObject,
-  customLabels: PKCustomLabelsConfigObject
+  customLabels: PKCustomLabelsConfigObject,
+  abr: PKAbrConfigObject
 }
 ```
 
@@ -43,8 +44,6 @@ var config = {
     captionsTextTrack1LanguageCode: 'en',
     captionsTextTrack2Label: 'Spanish',
     captionsTextTrack2LanguageCode: 'es',
-    fpsDroppedFramesInterval: 5000,
-    fpsDroppedMonitoringThreshold: 0.2,
     volume: 1,
     startTime: -1,
     playsinline: true,
@@ -77,6 +76,10 @@ var config = {
         format: 'progressive'
       }
     ]
+  },
+  abr: {
+    fpsDroppedFramesInterval: 5000,
+    fpsDroppedMonitoringThreshold: 0.2
   }
 };
 ```
@@ -690,26 +693,6 @@ var config = {
 >
 > ##
 >
-> > ### config.playback.fpsDroppedFramesInterval
-> >
-> > ##### Type: `number`
-> >
-> > ##### Default: `5000`
-> >
-> > ##### Description: Interval time in milliseconds to check if too many frames are dropped
->
-> ##
->
-> > ### config.playback.fpsDroppedMonitoringThreshold
-> >
-> > ##### Type: `number`
-> >
-> > ##### Default: `0.2`
-> >
-> > ##### Description: The allowed frames dropped threshold.
->
-> ##
->
 > > ### config.playback.startTime
 > >
 > > ##### Type: `number`
@@ -1009,6 +992,62 @@ var config = {
 >   }
 > };
 > ```
+
+##
+
+> ### config.abr
+>
+> ##### Type: `PKAbrConfigObject`
+>
+> ```js
+> {
+>  fpsDroppedMonitoringThreshold: number,
+>  fpsDroppedFramesInterval: number,
+>  capLevelOnFPSDrop: boolean
+> }
+> ```
+>
+> ##### Default:
+>
+> ```js
+> {
+>  fpsDroppedMonitoringThreshold: 0.2,
+>  fpsDroppedFramesInterval: 5000,
+>  capLevelOnFPSDrop: true
+> }
+> ```
+>
+> ##### Description: Specifies flags to control / restrict the abr mechanism.
+>
+> > ### config.abr.fpsDroppedFramesInterval
+> >
+> > ##### Type: `number`
+> >
+> > ##### Default: `5000`
+> >
+> > ##### Description: Interval time in milliseconds to check if too many frames are dropped
+>
+> ##
+>
+> > ### config.abr.fpsDroppedMonitoringThreshold
+> >
+> > ##### Type: `number`
+> >
+> > ##### Default: `0.2`
+> >
+> > ##### Description: The allowed frames dropped threshold.
+>
+> ##
+>
+> > ### config.abr.capLevelOnFPSDrop
+> >
+> > ##### Type: `boolean`
+> >
+> > ##### Default: true
+> >
+> > ##### Description: If the player should cap the level when the fps exceeds the threshold.
+>
+> ##
 
 ##
 

--- a/flow-typed/types/abr-config.js
+++ b/flow-typed/types/abr-config.js
@@ -1,0 +1,6 @@
+// @flow
+declare type PKAbrConfigObject = {
+  fpsDroppedMonitoringThreshold: number,
+  fpsDroppedFramesInterval: number,
+  capLevelOnFPSDrop: boolean
+};

--- a/src/engines/dropped-frames-watcher.js
+++ b/src/engines/dropped-frames-watcher.js
@@ -13,13 +13,13 @@ class DroppedFramesWatcher extends FakeEventTarget {
   _lastDecodedFrames: number = 0;
   _lastTime: number = 0;
   _mediaSourceAdapter: IMediaSourceAdapter;
-  _config: Object = {};
+  _config: PKAbrConfigObject;
   _videoElement: HTMLVideoElement;
   _currentBitrate: number = 0;
   _eventManager: EventManager;
   static _logger: any = getLogger('droppedFramesWatcher');
 
-  constructor(mediaSourceAdapter: IMediaSourceAdapter, config: Object, videoElement: HTMLVideoElement) {
+  constructor(mediaSourceAdapter: IMediaSourceAdapter, config: PKAbrConfigObject, videoElement: HTMLVideoElement) {
     super();
     this._eventManager = new EventManager();
     this._mediaSourceAdapter = mediaSourceAdapter;
@@ -29,8 +29,8 @@ class DroppedFramesWatcher extends FakeEventTarget {
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.FPS_DROP, event => this._triggerFPSDrop(event.payload.data));
       return;
     }
-    if (this._getDroppedAndDecodedFrames()[0] === NOT_SUPPORTED) {
-      DroppedFramesWatcher._logger.debug('Dropped frame watcher is not supported on this environment');
+    if (this._getDroppedAndDecodedFrames()[0] === NOT_SUPPORTED || !this._config.capLevelOnFPSDrop) {
+      DroppedFramesWatcher._logger.debug('Dropped frame watcher is disabled');
     } else {
       this._init();
     }

--- a/src/engines/dropped-frames-watcher.js
+++ b/src/engines/dropped-frames-watcher.js
@@ -29,9 +29,9 @@ class DroppedFramesWatcher extends FakeEventTarget {
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.FPS_DROP, event => this._triggerFPSDrop(event.payload.data));
       return;
     }
-    if (this._getDroppedAndDecodedFrames()[0] === NOT_SUPPORTED || !this._config.capLevelOnFPSDrop) {
-      DroppedFramesWatcher._logger.debug('Dropped frame watcher is disabled');
-    } else {
+    if (this._getDroppedAndDecodedFrames()[0] === NOT_SUPPORTED) {
+      DroppedFramesWatcher._logger.debug('Dropped frame watcher is not supported');
+    } else if (this._config.capLevelOnFPSDrop) {
       this._init();
     }
   }

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -850,7 +850,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   _loadMediaSourceAdapter(source: PKMediaSourceObject): void {
     this._mediaSourceAdapter = MediaSourceProvider.getMediaSourceAdapter(this.getVideoElement(), source, this._config);
     if (this._mediaSourceAdapter) {
-      this._droppedFramesWatcher = new DroppedFramesWatcher(this._mediaSourceAdapter, this._config.playback, this._el);
+      this._droppedFramesWatcher = new DroppedFramesWatcher(this._mediaSourceAdapter, this._config.abr, this._el);
     }
   }
 

--- a/src/player-config.json
+++ b/src/player-config.json
@@ -16,8 +16,6 @@
     "captionsTextTrack1LanguageCode": "en",
     "captionsTextTrack2Label": "Spanish",
     "captionsTextTrack2LanguageCode": "es",
-    "fpsDroppedFramesInterval": 5000,
-    "fpsDroppedMonitoringThreshold": 0.2,
     "volume": 1,
     "startTime": -1,
     "playsinline": true,
@@ -54,5 +52,10 @@
         "format": "hls"
       }
     ]
+  },
+  "abr": {
+    "fpsDroppedFramesInterval": 5000,
+    "fpsDroppedMonitoringThreshold": 0.2,
+    "capLevelOnFPSDrop": true
   }
 }

--- a/test/src/engines/dropped-frames-watcher.spec.js
+++ b/test/src/engines/dropped-frames-watcher.spec.js
@@ -4,9 +4,9 @@ import {CustomEventType} from '../../../src/event/event-type';
 import FakeEvent from '../../../src/event/fake-event';
 
 describe('constructor', function() {
-  let videoElement, sandbox;
+  let videoElement, sandbox, config;
   videoElement = document.createElement('video');
-
+  config = {capLevelOnFPSDrop: true};
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
   });
@@ -22,7 +22,7 @@ describe('constructor', function() {
     };
     hlsAdapter.addEventListener = () => {};
     let spy = sandbox.spy(hlsAdapter, 'addEventListener');
-    new DroppedFramesWatcher(hlsAdapter, {}, videoElement);
+    new DroppedFramesWatcher(hlsAdapter, config, videoElement);
     spy.should.have.been.calledOnce;
     spy.should.have.been.calledWithMatch(CustomEventType.FPS_DROP);
   });
@@ -34,7 +34,7 @@ describe('constructor', function() {
     };
     dashAdapter.addEventListener = () => {};
     let spy = sandbox.spy(dashAdapter, 'addEventListener');
-    new DroppedFramesWatcher(dashAdapter, {}, videoElement);
+    new DroppedFramesWatcher(dashAdapter, config, videoElement);
     spy.should.have.been.calledOnce;
     spy.should.have.been.calledWithMatch(CustomEventType.VIDEO_TRACK_CHANGED);
   });
@@ -44,7 +44,7 @@ describe('constructor', function() {
     dashAdapter.capabilities = {
       fpsControl: false
     };
-    const dfw = new DroppedFramesWatcher(dashAdapter, {}, videoElement);
+    const dfw = new DroppedFramesWatcher(dashAdapter, config, videoElement);
     dashAdapter.dispatchEvent(new FakeEvent(CustomEventType.VIDEO_TRACK_CHANGED, {selectedVideoTrack: {bandwidth: 100}}));
     setTimeout(() => {
       dfw._currentBitrate.should.equal(100);
@@ -57,7 +57,7 @@ describe('constructor', function() {
     dashAdapter.capabilities = {
       fpsControl: false
     };
-    const dfw = new DroppedFramesWatcher(dashAdapter, {}, videoElement);
+    const dfw = new DroppedFramesWatcher(dashAdapter, config, videoElement);
     dfw._droppedFramesInterval.should.not.equal(null);
   });
 });

--- a/test/src/engines/html5/html5.spec.js
+++ b/test/src/engines/html5/html5.spec.js
@@ -17,9 +17,10 @@ describe('Html5', () => {
     const progressiveSource = sourcesConfig.Mp4.progressive[0];
     const config = {
       sources: sourcesConfig.Mp4,
-      playback: {
+      abr: {
         fpsDroppedFramesInterval: 5000,
-        fpsDroppedMonitoringThreshold: 0.2
+        fpsDroppedMonitoringThreshold: 0.2,
+        capLevelOnFPSDrop: true
       }
     };
     const engine = Html5.createEngine(progressiveSource, config);
@@ -33,9 +34,10 @@ describe('Html5', () => {
     const progressiveSource = sourcesConfig.Mp4.progressive[0];
     const config = {
       sources: sourcesConfig.Mp4,
-      playback: {
+      abr: {
         fpsDroppedFramesInterval: 5000,
-        fpsDroppedMonitoringThreshold: 0.2
+        fpsDroppedMonitoringThreshold: 0.2,
+        capLevelOnFPSDrop: true
       }
     };
     const engine = Html5.createEngine(progressiveSource, config);
@@ -56,9 +58,10 @@ describe('Html5', () => {
     const progressiveSource = sourcesConfig.Mp4.progressive[0];
     const config = {
       sources: sourcesConfig.Mp4,
-      playback: {
+      abr: {
         fpsDroppedFramesInterval: 5000,
-        fpsDroppedMonitoringThreshold: 0.2
+        fpsDroppedMonitoringThreshold: 0.2,
+        capLevelOnFPSDrop: true
       }
     };
     const engine = Html5.createEngine(progressiveSource, config);


### PR DESCRIPTION
added the option to disable cap level on fps drop
and added new abr configuration:
```
abr: {
 fpsDroppedMonitoringThreshold: number,
 fpsDroppedFramesInterval: number,
  capLevelOnFPSDrop: boolean
}
```

### Description of the Changes

Please add a detailed description of the change, weather it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
