### PR TITLE
fix(FEC-8931): when using disableMediaPreload=true, .ts segments are still fired during bumper

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1724,14 +1724,11 @@ export default class Player extends FakeEventTarget {
    * If ads plugin enabled it's his responsibility to preload the content player.
    * So to avoid loading the player twice which can cause errors on MSEs we are not
    * calling load from the player.
-   * TODO: Change it to check the ads configuration when we will develop the ads manager.
    * @returns {boolean} - Whether the player can perform preload.
    * @private
    */
   _canPreload(): boolean {
-    return (
-      !this._config.plugins || ((this._config.plugins && !this._config.plugins.ima) || (this._config.plugins.ima && this._config.plugins.ima.disable))
-    );
+    return !this._adsController;
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Do not handle pre load if any ad plugin exists

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
