### PR TITLE
fix(FEC-8957): cannot pause/resume the ad after change media on iOS

### DIFF
--- a/src/utils/resize-watcher.js
+++ b/src/utils/resize-watcher.js
@@ -32,6 +32,9 @@ class ResizeWatcher extends FakeEventTarget {
    * @returns {void}
    */
   init(el: HTMLElement): void {
+    if (this._observer) {
+      return;
+    }
     this._el = el;
     window.ResizeObserver ? this._createNativeObserver() : this._createIframeObserver();
     if (this._el instanceof HTMLElement && this._observer) {


### PR DESCRIPTION
The issue was because the new iFrame was on top of the ads container and blocked it.

Initializing the resizeObserver only once, no need to initialize it on every reset (as long it's the same video element).

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
