### PR TITLE
fix(FEC-8807): on preload auto, player on chrome throws an error after 30 seconds

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -270,6 +270,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._eventManager.listen(this._videoElement, Html5EventType.ENDED, () => this._clearHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.ABORT, () => this._clearHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.SEEKED, () => this._onSeeked());
+        this._eventManager.listen(this._videoElement, Html5EventType.CAN_PLAY, () => this._clearHeartbeatTimeout());
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();
         }


### PR DESCRIPTION
clean the `heartbeattimeout` when `canplay` is fired
chrome fires one `timeupdate` when `preload=auto.`

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
