### PR TITLE
fix(FEC-8764): after change media / refresh the video has no subtitles (hls)

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -865,10 +865,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @private
    */
   _addCueChangeListener(): void {
-    let textTrackEl = Array.from(this._el.textTracks).find(track => track && track.mode !== 'disabled');
-    if (textTrackEl) {
-      this._eventManager.listen(textTrackEl, 'cuechange', e => this._onCueChange(e));
-    }
+    Array.from(this._el.textTracks).forEach(track => this._eventManager.listen(track, 'cuechange', e => this._onCueChange(e)));
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

since cues only exist in a 'hidden/showing' track and since all the other text tracks are disabled (by hls / or by the native adapter, [shaka has only 1 track]) then we can listen to all of them.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
