### PR TITLE
fix(FEC-8712): replay button does not display when using a non liner ad

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1866,8 +1866,8 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _onEnded(): void {
-    if (this._adsController && !this._adsController.allAdsCompleted) {
-      this._eventManager.listenOnce(this._adsController, AdEventType.ALL_ADS_COMPLETED, () => {
+    if (this._adsController && this._adsController.hasPostRoll) {
+      this._eventManager.listenOnce(this, AdEventType.ALL_ADS_COMPLETED, () => {
         this.dispatchEvent(new FakeEvent(CustomEventType.PLAYBACK_ENDED));
       });
     } else {


### PR DESCRIPTION
### Description of the Changes

wait to `ALL_ADS_COMPLETED` only when there is a post roll, else `ENDED` = `PLAYBACK_ENDED`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
