### PR TITLE
fix(FEC-8633): HLS fairplay fails with multiple players or consecutive playbacks

### DIFF
--- a/src/drm/fairplay.js
+++ b/src/drm/fairplay.js
@@ -1,6 +1,6 @@
 // @flow
 import BaseDrmProtocol from './base-drm-protocol';
-import type {fairplayDrmConfigType} from '../engines/html5/media-source/adapters/fairplay-drm-handler';
+import type {FairplayDrmConfigType} from '../engines/html5/media-source/adapters/fairplay-drm-handler';
 
 export default class FairPlay extends BaseDrmProtocol {
   static _logger = BaseDrmProtocol.getLogger('FairPlay');
@@ -29,11 +29,11 @@ export default class FairPlay extends BaseDrmProtocol {
 
   /**
    * Sets the FairPlay playback.
-   * @param {fairplayDrmConfigType} config - The config to manipulate.
+   * @param {FairplayDrmConfigType} config - The config to manipulate.
    * @param {Array<Object>} drmData - The drm data.
    * @returns {void}
    */
-  static setDrmPlayback(config: fairplayDrmConfigType, drmData: Array<Object>): void {
+  static setDrmPlayback(config: FairplayDrmConfigType, drmData: Array<Object>): void {
     FairPlay._logger.debug('Sets drm playback');
     let drmEntry = drmData.find(drmEntry => drmEntry.scheme === BaseDrmProtocol.DrmScheme.FAIRPLAY);
     if (drmEntry) {

--- a/src/drm/fairplay.js
+++ b/src/drm/fairplay.js
@@ -1,10 +1,11 @@
 // @flow
 import BaseDrmProtocol from './base-drm-protocol';
-import Error from '../error/error';
+import type {fairplayDrmConfigType} from '../engines/html5/media-source/adapters/fairplay-drm-handler';
 
 export default class FairPlay extends BaseDrmProtocol {
   static _logger = BaseDrmProtocol.getLogger('FairPlay');
   static _keySession: any;
+  static _onWebkitNeedKeyHandler: Function;
   static _KeySystem: string = 'com.apple.fps.1_0';
   static _WebkitEvents = {
     NEED_KEY: 'webkitneedkey',
@@ -28,207 +29,16 @@ export default class FairPlay extends BaseDrmProtocol {
 
   /**
    * Sets the FairPlay playback.
-   * @param {HTMLVideoElement} videoElement - The video element to manipulate.
+   * @param {fairplayDrmConfigType} config - The config to manipulate.
    * @param {Array<Object>} drmData - The drm data.
-   * @param {any} errorCallback - player error object
    * @returns {void}
    */
-  static setDrmPlayback(videoElement: HTMLVideoElement, drmData: Array<Object> = [], errorCallback: Function): void {
-    FairPlay._logger.debug('Sets DRM playback');
-    videoElement.addEventListener(FairPlay._WebkitEvents.NEED_KEY, FairPlay._onWebkitNeedKey.bind(null, drmData), false);
-    FairPlay._errorCallback = errorCallback;
-  }
-
-  static _onWebkitNeedKey(drmData: Array<Object>, event: any): void {
-    FairPlay._logger.debug('Webkit need key triggered');
-    let fpDrmData = drmData.find(drmEntry => drmEntry.scheme === BaseDrmProtocol.DrmScheme.FAIRPLAY);
-    if (!fpDrmData || FairPlay._keySession) {
-      return;
+  static setDrmPlayback(config: fairplayDrmConfigType, drmData: Array<Object>): void {
+    FairPlay._logger.debug('Sets drm playback');
+    let drmEntry = drmData.find(drmEntry => drmEntry.scheme === BaseDrmProtocol.DrmScheme.FAIRPLAY);
+    if (drmEntry) {
+      config.licenseUrl = drmEntry.licenseUrl;
+      config.certificate = drmEntry.certificate;
     }
-    let fpCertificate = fpDrmData.certificate;
-    let videoElement = event.target;
-    let initData = event.initData;
-    let contentId = FairPlay._extractContentId(initData);
-    let aCertificate = FairPlay._base64DecodeUint8Array(fpCertificate);
-
-    initData = FairPlay._concatInitDataIdAndCertificate(initData, contentId, aCertificate);
-
-    if (!videoElement.webkitKeys) {
-      let keySystem = FairPlay._selectKeySystem();
-      FairPlay._logger.debug('Sets media keys');
-      videoElement.webkitSetMediaKeys(new window.WebKitMediaKeys(keySystem));
-    }
-    if (!videoElement.webkitKeys) {
-      FairPlay._onError(Error.Code.COULD_NOT_CREATE_MEDIA_KEYS);
-    }
-    FairPlay._logger.debug('Creates session');
-    FairPlay._keySession = videoElement.webkitKeys.createSession('video/mp4', initData);
-    if (!FairPlay._keySession) {
-      FairPlay._onError(Error.Code.COULD_NOT_CREATE_KEY_SESSION);
-    }
-    FairPlay._keySession.contentId = contentId;
-    FairPlay._keySession.addEventListener(FairPlay._WebkitEvents.KEY_MESSAGE, FairPlay._onWebkitKeyMessage.bind(null, fpDrmData), false);
-    FairPlay._keySession.addEventListener(FairPlay._WebkitEvents.KEY_ADDED, FairPlay._onWebkitKeyAdded, false);
-    FairPlay._keySession.addEventListener(FairPlay._WebkitEvents.KEY_ERROR, FairPlay._onWebkitKeyError, false);
-  }
-
-  static destroy(): void {
-    FairPlay._keySession = null;
-  }
-
-  static _onWebkitKeyMessage(drmData: Object, event: any): void {
-    FairPlay._logger.debug('Webkit key message triggered');
-    let message = event.message;
-    let request = new XMLHttpRequest();
-    request.responseType = 'text';
-    request.addEventListener('load', FairPlay._licenseRequestLoaded, false);
-    request.addEventListener('error', () => FairPlay._onError(Error.Code.LICENSE_REQUEST_FAILED), false);
-    let params = FairPlay._base64EncodeUint8Array(message);
-    request.open('POST', drmData.licenseUrl, true);
-    request.setRequestHeader('Content-type', 'application/json');
-    FairPlay._logger.debug('Ready for license request');
-    request.send(params);
-  }
-
-  static _onWebkitKeyAdded(): void {
-    FairPlay._logger.debug('Decryption key was added to session');
-  }
-
-  static _onWebkitKeyError(): void {
-    FairPlay._logger.error('A decryption key error was encountered');
-  }
-
-  static _licenseRequestLoaded(event: any): void {
-    FairPlay._logger.debug('License request loaded');
-    let request = event.target;
-    let keyText = request.responseText.trim();
-    let responseObj = {};
-    try {
-      responseObj = JSON.parse(keyText);
-    } catch (error) {
-      FairPlay._onError(Error.Code.BAD_FAIRPLAY_RESPONSE, error);
-    }
-    let isValidResponse = FairPlay._validateResponse(responseObj);
-    if (isValidResponse.valid) {
-      let key = FairPlay._base64DecodeUint8Array(responseObj.ckc);
-      FairPlay._keySession.update(key);
-    } else {
-      FairPlay._onError(Error.Code.BAD_FAIRPLAY_RESPONSE, isValidResponse);
-    }
-  }
-
-  static _onError(code: number, data?: Object): void {
-    FairPlay._errorCallback(new Error(Error.Severity.CRITICAL, Error.Category.DRM, code, data));
-  }
-
-  static _validateResponse(responseObj: Object): Object {
-    if ((responseObj.message && responseObj.message.indexOf('error') > 0) || responseObj.reference === null || responseObj.status_code === 500) {
-      return {
-        //todo: create & edit an error object
-        valid: false,
-        details: 'internal server error' // would be ERROR.INTERNAL or something like that
-      };
-    } else if (responseObj.ckc === '') {
-      return {
-        valid: false,
-        details: 'ckc is missing' // would be ERROR.MISSING_CKC or something like that
-      };
-    } else {
-      return {
-        valid: true
-      };
-    }
-  }
-
-  static _extractContentId(initData: Uint8Array): string {
-    let link = document.createElement('a');
-    link.href = FairPlay._arrayToString(initData);
-    return link.hostname;
-  }
-
-  static _selectKeySystem(): ?string {
-    let keySystem = null;
-    if (window.WebKitMediaKeys.isTypeSupported(FairPlay._KeySystem, 'video/mp4')) {
-      keySystem = FairPlay._KeySystem;
-    } else {
-      FairPlay._logger.warn('Key System not supported');
-    }
-    return keySystem;
-  }
-
-  static _arrayToString(array: Uint8Array): string {
-    return String.fromCharCode.apply(null, new Uint16Array(array.buffer));
-  }
-
-  static _base64DecodeUint8Array(input: string): Uint8Array {
-    let raw = window.atob(input);
-    let rawLength = raw.length;
-    let array = new Uint8Array(new ArrayBuffer(rawLength));
-    for (let i = 0; i < rawLength; i++) {
-      array[i] = raw.charCodeAt(i);
-    }
-    return array;
-  }
-
-  static _concatInitDataIdAndCertificate(initData: Uint8Array, id: string | Uint16Array, cert: Uint8Array): Uint8Array {
-    if (typeof id === 'string') {
-      id = FairPlay._stringToArray(id);
-    }
-    let offset = 0;
-    let buffer = new ArrayBuffer(initData.byteLength + 4 + id.byteLength + 4 + cert.byteLength);
-    let dataView = new DataView(buffer);
-
-    let initDataArray = new Uint8Array(buffer, offset, initData.byteLength);
-    initDataArray.set(initData);
-    offset += initData.byteLength;
-
-    dataView.setUint32(offset, id.byteLength, true);
-    offset += 4;
-
-    let idArray = new Uint8Array(buffer, offset, id.byteLength);
-    idArray.set(id);
-    offset += idArray.byteLength;
-
-    dataView.setUint32(offset, cert.byteLength, true);
-    offset += 4;
-
-    let certArray = new Uint8Array(buffer, offset, cert.byteLength);
-    certArray.set(cert);
-
-    return new Uint8Array(buffer, 0, buffer.byteLength);
-  }
-
-  static _stringToArray(string: string): Uint16Array {
-    let buffer = new ArrayBuffer(string.length * 2);
-    let array = new Uint16Array(buffer);
-    for (let i = 0, strLen = string.length; i < strLen; i++) {
-      array[i] = string.charCodeAt(i);
-    }
-    return array;
-  }
-
-  static _base64EncodeUint8Array(input: Uint8Array): string {
-    let keyStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-    let output = '';
-    let chr1, chr2, chr3, enc1, enc2, enc3, enc4;
-    let i = 0;
-    while (i < input.length) {
-      chr1 = input[i++];
-      chr2 = i < input.length ? input[i++] : Number.NaN;
-      chr3 = i < input.length ? input[i++] : Number.NaN;
-
-      enc1 = chr1 >> 2;
-      enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
-      enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
-      enc4 = chr3 & 63;
-
-      if (isNaN(chr2)) {
-        enc3 = enc4 = 64;
-      } else if (isNaN(chr3)) {
-        enc4 = 64;
-      }
-      output += keyStr.charAt(enc1) + keyStr.charAt(enc2) + keyStr.charAt(enc3) + keyStr.charAt(enc4);
-    }
-    return output;
   }
 }

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -6,7 +6,8 @@ import type {SeverityType} from '../../../../error/severity';
 import type {CategoryType} from '../../../../error/category';
 
 const KeySystem: string = 'com.apple.fps.1_0';
-const WebkitEvents = {
+type WebkitEventsType = {[name: string]: string};
+const WebkitEvents: WebkitEventsType = {
   NEED_KEY: 'webkitneedkey',
   KEY_MESSAGE: 'webkitkeymessage',
   KEY_ADDED: 'webkitkeyadded',
@@ -16,6 +17,7 @@ const WebkitEvents = {
 type FairplayDrmConfigType = {licenseUrl: string, certificate: string};
 
 class FairplayDrmHandler {
+  static WebkitEvents: WebkitEventsType = WebkitEvents;
   _logger = getLogger('FairPlayDrmHandler');
   _keySession: any;
   _config: FairplayDrmConfigType;
@@ -233,6 +235,8 @@ class FairplayDrmHandler {
     return output;
   }
 }
+
+FairplayDrmHandler.WebkitEvents = WebkitEvents;
 
 export {FairplayDrmHandler};
 export type {FairplayDrmConfigType};

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -13,12 +13,12 @@ const WebkitEvents = {
   KEY_ERROR: 'webkitkeyerror'
 };
 
-type fairplayDrmConfigType = {licenseUrl: string, certificate: string};
+type FairplayDrmConfigType = {licenseUrl: string, certificate: string};
 
 class FairplayDrmHandler {
   _logger = getLogger('FairPlayDrmHandler');
   _keySession: any;
-  _config: fairplayDrmConfigType;
+  _config: FairplayDrmConfigType;
   _onWebkitNeedKeyHandler: Function;
   _errorCallback: Function;
   _videoElement: HTMLVideoElement;
@@ -27,10 +27,10 @@ class FairplayDrmHandler {
   /**
    * Fairplay DRM handler
    * @param {HTMLVideoElement} videoElement - the video element
-   * @param {fairplayDrmConfigType} config - config object
+   * @param {FairplayDrmConfigType} config - config object
    * @param {Function} errorCallback - error callback function
    */
-  constructor(videoElement: HTMLVideoElement, config: fairplayDrmConfigType, errorCallback: Function): void {
+  constructor(videoElement: HTMLVideoElement, config: FairplayDrmConfigType, errorCallback: Function): void {
     this._config = config;
     this._errorCallback = errorCallback;
     this._videoElement = videoElement;
@@ -235,4 +235,4 @@ class FairplayDrmHandler {
 }
 
 export {FairplayDrmHandler};
-export type {fairplayDrmConfigType};
+export type {FairplayDrmConfigType};

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -1,0 +1,238 @@
+// @flow
+import Error from '../../../../error/error';
+import getLogger from '../../../../utils/logger';
+import type {CodeType} from '../../../../error/code';
+import type {SeverityType} from '../../../../error/severity';
+import type {CategoryType} from '../../../../error/category';
+
+const KeySystem: string = 'com.apple.fps.1_0';
+const WebkitEvents = {
+  NEED_KEY: 'webkitneedkey',
+  KEY_MESSAGE: 'webkitkeymessage',
+  KEY_ADDED: 'webkitkeyadded',
+  KEY_ERROR: 'webkitkeyerror'
+};
+
+type fairplayDrmConfigType = {licenseUrl: string, certificate: string};
+
+class FairplayDrmHandler {
+  _logger = getLogger('FairPlayDrmHandler');
+  _keySession: any;
+  _config: fairplayDrmConfigType;
+  _onWebkitNeedKeyHandler: Function;
+  _errorCallback: Function;
+  _videoElement: HTMLVideoElement;
+  _retryLicenseRequest: number = 4;
+
+  /**
+   * Fairplay DRM handler
+   * @param {HTMLVideoElement} videoElement - the video element
+   * @param {fairplayDrmConfigType} config - config object
+   * @param {Function} errorCallback - error callback function
+   */
+  constructor(videoElement: HTMLVideoElement, config: fairplayDrmConfigType, errorCallback: Function): void {
+    this._config = config;
+    this._errorCallback = errorCallback;
+    this._videoElement = videoElement;
+    this._onWebkitNeedKeyHandler = e => this._onWebkitNeedKey(e);
+    this._videoElement.addEventListener(WebkitEvents.NEED_KEY, this._onWebkitNeedKeyHandler, false);
+  }
+
+  _onWebkitNeedKey(event: any): void {
+    this._logger.debug('Webkit need key triggered');
+    let videoElement = event.target;
+    let initData = event.initData;
+
+    let contentId = FairplayDrmHandler._extractContentId(initData);
+    let fpsCertificate = FairplayDrmHandler._base64DecodeUint8Array(this._config.certificate);
+
+    initData = FairplayDrmHandler._concatInitDataIdAndCertificate(initData, contentId, fpsCertificate);
+
+    if (!videoElement.webkitKeys) {
+      let keySystem = this._selectKeySystem();
+      this._logger.debug('Sets media keys');
+      videoElement.webkitSetMediaKeys(new window.WebKitMediaKeys(keySystem));
+    }
+    if (!videoElement.webkitKeys) {
+      this._onError((Error.Code: CodeType).COULD_NOT_CREATE_MEDIA_KEYS);
+    }
+    this._logger.debug('Creates session');
+    this._keySession = videoElement.webkitKeys.createSession('video/mp4', initData);
+    if (!this._keySession) {
+      this._onError((Error.Code: CodeType).COULD_NOT_CREATE_KEY_SESSION);
+    }
+    this._keySession.contentId = contentId;
+    this._keySession.addEventListener(WebkitEvents.KEY_MESSAGE, e => this._onWebkitKeyMessage(e), false);
+    this._keySession.addEventListener(WebkitEvents.KEY_ADDED, () => this._onWebkitKeyAdded(), false);
+    this._keySession.addEventListener(WebkitEvents.KEY_ERROR, e => this._onWebkitKeyError(e), false);
+  }
+
+  destroy(): void {
+    this._videoElement.removeEventListener(WebkitEvents.NEED_KEY, this._onWebkitNeedKeyHandler);
+    this._keySession.close();
+    this._keySession = null;
+  }
+
+  _onWebkitKeyMessage(event: any): void {
+    this._logger.debug('Webkit key message triggered');
+    let message = event.message;
+    let request = new XMLHttpRequest();
+    request.responseType = 'text';
+    request.addEventListener('load', (e: Event) => this._licenseRequestLoaded(e), false);
+    request.addEventListener('error', () => this._onError((Error.Code: CodeType).LICENSE_REQUEST_FAILED), false);
+    let params = FairplayDrmHandler._base64EncodeUint8Array(message);
+    request.open('POST', this._config.licenseUrl, true);
+    request.setRequestHeader('Content-type', 'application/json');
+    this._logger.debug('Ready for license request');
+    request.send(params);
+  }
+
+  _onWebkitKeyAdded(): void {
+    this._logger.debug('Decryption key was added to session');
+  }
+
+  _onWebkitKeyError(e: any): void {
+    this._logger.error('A decryption key error was encountered', e);
+    if (this._retryLicenseRequest <= 0) {
+      this._onError((Error.Code: CodeType).LICENSE_REQUEST_FAILED, e.target.error);
+    }
+    this._retryLicenseRequest--;
+  }
+
+  _licenseRequestLoaded(event: any): void {
+    this._logger.debug('License request loaded');
+    let request = event.target;
+    let keyText = request.responseText.trim();
+    let responseObj = {};
+    try {
+      responseObj = JSON.parse(keyText);
+    } catch (error) {
+      this._onError((Error.Code: CodeType).BAD_FAIRPLAY_RESPONSE, error);
+    }
+    let isValidResponse = FairplayDrmHandler._validateResponse(responseObj);
+    if (isValidResponse.valid) {
+      let key = FairplayDrmHandler._base64DecodeUint8Array(responseObj.ckc);
+      this._keySession.update(key);
+    } else {
+      this._onError((Error.Code: CodeType).BAD_FAIRPLAY_RESPONSE, isValidResponse);
+    }
+  }
+
+  _onError(code: number, data?: Object): void {
+    this._errorCallback(new Error((Error.Severity: SeverityType).CRITICAL, (Error.Category: CategoryType).DRM, code, data));
+  }
+
+  static _validateResponse(responseObj: Object): Object {
+    if ((responseObj.message && responseObj.message.indexOf('error') > 0) || responseObj.reference === null || responseObj.status_code === 500) {
+      return {
+        //todo: create & edit an error object
+        valid: false,
+        details: 'internal server error' // would be ERROR.INTERNAL or something like that
+      };
+    } else if (responseObj.ckc === '') {
+      return {
+        valid: false,
+        details: 'ckc is missing' // would be ERROR.MISSING_CKC or something like that
+      };
+    } else {
+      return {
+        valid: true
+      };
+    }
+  }
+
+  _selectKeySystem(): ?string {
+    let keySystem = null;
+    if (window.WebKitMediaKeys.isTypeSupported(KeySystem, 'video/mp4')) {
+      keySystem = KeySystem;
+    } else {
+      this._logger.warn('Key System not supported');
+    }
+    return keySystem;
+  }
+
+  static _extractContentId(initData: Uint8Array): string {
+    let link = document.createElement('a');
+    link.href = FairplayDrmHandler._arrayToString(initData);
+    return link.hostname;
+  }
+
+  static _arrayToString(array: Uint8Array): string {
+    return String.fromCharCode.apply(null, new Uint16Array(array.buffer));
+  }
+
+  static _base64DecodeUint8Array(input: string): Uint8Array {
+    let raw = window.atob(input);
+    let rawLength = raw.length;
+    let array = new Uint8Array(new ArrayBuffer(rawLength));
+    for (let i = 0; i < rawLength; i++) {
+      array[i] = raw.charCodeAt(i);
+    }
+    return array;
+  }
+
+  static _concatInitDataIdAndCertificate(initData: Uint8Array, id: string | Uint16Array, cert: Uint8Array): Uint8Array {
+    if (typeof id === 'string') {
+      id = FairplayDrmHandler._stringToArray(id);
+    }
+    let offset = 0;
+    let buffer = new ArrayBuffer(initData.byteLength + 4 + id.byteLength + 4 + cert.byteLength);
+    let dataView = new DataView(buffer);
+
+    let initDataArray = new Uint8Array(buffer, offset, initData.byteLength);
+    initDataArray.set(initData);
+    offset += initData.byteLength;
+
+    dataView.setUint32(offset, id.byteLength, true);
+    offset += 4;
+
+    let idArray = new Uint8Array(buffer, offset, id.byteLength);
+    idArray.set(id);
+    offset += idArray.byteLength;
+
+    dataView.setUint32(offset, cert.byteLength, true);
+    offset += 4;
+
+    let certArray = new Uint8Array(buffer, offset, cert.byteLength);
+    certArray.set(cert);
+
+    return new Uint8Array(buffer, 0, buffer.byteLength);
+  }
+
+  static _stringToArray(string: string): Uint16Array {
+    let buffer = new ArrayBuffer(string.length * 2);
+    let array = new Uint16Array(buffer);
+    for (let i = 0, strLen = string.length; i < strLen; i++) {
+      array[i] = string.charCodeAt(i);
+    }
+    return array;
+  }
+
+  static _base64EncodeUint8Array(input: Uint8Array): string {
+    let keyStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+    let output = '';
+    let chr1, chr2, chr3, enc1, enc2, enc3, enc4;
+    let i = 0;
+    while (i < input.length) {
+      chr1 = input[i++];
+      chr2 = i < input.length ? input[i++] : Number.NaN;
+      chr3 = i < input.length ? input[i++] : Number.NaN;
+
+      enc1 = chr1 >> 2;
+      enc2 = ((chr1 & 3) << 4) | (chr2 >> 4);
+      enc3 = ((chr2 & 15) << 2) | (chr3 >> 6);
+      enc4 = chr3 & 63;
+
+      if (isNaN(chr2)) {
+        enc3 = enc4 = 64;
+      } else if (isNaN(chr3)) {
+        enc4 = 64;
+      }
+      output += keyStr.charAt(enc1) + keyStr.charAt(enc2) + keyStr.charAt(enc3) + keyStr.charAt(enc4);
+    }
+    return output;
+  }
+}
+
+export {FairplayDrmHandler};
+export type {fairplayDrmConfigType};

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -12,6 +12,8 @@ import FairPlay from '../../../../drm/fairplay';
 import Env from '../../../../utils/env';
 import Error from '../../../../error/error';
 import defaultConfig from './native-adapter-default-config';
+import {FairplayDrmHandler} from './fairplay-drm-handler';
+import type {fairplayDrmConfigType} from './fairplay-drm-handler';
 
 /**
  * An illustration of media source extension for progressive download
@@ -55,6 +57,12 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @static
    */
   static _drmProtocol: ?Function = null;
+  /**
+   * The DRM handler playback.
+   * @type {?FairplayDrmHandler}
+   * @private
+   */
+  _drmHandler: ?FairplayDrmHandler;
   /**
    * The event manager of the class.
    * @member {EventManager} - _eventManager
@@ -182,7 +190,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     NativeAdapter._logger.debug('Creating adapter');
     super(videoElement, source, config);
     this._eventManager = new EventManager();
-    this._maybeSetDrmPlayback();
     this._config = Utils.Object.mergeDeep({}, defaultConfig, this._config);
     this._progressiveSources = config.progressiveSources;
     this._liveEdge = 0;
@@ -191,10 +198,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   /**
    * dispatches an error (is given to a class the cannot dispatch, like static fair play class)
    * @private
-   * @param {any} error - the error to dispatch
+   * @param {Error} error - the error to dispatch
    * @returns {void}
    */
-  _dispatchErrorCallback(error: any): void {
+  _dispatchErrorCallback(error: Error): void {
     this._trigger(Html5EventType.ERROR, error);
   }
 
@@ -205,7 +212,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    */
   _maybeSetDrmPlayback(): void {
     if (NativeAdapter._drmProtocol && this._sourceObj && this._sourceObj.drmData) {
-      NativeAdapter._drmProtocol.setDrmPlayback(this._videoElement, this._sourceObj.drmData, error => this._dispatchErrorCallback(error));
+      const drmConfig: fairplayDrmConfigType = {licenseUrl: '', certificate: ''};
+      NativeAdapter._drmProtocol.setDrmPlayback(drmConfig, this._sourceObj.drmData);
+      this._drmHandler = new FairplayDrmHandler(this._videoElement, drmConfig, error => this._dispatchErrorCallback(error));
     }
   }
 
@@ -239,6 +248,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @returns {Promise<Object>} - The loaded data
    */
   load(startTime: ?number): Promise<Object> {
+    this._maybeSetDrmPlayback();
     if (!this._loadPromise) {
       this._loadPromise = new Promise((resolve, reject) => {
         this._lastTimeUpdate = startTime || 0;
@@ -353,6 +363,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     NativeAdapter._logger.debug('destroy');
     return super.destroy().then(() => {
       this._eventManager.destroy();
+      this._drmHandler && this._drmHandler.destroy();
       this._waitingEventTriggered = false;
       this._progressiveSources = [];
       this._loadPromise = null;

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -13,7 +13,7 @@ import Env from '../../../../utils/env';
 import Error from '../../../../error/error';
 import defaultConfig from './native-adapter-default-config';
 import {FairplayDrmHandler} from './fairplay-drm-handler';
-import type {fairplayDrmConfigType} from './fairplay-drm-handler';
+import type {FairplayDrmConfigType} from './fairplay-drm-handler';
 
 /**
  * An illustration of media source extension for progressive download
@@ -212,7 +212,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    */
   _maybeSetDrmPlayback(): void {
     if (NativeAdapter._drmProtocol && this._sourceObj && this._sourceObj.drmData) {
-      const drmConfig: fairplayDrmConfigType = {licenseUrl: '', certificate: ''};
+      const drmConfig: FairplayDrmConfigType = {licenseUrl: '', certificate: ''};
       NativeAdapter._drmProtocol.setDrmPlayback(drmConfig, this._sourceObj.drmData);
       this._drmHandler = new FairplayDrmHandler(this._videoElement, drmConfig, error => this._dispatchErrorCallback(error));
     }

--- a/test/src/drm/fairplay.spec.js
+++ b/test/src/drm/fairplay.spec.js
@@ -1,6 +1,5 @@
 import FairPlay from '../../../src/drm/fairplay';
 import Env from '../../../src/utils/env';
-import {createElement, removeVideoElementsFromTestPage} from '../utils/test-utils';
 
 const BROWSER: string = Env.browser.name;
 const fpDrmData = [{licenseUrl: 'LICENSE_URL', scheme: FairPlay.DrmScheme.FAIRPLAY}];
@@ -22,65 +21,6 @@ describe('FairPlay', function() {
 
     it('should return false for non-fairplay data in any case', function() {
       FairPlay.canPlayDrm(wwDrmData).should.be.false;
-    });
-  });
-
-  describe('setDrmPlayback', function() {
-    let videoId = 'myVideoElement';
-    let videoElement;
-    let sandbox;
-
-    beforeEach(function() {
-      sandbox = sinon.sandbox.create();
-      createElement('video', videoId);
-      videoElement = document.getElementById(videoId);
-    });
-
-    afterEach(function() {
-      sandbox = sandbox.restore();
-      removeVideoElementsFromTestPage();
-    });
-
-    it('sets the webkitneedkey event on the video element', function() {
-      let spy = sandbox.spy(HTMLVideoElement.prototype, 'addEventListener');
-      FairPlay.setDrmPlayback(videoElement, fpDrmData);
-      spy.should.have.been.calledOnce;
-      spy.should.have.been.calledWithMatch(FairPlay._WebkitEvents.NEED_KEY);
-    });
-  });
-
-  describe('_validateResponse', function() {
-    it('should return an object with valid=true', () => {
-      let drmResponse = {
-        ckc: '123',
-        expire: '98798798791'
-      };
-      let validationResponse = FairPlay._validateResponse(drmResponse);
-      validationResponse.valid.should.equals(true);
-    });
-
-    it('should return an object with valid=false, error', () => {
-      let drmResponse = {
-        message: 'internal, error'
-      };
-      let validationResponse = FairPlay._validateResponse(drmResponse);
-      validationResponse.valid.should.equals(false);
-    });
-
-    it('should return an object with valid=false, ckc is empty', () => {
-      let drmResponse = {
-        ckc: ''
-      };
-      let validationResponse = FairPlay._validateResponse(drmResponse);
-      validationResponse.valid.should.equals(false);
-    });
-
-    it('should return an object with valid=false, status code is 500 ', () => {
-      let drmResponse = {
-        status_code: 500
-      };
-      let validationResponse = FairPlay._validateResponse(drmResponse);
-      validationResponse.valid.should.equals(false);
     });
   });
 });

--- a/test/src/engines/html5/media-source/adapters/fairplay-drm-handler.spec.js
+++ b/test/src/engines/html5/media-source/adapters/fairplay-drm-handler.spec.js
@@ -1,0 +1,65 @@
+import {FairplayDrmHandler} from '../../../../../../src/engines/html5/media-source/adapters/fairplay-drm-handler';
+import {removeVideoElementsFromTestPage, createElement} from '../../../../utils/test-utils';
+
+const fpsDrmData = [{licenseUrl: 'LICENSE_URL', certificate: 'fpsCertificate'}];
+
+describe('Fairplay Drm Handler', function() {
+  describe('constructor', function() {
+    let videoId = 'myVideoElement';
+    let videoElement;
+    let sandbox;
+
+    beforeEach(function() {
+      sandbox = sinon.sandbox.create();
+      createElement('video', videoId);
+      videoElement = document.getElementById(videoId);
+    });
+
+    afterEach(function() {
+      sandbox = sandbox.restore();
+      removeVideoElementsFromTestPage();
+    });
+
+    it('should register the webkitneedkey event on the video element', function() {
+      let spy = sandbox.spy(HTMLVideoElement.prototype, 'addEventListener');
+      new FairplayDrmHandler(videoElement, fpsDrmData, () => {});
+      spy.should.have.been.calledOnce;
+      spy.should.have.been.calledWithMatch(FairplayDrmHandler.WebkitEvents.NEED_KEY);
+    });
+  });
+
+  describe('_validateResponse', function() {
+    it('should return an object with valid=true', () => {
+      let drmResponse = {
+        ckc: '123',
+        expire: '98798798791'
+      };
+      let validationResponse = FairplayDrmHandler._validateResponse(drmResponse);
+      validationResponse.valid.should.equals(true);
+    });
+
+    it('should return an object with valid=false, error', () => {
+      let drmResponse = {
+        message: 'internal, error'
+      };
+      let validationResponse = FairplayDrmHandler._validateResponse(drmResponse);
+      validationResponse.valid.should.equals(false);
+    });
+
+    it('should return an object with valid=false, ckc is empty', () => {
+      let drmResponse = {
+        ckc: ''
+      };
+      let validationResponse = FairplayDrmHandler._validateResponse(drmResponse);
+      validationResponse.valid.should.equals(false);
+    });
+
+    it('should return an object with valid=false, status code is 500 ', () => {
+      let drmResponse = {
+        status_code: 500
+      };
+      let validationResponse = FairplayDrmHandler._validateResponse(drmResponse);
+      validationResponse.valid.should.equals(false);
+    });
+  });
+});


### PR DESCRIPTION
### Description of the Changes

The fairplay hander was managed as a static class and saved the media session on it.
When the player was reset the session wasn't closed and its reference remained on the static class.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
