### PR TITLE
fix(FEC-8829, FEC-8807): native adapter throws an error after 30 seconds pause

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,7 +57,8 @@ var config = {
     options: {
       html5: {
         hls: {},
-        dash: {}
+        dash: {},
+        native: {}
       }
     },
     preferNative: {

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -186,8 +186,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       adapterConfig.captionsTextTrack1LanguageCode = config.playback.captionsTextTrack1LanguageCode;
       adapterConfig.captionsTextTrack2Label = config.playback.captionsTextTrack2Label;
       adapterConfig.captionsTextTrack2LanguageCode = config.playback.captionsTextTrack2LanguageCode;
-      if (Utils.Object.hasPropertyPath(config.playback, 'options.html5.native.heartbeatTimeout')) {
-        adapterConfig.heartbeatTimeout = config.playback.options.html5.native.heartbeatTimeout;
+      if (Utils.Object.hasPropertyPath(config.playback, 'options.html5.native')) {
+        Utils.Object.mergeDeep(adapterConfig, config.playback.options.html5.native);
       }
     }
     return new this(videoElement, source, adapterConfig);

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -186,6 +186,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       adapterConfig.captionsTextTrack1LanguageCode = config.playback.captionsTextTrack1LanguageCode;
       adapterConfig.captionsTextTrack2Label = config.playback.captionsTextTrack2Label;
       adapterConfig.captionsTextTrack2LanguageCode = config.playback.captionsTextTrack2LanguageCode;
+      if (Utils.Object.hasPropertyPath(config.playback, 'options.html5.native.heartbeatTimeout')) {
+        adapterConfig.heartbeatTimeout = config.playback.options.html5.native.heartbeatTimeout;
+      }
     }
     return new this(videoElement, source, adapterConfig);
   }
@@ -323,7 +326,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   }
 
   _onTimeUpdate(): void {
-    if (this._videoElement.currentTime > this._lastTimeUpdate) {
+    if (!this._videoElement.paused && this._videoElement.currentTime > this._lastTimeUpdate) {
       if (this._waitingEventTriggered) {
         this._waitingEventTriggered = false;
         this._trigger(Html5EventType.PLAYING);

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -28,7 +28,8 @@ const DefaultConfig = {
     options: {
       html5: {
         hls: {},
-        dash: {}
+        dash: {},
+        native: {}
       }
     },
     preferNative: {


### PR DESCRIPTION
### Description of the Changes

In some cases (chrome on `preload=auto`, IE after a pause) an additional `timeupdate` is raised by the video element, which initiates the timeout.

1. added protection so it won't start a timeout if the video element is in a paused state.
2. added the ability to configure the timeout by the application

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
