### PR TITLE
fix(FEC-8770): iOS -  captions style it applies for both players in the same page

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -67,11 +67,11 @@ const POSTER_CLASS_NAME: string = 'playkit-poster';
 const ENGINE_CLASS_NAME: string = 'playkit-engine';
 
 /**
- * The text style id.
+ * The text style class name.
  * @type {string}
  * @const
  */
-const SUBTITLES_STYLE_ID_NAME: string = 'playkit-subtitles-style';
+const SUBTITLES_STYLE_CLASS_NAME: string = 'playkit-subtitles-style';
 
 /**
  * The subtitles class name.
@@ -1099,10 +1099,11 @@ export default class Player extends FakeEventTarget {
     if (!(style instanceof TextStyle)) {
       throw new Error('Style must be instance of TextStyle');
     }
-    let element = Utils.Dom.getElementById(SUBTITLES_STYLE_ID_NAME);
+    let element = Utils.Dom.getElementBySelector(`.${this._playerId}.${SUBTITLES_STYLE_CLASS_NAME}`);
     if (!element) {
       element = Utils.Dom.createElement('style');
-      Utils.Dom.setAttribute(element, 'id', SUBTITLES_STYLE_ID_NAME);
+      Utils.Dom.addClassName(element, this._playerId);
+      Utils.Dom.addClassName(element, SUBTITLES_STYLE_CLASS_NAME);
       Utils.Dom.appendChild(document.head, element);
     }
     let sheet = element.sheet;
@@ -1113,7 +1114,7 @@ export default class Player extends FakeEventTarget {
 
     try {
       if (this._config.playback.useNativeTextTrack) {
-        sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::cue { ${style.toCSS()} }`, 0);
+        sheet.insertRule(`#${this._playerId}  video.${ENGINE_CLASS_NAME}::cue { ${style.toCSS()} }`, 0);
       } else {
         sheet.insertRule(`#${this._playerId} .${SUBTITLES_CLASS_NAME} > div > div > div { ${style.toCSS()} }`, 0);
       }

--- a/src/player.js
+++ b/src/player.js
@@ -1113,7 +1113,7 @@ export default class Player extends FakeEventTarget {
 
     try {
       if (this._config.playback.useNativeTextTrack) {
-        sheet.insertRule(`video.${ENGINE_CLASS_NAME}::cue { ${style.toCSS()} }`, 0);
+        sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::cue { ${style.toCSS()} }`, 0);
       } else {
         sheet.insertRule(`#${this._playerId} .${SUBTITLES_CLASS_NAME} > div > div > div { ${style.toCSS()} }`, 0);
       }


### PR DESCRIPTION
### Description of the Changes

Current state: style sheet is selected by id.
change: select it by class, adding playerid for the style sheet class.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
