### PR TITLE
fix(FEC-8381): when external caption http request fails, the error message is not clear

### DIFF
--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -281,9 +281,13 @@ class ExternalCaptionsHandler extends FakeEventTarget {
         .then(response => {
           resolve(captionType === SRT_POSTFIX ? this._convertSrtToVtt(response) : response);
         })
-        .catch(error => {
+        .catch(() => {
           this._textTrackModel[textTrack.language].cuesStatus = CuesStatus.NOT_DOWNLOADED;
-          reject(new Error(Error.Severity.RECOVERABLE, Error.Category.TEXT, Error.Code.HTTP_ERROR, error.payload));
+          reject(
+            new Error(Error.Severity.RECOVERABLE, Error.Category.TEXT, Error.Code.HTTP_ERROR, {
+              url: track.url
+            })
+          );
         });
     });
   }


### PR DESCRIPTION
### Description of the Changes

adding the URL to the HTTP error when fetching a VTT/SRT file

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
