### PR TITLE
fix(FEC-8714):  change media doesn't work after player.destroy() on iOS

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -400,6 +400,7 @@ export default class Player extends FakeEventTarget {
    */
   constructor(config: Object = {}) {
     super();
+    Player._prepareVideoElement();
     Player.runCapabilities();
     this._env = Env;
     this._tracks = [];
@@ -608,6 +609,7 @@ export default class Player extends FakeEventTarget {
     if (this._destroyed) return;
     //make sure all services are destroyed before engine and engine attributes are destroyed
     this._externalCaptionsHandler.destroy();
+    Player._playerCapabilities = {};
     this._posterManager.destroy();
     this._pluginManager.destroy();
     this._stateManager.destroy();


### PR DESCRIPTION
1. creating the player video element before running the capabilities so a click would affect it as well as the video element created in `runCapabilities`
2. set `Player._playerCapabilities = {}` on destroy. Because after a 'click' it is set to `autoplay: true`. After change media - it's not always the case

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
