### PR TITLE
fix(FEC-7444): when selecting fullscreen in android captions size is too large

### DIFF
--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -1020,7 +1020,8 @@ function processCues(window, cues, overlay) {
 
   let boxPositions = [],
     containerBox = BoxPosition.getSimpleBoxPosition(paddedOverlay),
-    fontSize = Math.round(containerBox.height * FONT_SIZE_PERCENT * 100) / 100;
+    dimensionSize = containerBox.height < containerBox.width ? containerBox.height : containerBox.width,
+    fontSize = Math.round(dimensionSize * FONT_SIZE_PERCENT * 100) / 100;
   let styleOptions = {
     font: fontSize * fontScale + 'px ' + FONT_STYLE
   };


### PR DESCRIPTION
instead of relying on the height of the video to determine subtitles size, deciding on the dimention according to the box size. if height > width then using width. else -> using height.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
