### PR TITLE
feat(FEC-8700): add config option to specify DRM system

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,8 @@ var player = playkit.core.loadPlayer(config);
   session: PKSessionConfigObject,
   plugins: PKPluginsConfigObject,
   customLabels: PKCustomLabelsConfigObject,
-  abr: PKAbrConfigObject
+  abr: PKAbrConfigObject,
+  drm: PKDrmConfigObject
 }
 ```
 
@@ -82,6 +83,9 @@ var config = {
     fpsDroppedFramesInterval: 5000,
     fpsDroppedMonitoringThreshold: 0.2,
     capLevelOnFPSDrop: true
+  },
+  drm: {
+    keySystem: ''
   }
 };
 ```
@@ -1066,6 +1070,38 @@ var config = {
 > > ##### Default: true
 > >
 > > ##### Description: If the player should cap the level when the fps exceeds the threshold.
+>
+> ##
+
+##
+
+> ### config.drm
+>
+> ##### Type: `PKDrmConfigObject`
+>
+> ```js
+> {
+>   keySystem: string;
+> }
+> ```
+>
+> ##### Default:
+>
+> ```js
+> {
+>   keySystem: '';
+> }
+> ```
+>
+> ##### Description: DRM system configuration
+>
+> > ### config.drm.keySystem
+> >
+> > ##### Type: `string`
+> >
+> > ##### Default: ``
+> >
+> > ##### Description: A specific DRM key system to use
 >
 > ##
 

--- a/flow-typed/interfaces/engine.js
+++ b/flow-typed/interfaces/engine.js
@@ -6,7 +6,7 @@ import TextTrack from '../../src/track/text-track';
 declare interface IEngine {
   static id: string;
   static createEngine(source: PKMediaSourceObject, config: Object): IEngine;
-  static canPlaySource(source: PKMediaSourceObject, preferNative: boolean, drmConfig:PKDrmConfigObject): boolean;
+  static canPlaySource(source: PKMediaSourceObject, preferNative: boolean, drmConfig: PKDrmConfigObject): boolean;
   static runCapabilities(): void;
   static getCapabilities(): Promise<Object>;
   static prepareVideoElement(): void;

--- a/flow-typed/interfaces/engine.js
+++ b/flow-typed/interfaces/engine.js
@@ -6,7 +6,7 @@ import TextTrack from '../../src/track/text-track';
 declare interface IEngine {
   static id: string;
   static createEngine(source: PKMediaSourceObject, config: Object): IEngine;
-  static canPlaySource(source: PKMediaSourceObject, preferNative: boolean): boolean;
+  static canPlaySource(source: PKMediaSourceObject, preferNative: boolean, drmConfig:PKDrmConfigObject): boolean;
   static runCapabilities(): void;
   static getCapabilities(): Promise<Object>;
   static prepareVideoElement(): void;

--- a/flow-typed/types/drm-config.js
+++ b/flow-typed/types/drm-config.js
@@ -1,0 +1,6 @@
+// @flow
+import {DrmScheme} from '../../src/drm/drm-scheme';
+
+declare type PKDrmConfigObject = {
+  keySystem: ?DrmScheme
+};

--- a/src/drm/base-drm-protocol.js
+++ b/src/drm/base-drm-protocol.js
@@ -10,6 +10,10 @@ export default class BaseDrmProtocol implements IDrmProtocol {
   static DrmSupport = DrmSupport;
   static DrmScheme = DrmScheme;
 
+  static isConfigured(drmData: Array<Object>, drmConfig: PKDrmConfigObject): boolean {
+    throw new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.RUNTIME_ERROR_METHOD_NOT_IMPLEMENTED, 'static isConfigured');
+  }
+
   static canPlayDrm(drmData: Array<Object>): boolean {
     throw new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.RUNTIME_ERROR_METHOD_NOT_IMPLEMENTED, 'static canPlayDrm');
   }

--- a/src/drm/fairplay.js
+++ b/src/drm/fairplay.js
@@ -16,6 +16,16 @@ export default class FairPlay extends BaseDrmProtocol {
   static _errorCallback: Function;
 
   /**
+   * FairPlay is the configure key system.
+   * @param {Array<Object>} drmData - The drm data.
+   * @param {PKDrmConfigObject} drmConfig - The drm config.
+   * @return {boolean} - Whether FairPlay is the configure key system.
+   */
+  static isConfigured(drmData: Array<Object>, drmConfig: PKDrmConfigObject): boolean {
+    return BaseDrmProtocol.DrmScheme.FAIRPLAY === drmConfig.keySystem && !!drmData.find(drmEntry => drmEntry.scheme === drmConfig.keySystem);
+  }
+
+  /**
    * FairPlay playback supports in case 2 conditions are met:
    * 1. The environment supports FairPlay playback.
    * 2. The drm data of the source object contains entry with FairPlay scheme.

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -108,13 +108,14 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   /**
    * Checks if the engine can play a given source.
    * @param {PKMediaSourceObject} source - The source object to check.
-   * @param {boolean} preferNative - prefer native flag
+   * @param {boolean} preferNative - prefer native flag.
+   * @param {PKDrmConfigObject} drmConfig - The drm config.
    * @returns {boolean} - Whether the engine can play the source.
    * @public
    * @static
    */
-  static canPlaySource(source: PKMediaSourceObject, preferNative: boolean): boolean {
-    return MediaSourceProvider.canPlaySource(source, preferNative);
+  static canPlaySource(source: PKMediaSourceObject, preferNative: boolean, drmConfig: PKDrmConfigObject): boolean {
+    return MediaSourceProvider.canPlaySource(source, preferNative, drmConfig);
   }
 
   /**

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -134,16 +134,26 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * Checks if NativeAdapter can play a given drm data.
    * @function canPlayDrm
    * @param {Array<Object>} drmData - The drm data to check.
+   * @param {PKDrmConfigObject} drmConfig - The drm config.
    * @returns {boolean} - Whether the native adapter can play a specific drm data.
    * @static
    */
-  static canPlayDrm(drmData: Array<Object>): boolean {
+  static canPlayDrm(drmData: Array<Object>, drmConfig: PKDrmConfigObject): boolean {
     let canPlayDrm = false;
     for (let drmProtocol of NativeAdapter._drmProtocols) {
-      if (drmProtocol.canPlayDrm(drmData)) {
+      if (drmProtocol.isConfigured(drmData, drmConfig)) {
         NativeAdapter._drmProtocol = drmProtocol;
         canPlayDrm = true;
         break;
+      }
+    }
+    if (!canPlayDrm) {
+      for (let drmProtocol of NativeAdapter._drmProtocols) {
+        if (drmProtocol.canPlayDrm(drmData)) {
+          NativeAdapter._drmProtocol = drmProtocol;
+          canPlayDrm = true;
+          break;
+        }
       }
     }
     NativeAdapter._logger.debug('canPlayDrm result is ' + canPlayDrm.toString(), drmData);

--- a/src/engines/html5/media-source/media-source-provider.js
+++ b/src/engines/html5/media-source/media-source-provider.js
@@ -65,17 +65,21 @@ export default class MediaSourceProvider {
   /**
    * Checks if the a media source adapter can play a given source.
    * @param {PKMediaSourceObject} source - The source object to check.
-   *  @param {boolean} [preferNative=true] - prefer native flag
+   * @param {boolean} [preferNative=true] - prefer native flag.
+   * @param {PKDrmConfigObject} drmConfig - The drm config.
    * @returns {boolean} - Whether a media source adapter can play the source.
    * @public
    * @static
    */
-  static canPlaySource(source: PKMediaSourceObject, preferNative: boolean = true): boolean {
+  static canPlaySource(source: PKMediaSourceObject, preferNative: boolean = true, drmConfig: PKDrmConfigObject): boolean {
     MediaSourceProvider._orderMediaSourceAdapters(preferNative);
     let mediaSourceAdapters = MediaSourceProvider._mediaSourceAdapters;
     if (source && source.mimetype) {
       for (let i = 0; i < mediaSourceAdapters.length; i++) {
-        if (mediaSourceAdapters[i].canPlayType(source.mimetype) && (!source.drmData || mediaSourceAdapters[i].canPlayDrm(source.drmData))) {
+        if (
+          mediaSourceAdapters[i].canPlayType(source.mimetype) &&
+          (!source.drmData || mediaSourceAdapters[i].canPlayDrm(source.drmData, drmConfig))
+        ) {
           MediaSourceProvider._selectedAdapter = mediaSourceAdapters[i];
           MediaSourceProvider._logger.debug(`Selected adapter is <${MediaSourceProvider._selectedAdapter.id}>`);
           return true;
@@ -112,7 +116,7 @@ export default class MediaSourceProvider {
   static getMediaSourceAdapter(videoElement: HTMLVideoElement, source: PKMediaSourceObject, config: Object): ?IMediaSourceAdapter {
     if (videoElement && source && config) {
       if (!MediaSourceProvider._selectedAdapter) {
-        MediaSourceProvider.canPlaySource(source, true);
+        MediaSourceProvider.canPlaySource(source, true, config.drm);
       }
       return MediaSourceProvider._selectedAdapter ? MediaSourceProvider._selectedAdapter.createAdapter(videoElement, source, config) : null;
     }

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -65,6 +65,9 @@ const DefaultConfig = {
       minBitrate: 0,
       maxBitrate: Infinity
     }
+  },
+  drm: {
+    keySystem: ''
   }
 };
 

--- a/src/player.js
+++ b/src/player.js
@@ -1494,7 +1494,7 @@ export default class Player extends FakeEventTarget {
         const formatSources = sources[format];
         if (formatSources && formatSources.length > 0) {
           const source = formatSources[0];
-          if (Engine.canPlaySource(source, preferNative[format])) {
+          if (Engine.canPlaySource(source, preferNative[format], this._config.drm)) {
             Player._logger.debug('Source selected: ', formatSources);
             this._loadEngine(Engine, source);
             this._engineType = engineId;

--- a/test/src/drm/fairplay.spec.js
+++ b/test/src/drm/fairplay.spec.js
@@ -10,6 +10,20 @@ function isValidEnvForFairPlay() {
 }
 
 describe('FairPlay', function() {
+  describe('isConfigured', function() {
+    it('should return true for fairplay data if configured', function() {
+      FairPlay.isConfigured(fpDrmData, {keySystem: FairPlay.DrmScheme.FAIRPLAY}).should.be.true;
+    });
+
+    it('should return false for fairplay data if not configured', function() {
+      FairPlay.isConfigured(fpDrmData, {keySystem: FairPlay.DrmScheme.WIDEVINE}).should.be.false;
+    });
+
+    it('should return false for non-fairplay data even configured', function() {
+      FairPlay.isConfigured(wwDrmData, {keySystem: FairPlay.DrmScheme.FAIRPLAY}).should.be.false;
+    });
+  });
+
   describe('canPlayDrm', function() {
     it('should return true for fairplay data on valid fairplay env and false otherwise', function() {
       if (isValidEnvForFairPlay()) {

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -7,6 +7,7 @@ import sourcesConfig from '../../../../configs/sources.json';
 import * as Utils from '../../../../../../src/utils/util';
 import Env from '../../../../../../src/utils/env';
 import {CustomEventType, Html5EventType} from '../../../../../../src/event/event-type';
+import FairPlay from '../../../../../../src/drm/fairplay';
 
 describe('NativeAdapter: isSupported', () => {
   it('should be supported', () => {
@@ -47,6 +48,30 @@ describe('NativeAdapter: canPlayType', () => {
 
   it('should return false for no mime type', () => {
     NativeAdapter.canPlayType().should.be.false;
+  });
+});
+
+describe('NativeAdapter: canPlayDrm', () => {
+  const fpDrmData = [{licenseUrl: 'LICENSE_URL', scheme: FairPlay.DrmScheme.FAIRPLAY}];
+  const wwDrmData = [{licenseUrl: 'LICENSE_URL', scheme: FairPlay.DrmScheme.WIDEVINE}];
+
+  beforeEach(() => {
+    NativeAdapter._drmProtocol = null;
+  });
+
+  it('should return true for fairplay data if configured', function() {
+    NativeAdapter.canPlayDrm(fpDrmData, {keySystem: FairPlay.DrmScheme.FAIRPLAY}).should.be.true;
+    NativeAdapter._drmProtocol._KeySystem.should.equal(FairPlay._KeySystem);
+  });
+
+  it('should return false for fairplay data if not configured', function() {
+    NativeAdapter.canPlayDrm(fpDrmData, {keySystem: FairPlay.DrmScheme.WIDEVINE}).should.be.false;
+    (NativeAdapter._drmProtocol === null).should.be.true;
+  });
+
+  it('should return false for non-fairplay data even configured', function() {
+    NativeAdapter.canPlayDrm(wwDrmData, {keySystem: FairPlay.DrmScheme.FAIRPLAY}).should.be.false;
+    (NativeAdapter._drmProtocol === null).should.be.true;
   });
 });
 

--- a/test/src/engines/html5/media-source/adapters/test-adapters/test-adapters.js
+++ b/test/src/engines/html5/media-source/adapters/test-adapters/test-adapters.js
@@ -27,8 +27,8 @@ class Adapter1 implements IMediaSourceAdapter {
     return ['mimeType0', 'mimeType1'].includes(mimeType);
   }
 
-  static canPlayDrm(drmData: Array<Object>): boolean {
-    return !!(drmData.length && drmData[0].scheme === 's1');
+  static canPlayDrm(drmData: Array<Object>, drmConfig: PKDrmConfigObject): boolean {
+    return !!((drmData.length && drmData[0].scheme === 's1') || drmConfig.keySystem === 's1');
   }
 
   static createAdapter(videoElement: HTMLVideoElement, source: Object, config: Object): IMediaSourceAdapter {
@@ -75,8 +75,8 @@ class Adapter3 implements IMediaSourceAdapter {
     return !!document.createElement('video').canPlayType(mimeType);
   }
 
-  static canPlayDrm(drmData: Array<Object>): boolean {
-    return !!(drmData.length && drmData[0].scheme === 's3');
+  static canPlayDrm(drmData: Array<Object>, drmConfig: PKDrmConfigObject): boolean {
+    return !!((drmData.length && drmData[0].scheme === 's3') || drmConfig.keySystem === 's3');
   }
 
   static createAdapter(videoElement: HTMLVideoElement, source: Object, config: Object): IMediaSourceAdapter {

--- a/test/src/engines/html5/media-source/media-source-provider.spec.js
+++ b/test/src/engines/html5/media-source/media-source-provider.spec.js
@@ -112,39 +112,49 @@ describe('mediaSourceProvider:canPlaySource', () => {
   });
 
   it('should can play source with type mimeType1', () => {
-    MediaSourceProvider.canPlaySource({mimetype: 'mimeType1'}).should.be.true;
+    MediaSourceProvider.canPlaySource({mimetype: 'mimeType1'}, true, {}).should.be.true;
     MediaSourceProvider._selectedAdapter.id.should.equal('Adapter1');
   });
 
   it('should can play source with type mimeType1 and drm scheme s1', () => {
-    MediaSourceProvider.canPlaySource({mimetype: 'mimeType1', drmData: [{scheme: 's1'}]}).should.be.true;
+    MediaSourceProvider.canPlaySource({mimetype: 'mimeType1', drmData: [{scheme: 's1'}]}, true, {}).should.be.true;
     MediaSourceProvider._selectedAdapter.id.should.equal('Adapter1');
   });
 
   it('should can play source with type mimeType2', () => {
-    MediaSourceProvider.canPlaySource({mimetype: 'mimeType2'}).should.be.true;
+    MediaSourceProvider.canPlaySource({mimetype: 'mimeType2'}, true, {}).should.be.true;
     MediaSourceProvider._selectedAdapter.id.should.equal('Adapter2');
   });
 
   it('should can play source with type video/mp4', () => {
-    MediaSourceProvider.canPlaySource({mimetype: 'video/mp4'}).should.be.true;
+    MediaSourceProvider.canPlaySource({mimetype: 'video/mp4'}, true, {}).should.be.true;
     MediaSourceProvider._selectedAdapter.id.should.equal('Adapter3');
   });
 
   it('should can play source with type video/mp4 and drm scheme s3', () => {
-    MediaSourceProvider.canPlaySource({mimetype: 'video/mp4', drmData: [{scheme: 's3'}]}).should.be.true;
+    MediaSourceProvider.canPlaySource({mimetype: 'video/mp4', drmData: [{scheme: 's3'}]}, true, {}).should.be.true;
+    MediaSourceProvider._selectedAdapter.id.should.equal('Adapter3');
+  });
+
+  it('should can play source with type mimeType1 and drm scheme s3 by drm config', () => {
+    MediaSourceProvider.canPlaySource({mimetype: 'mimeType1', drmData: [{scheme: 's3'}]}, true, {keySystem: 's1'}).should.be.true;
+    MediaSourceProvider._selectedAdapter.id.should.equal('Adapter1');
+  });
+
+  it('should can play source with type video/mp4 and drm scheme s1 by drm config', () => {
+    MediaSourceProvider.canPlaySource({mimetype: 'video/mp4', drmData: [{scheme: 's1'}]}, true, {keySystem: 's3'}).should.be.true;
     MediaSourceProvider._selectedAdapter.id.should.equal('Adapter3');
   });
 
   it('should cannot play source with valid mime type and not valid drm scheme', () => {
-    MediaSourceProvider.canPlaySource({mimetype: 'mimeType0', drmData: [{scheme: 's4'}]}).should.be.false;
-    MediaSourceProvider.canPlaySource({mimetype: 'mimeType1', drmData: [{scheme: 's4'}]}).should.be.false;
-    MediaSourceProvider.canPlaySource({mimetype: 'mimeType2', drmData: [{scheme: 's4'}]}).should.be.false;
-    MediaSourceProvider.canPlaySource({mimetype: 'video/mp4', drmData: [{scheme: 's4'}]}).should.be.false;
+    MediaSourceProvider.canPlaySource({mimetype: 'mimeType0', drmData: [{scheme: 's4'}]}, true, {}).should.be.false;
+    MediaSourceProvider.canPlaySource({mimetype: 'mimeType1', drmData: [{scheme: 's4'}]}, true, {}).should.be.false;
+    MediaSourceProvider.canPlaySource({mimetype: 'mimeType2', drmData: [{scheme: 's4'}]}, true, {}).should.be.false;
+    MediaSourceProvider.canPlaySource({mimetype: 'video/mp4', drmData: [{scheme: 's4'}]}, true, {}).should.be.false;
   });
 
   it('should cannot play source with unknown mime type', () => {
-    MediaSourceProvider.canPlaySource({mimetype: 'unknownType'}).should.be.false;
+    MediaSourceProvider.canPlaySource({mimetype: 'unknownType'}, true, {}).should.be.false;
   });
 
   it('should cannot play source with no source', () => {


### PR DESCRIPTION
### Description of the Changes

Add `drm.keySystem` config which specify the drm system to run with. 
This config prior to the [browser-drmSystem map](https://github.com/kaltura/playkit-js/blob/2695cb4a848c259e4b448c09bed68011db18ee2a/src/drm/drm-support.js#L8)  

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
