### PR TITLE
fix(FEC-8695): reset/destroy engine only after all services are destroyed

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -578,8 +578,12 @@ export default class Player extends FakeEventTarget {
   reset(): void {
     if (this._reset) return;
     this.pause();
+    //make sure all services are reset before engine and engine attributes are reset
+    this._externalCaptionsHandler.reset();
+    this._posterManager.reset();
+    this._pluginManager.reset();
+    this._stateManager.reset();
     this._config.sources = {};
-    this._eventManager.removeAll();
     this._createReadyPromise();
     this._activeTextCues = [];
     this._updateTextDisplay([]);
@@ -587,14 +591,11 @@ export default class Player extends FakeEventTarget {
     this._resetStateFlags();
     this._engineType = '';
     this._streamType = '';
-    this._posterManager.reset();
-    this._stateManager.reset();
-    this._pluginManager.reset();
-    this._externalCaptionsHandler.reset();
     this._engine.reset();
     this._showBlackCover();
     this._reset = true;
     this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET));
+    this._eventManager.removeAll();
   }
 
   /**
@@ -604,9 +605,7 @@ export default class Player extends FakeEventTarget {
    */
   destroy(): void {
     if (this._destroyed) return;
-    if (this._engine) {
-      this._engine.destroy();
-    }
+    //make sure all services are destroyed before engine and engine attributes are destroyed
     this._externalCaptionsHandler.destroy();
     this._posterManager.destroy();
     this._pluginManager.destroy();
@@ -620,6 +619,9 @@ export default class Player extends FakeEventTarget {
     this._readyPromise = null;
     this._resetStateFlags();
     this._playbackAttributesState = {};
+    if (this._engine) {
+      this._engine.destroy();
+    }
     if (this._el) {
       Utils.Dom.removeChild(this._el.parentNode, this._el);
     }

--- a/src/player.js
+++ b/src/player.js
@@ -584,7 +584,6 @@ export default class Player extends FakeEventTarget {
     this._pluginManager.reset();
     this._stateManager.reset();
     this._config.sources = {};
-    this._createReadyPromise();
     this._activeTextCues = [];
     this._updateTextDisplay([]);
     this._tracks = [];
@@ -596,6 +595,7 @@ export default class Player extends FakeEventTarget {
     this._reset = true;
     this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET));
     this._eventManager.removeAll();
+    this._createReadyPromise();
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

services that depend on engine must be reset/destroyed before the engine is reset/destroyed as they may depend on reading data from the player before they cleanup.
relates to https://github.com/kaltura/playkit-js-ott-analytics/pull/19

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
