### PR TITLE
feat(FEC-8808): add preload metadata support

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1713,7 +1713,10 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _handlePreload(): void {
-    if (this._config.playback.preload === 'auto' && !this._config.playback.autoplay && this._canPreload()) {
+    if (this._config.playback.preload !== 'none' && !this._config.playback.autoplay && this._canPreload()) {
+      if (this._config.playback.preload === 'metadata') {
+        this._engine.preload = 'metadata';
+      }
       this.load();
     }
   }


### PR DESCRIPTION
### Description of the Changes

currently the player supports `preload: 'auto'` and `preload: 'none'`.
add support in `preload: 'metadata'` via the player configuration.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
