### PR TITLE
fix(FEC-8668): inline styled vtt parser crash

### DIFF
--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -304,7 +304,6 @@ function parseContent(window, input) {
       return null;
     }
     let element = window.document.createElement(tagName);
-    element.localName = tagName;
     const name = TAG_ANNOTATION[type];
     if (name && annotation) {
       element[name] = annotation.trim();


### PR DESCRIPTION
### Description of the Changes

We are using vtt.js parser.
When parsing captions it tries to create an HTMLElement and it also tries to set the localName of it, which is read only, and this causes a crash and captions don't appear.

Docs for HTMLElement.localName:
https://developer.mozilla.org/en-US/docs/Web/API/Element/localName

I don't see any reason to set this anyhow as the creation of an HTMLElement of a certain type also sets its localName by itself.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
