### PR TITLE
fix(FEC-8650): the video continues in picture-in-picture window when full screen opened

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1194,6 +1194,9 @@ export default class Player extends FakeEventTarget {
    */
   enterFullscreen(): void {
     if (!this._fullscreen) {
+      if (this.isInPictureInPicture()) {
+        this.exitPictureInPicture();
+      }
       this.dispatchEvent(new FakeEvent(CustomEventType.REQUESTED_ENTER_FULLSCREEN));
     }
   }
@@ -1219,6 +1222,9 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   enterPictureInPicture(): void {
+    if (this.isFullscreen()) {
+      this.exitFullscreen();
+    }
     if (!this._engine.isInPictureInPicture) {
       this._engine.enterPictureInPicture();
     }

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1193,6 +1193,7 @@ describe('Player', function() {
 
     beforeEach(() => {
       player = new Player();
+      player._engine = {destroy: function() {}};
     });
 
     afterEach(() => {


### PR DESCRIPTION
### Description of the Changes

full screen and PIP transitions.

When the player is on PIP and changes to full screen: close the PIP first (otherwise on chrome it will not transition to full screen properly)
When the player is on full screen and changes to PIP: close the full screen first.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
