### PR TITLE
fix(FEC-8763): add loadMedia life cycle hook for plugins

### DIFF
--- a/flow-typed/interfaces/plugin.js
+++ b/flow-typed/interfaces/plugin.js
@@ -2,6 +2,7 @@
 declare interface IPlugin {
   getConfig(attr?: string): any;
   updateConfig(update: Object): void;
+  loadMedia(): void;
   destroy(): void;
   reset(): void;
 }

--- a/src/player.js
+++ b/src/player.js
@@ -436,6 +436,7 @@ export default class Player extends FakeEventTarget {
       this.reset();
       Player._logger.debug('Change source started');
       this.dispatchEvent(new FakeEvent(CustomEventType.CHANGE_SOURCE_STARTED));
+      this._pluginManager.loadMedia();
       Utils.Object.mergeDeep(this._config, config);
       this._reset = false;
       if (this._selectEngineByPriority()) {

--- a/src/plugin/base-plugin.js
+++ b/src/plugin/base-plugin.js
@@ -112,6 +112,15 @@ export default class BasePlugin implements IPlugin {
   }
 
   /**
+   * Runs the loadMedia logic of the plugin.
+   * plugin must implement this method.
+   * @public
+   * @virtual
+   * @returns {void}
+   */
+  loadMedia(): void {}
+
+  /**
    * Runs the destroy logic of the plugin.
    * plugin must implement this method.
    * @public

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -106,6 +106,15 @@ export default class PluginManager {
   }
 
   /**
+   * Iterates over all the plugins and calls loadMedia().
+   * @public
+   * @returns {void}
+   */
+  loadMedia(): void {
+    Object.keys(this._plugins).forEach(k => this._plugins[k].loadMedia());
+  }
+
+  /**
    * Iterates over all the plugins and calls destroy().
    * @public
    * @returns {void}


### PR DESCRIPTION
### Description of the Changes

plugins life cycle should also have a life cycle method to identify that new media was loaded.
The new life cycle hook will enable returning event listeners or set up internal logic for a new media.  

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
