### PR TITLE
docs(FEC-8751): add support for ima playAdsAfterTime setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -711,9 +711,9 @@ var config = {
 > >
 > > Default -1 refer to automatic start time - 0 to VOD and live edge to live.
 > >
-> > > Note. `startTime` impacts also the ad playback, e.g. `startTime: 10` will skip ads scheduled until 10.
-> > > <br>To force playing ads scheduled before `startTime`, need to configure the ad plugin.
-> > > <br>For example with [IMA](https://github.com/kaltura/playkit-js-ima/blob/master/docs/api.md) plugin set `adsRenderingSettings: {playAdsAfterTime: -1}`.
+> > > Note. `startTime` affects the ad playback, e.g. `startTime: 10` will skip ads scheduled until 10.
+> > > <br>To force playing ads scheduled before `startTime`, need to configure the ads plugin.
+> > > <br>For example with [IMA](https://github.com/kaltura/playkit-js-ima/blob/master/docs/api.md) plugin, set `adsRenderingSettings: {playAdsAfterTime: -1}`.
 >
 > ##
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -710,6 +710,10 @@ var config = {
 > > ##### Description: Optional start time, in seconds, to begin playback.
 > >
 > > Default -1 refer to automatic start time - 0 to VOD and live edge to live.
+> >
+> > > Note. `startTime` impacts also the ad playback, e.g. `startTime: 10` will skip ads scheduled until 10.
+> > > <br>To force playing ads scheduled before `startTime`, need to configure the ad plugin.
+> > > <br>For example with [IMA](https://github.com/kaltura/playkit-js-ima/blob/master/docs/api.md) plugin set `adsRenderingSettings: {playAdsAfterTime: -1}`.
 >
 > ##
 >


### PR DESCRIPTION
### Description of the Changes

Document the `startTime` affect on ads plugin. 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
