### PR TITLE
fix(FEC-8865): the captions style change is not applied on iOS

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1121,7 +1121,7 @@ export default class Player extends FakeEventTarget {
     try {
       this._textStyle = style;
       if (this._config.playback.useNativeTextTrack) {
-        sheet.insertRule(`#${this._playerId}video.${ENGINE_CLASS_NAME}::cue { ${style.toCSS()} }`, 0);
+        sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::cue { ${style.toCSS()} }`, 0);
       } else if (this._engine) {
         this._engine.resetAllCues();
         this._externalCaptionsHandler.resetAllCues();


### PR DESCRIPTION
### Description of the Changes

fix the selector of the native text cues

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
