### PR TITLE
fix(FEC-8874): captions look and feel issues

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1645,6 +1645,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _resetTextCuesAndReposition(): void {
+    this._engine.resetAllCues();
     this._updateTextDisplay([]);
     for (let i = 0; i < this._activeTextCues.length; i++) {
       this._activeTextCues[i].hasBeenReset = true;

--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -792,12 +792,7 @@ class BoxPosition {
       case '+y':
         return this.top < container.top;
       case '-y':
-        // IE has too many digits after the decimal point which results in wrong calculation.
-        try{
-          return Number.parseFloat(this.bottom).toFixed(2) > Number.parseFloat(container.bottom).toFixed(2);
-        } catch(e) {
-          return this.bottom > container.bottom;
-        }
+        return this.bottom > container.bottom;
     }
   }
 

--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -792,6 +792,7 @@ class BoxPosition {
       case '+y':
         return this.top < container.top;
       case '-y':
+        // IE has too many digits after the decimal point which results in wrong calculation.
         try{
           return Number.parseFloat(this.bottom).toFixed(2) > Number.parseFloat(container.bottom).toFixed(2);
         } catch(e) {

--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -792,7 +792,11 @@ class BoxPosition {
       case '+y':
         return this.top < container.top;
       case '-y':
-        return this.bottom > container.bottom;
+        try{
+          return Number.parseFloat(this.bottom).toFixed(2) > Number.parseFloat(container.bottom).toFixed(2);
+        } catch(e) {
+          return this.bottom > container.bottom;
+        }
     }
   }
 
@@ -973,7 +977,7 @@ function convertCueToDOMTree(window, cuetext) {
   return parseContent(window, cuetext);
 }
 
-const FONT_SIZE_PERCENT = 0.065;
+const FONT_SIZE_PERCENT = 0.058;
 const FONT_STYLE = 'sans-serif';
 const CUE_BACKGROUND_PADDING = '1.5%';
 

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2860,6 +2860,10 @@ describe('Player', function() {
     it('should reset the active text cues', () => {
       player._activeTextCues[0] = {};
       player._updateTextDisplay = () => {};
+      player._engine = {
+        resetAllCues: function() {},
+        destroy: function() {}
+      };
       player._resetTextCuesAndReposition();
       let cue = player._activeTextCues[0];
       cue.hasBeenReset.should.equals(true);


### PR DESCRIPTION
1. Moving base font percentage to 0.58, so the captions will be smaller, like in our previous versions.
2. Adding `resetAllCues` whenever `resetTextCues` is called. (mainly fix seek back captions issues)


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
