### PR TITLE
fix(FEC-8722): more than one caption is checked at the caption menu

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2123,6 +2123,7 @@ export default class Player extends FakeEventTarget {
     const track: ?Track = this._getTracksByType(type).find(track => Track.langComparer(language, track.language));
     if (track) {
       this.selectTrack(track);
+      this._markActiveTrack(track);
     } else if (defaultTrack && !defaultTrack.active) {
       this.selectTrack(defaultTrack);
     }

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -161,8 +161,11 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @private
    */
   _createTextTrack(caption: PKExternalCaptionObject, index: number): TextTrack {
+    const active =
+      !!caption.default &&
+      (this._player.config.playback.textLanguage === 'auto' || Track.langComparer(this._player.config.playback.textLanguage, caption.language));
     return new TextTrack({
-      active: !!caption.default,
+      active,
       index: index,
       kind: 'subtitles',
       label: caption.label,

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -165,7 +165,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
       this._isTextTrackActive = true;
     }
     return new TextTrack({
-      active: caption.default,
+      active: !!caption.default,
       index: index,
       kind: 'subtitles',
       label: caption.label,
@@ -199,8 +199,8 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     if (this._textTrackModel[textTrack.language]) {
       if (this._textTrackModel[textTrack.language].cuesStatus === CuesStatus.DOWNLOADED && !this._player.config.playback.useNativeTextTrack) {
         textTrack.active = true;
-        this.hideTextTrack();
         this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}));
+        this.hideTextTrack();
         this._setTextTrack(textTrack);
       } else if (this._textTrackModel[textTrack.language].cuesStatus === CuesStatus.NOT_DOWNLOADED) {
         textTrack.active = true;

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -161,9 +161,6 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @private
    */
   _createTextTrack(caption: PKExternalCaptionObject, index: number): TextTrack {
-    if (caption.default) {
-      this._isTextTrackActive = true;
-    }
     return new TextTrack({
       active: !!caption.default,
       index: index,

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -99,8 +99,6 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   hideTextTrack(): void {
     // only if external text track was active we need to hide it.
     if (this._isTextTrackActive) {
-      const offTrack = this._player.getTracks(TrackType.TEXT).find(track => track instanceof TextTrack && track.language === 'off');
-      this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: offTrack}));
       this._eventManager.unlisten(this._player, Html5EventType.TIME_UPDATE);
       this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_CUE_CHANGED, {cues: []}));
       this._resetCurrentTrack();
@@ -163,9 +161,6 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @private
    */
   _createTextTrack(caption: PKExternalCaptionObject, index: number): TextTrack {
-    // const active =
-    //   !!caption.default &&
-    //   (this._player.config.playback.textLanguage === 'auto' || Track.langComparer(this._player.config.playback.textLanguage, caption.language));
     if (caption.default) {
       this._isTextTrackActive = true;
     }


### PR DESCRIPTION
### Description of the Changes

external text track will be active at the beginning in the following scenarios:
1. caption config has 'default: true' and playback.textLanguage is set to auto.
2. caption config has 'default: true' and playback.textLanguage is the same as the caption language.
otherwise, it will be set to false.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
