### PR TITLE
fix(FEC-8715): if label does not exist in manifest use the language property

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1008,6 +1008,10 @@ var config = {
 >   }
 > };
 > ```
+>
+> **Important**:
+> A Text track has language and label properties. The label is set by the label property in the manifest.
+> However, in case the manifest does not have a label property - the language property will be set as the tracks label.
 
 ##
 

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -46,6 +46,8 @@ export default class TextTrack extends Track {
    */
   constructor(settings: Object = {}) {
     super(settings);
+    // some of the OTT dash manifests do not return a label, we will take the language instead.
+    this._label = this.label || this.language;
     this._kind = settings.kind;
     this._external = settings.external;
   }

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -46,7 +46,7 @@ export default class TextTrack extends Track {
    */
   constructor(settings: Object = {}) {
     super(settings);
-    // some of the OTT dash manifests do not return a label, we will take the language instead.
+    // use language tag if no display label is available
     this._label = this.label || this.language;
     this._kind = settings.kind;
     this._external = settings.external;

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -303,7 +303,11 @@ describe('NativeAdapter: _getParsedTracks', function() {
         if (track instanceof TextTrack) {
           track.kind.should.equal(video.textTracks[track.index].kind);
           track.active.should.equal(video.textTracks[track.index].mode === 'showing');
-          track.label.should.equal(video.textTracks[track.index].label);
+          if (video.textTracks[track.index].label) {
+            track.label.should.equal(video.textTracks[track.index].label);
+          } else {
+            track.label.should.equal(video.textTracks[track.index].language);
+          }
           track.language.should.equal(video.textTracks[track.index].language);
         }
       });


### PR DESCRIPTION
### Description of the Changes

if label does not exist - use the language property.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
