### PR TITLE
fix(FEC-8621): player destroy event is not dispatched

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -609,7 +609,6 @@ export default class Player extends FakeEventTarget {
     }
     this._externalCaptionsHandler.destroy();
     this._posterManager.destroy();
-    this._eventManager.destroy();
     this._pluginManager.destroy();
     this._stateManager.destroy();
     this._activeTextCues = [];
@@ -626,6 +625,7 @@ export default class Player extends FakeEventTarget {
     }
     this._destroyed = true;
     this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_DESTROY));
+    this._eventManager.destroy();
   }
 
   /**

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2643,6 +2643,14 @@ describe('Player', function() {
       (player._readyPromise === null).should.be.true;
       player._firstPlay.should.be.true;
     });
+
+    it('should dispatch a player destroyed event', function(done) {
+      player = new Player(config);
+      player.addEventListener(player.Event.PLAYER_DESTROY, () => {
+        done();
+      });
+      player.destroy();
+    });
   });
 
   describe('reset', function() {


### PR DESCRIPTION
### Description of the Changes

The event manager is destroyed before the event is dispatched :-)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment 
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
