### PR TITLE
fix(FEC-8826): pass html element from api and there isn't check for ios in isfullscreen method

### DIFF
--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -40,8 +40,16 @@ class FullscreenController {
    * @returns {boolean} - the current fullscreen state of the document
    */
   _isNativeFullscreen(): boolean {
-    // $FlowFixMe
-    return !!(document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement || document.msFullscreenElement);
+    //for ios mobile checking video element
+    const videoElement: ?HTMLVideoElement = typeof this._player.getVideoElement === 'function' ? this._player.getVideoElement() : null;
+    return !!(
+      document.fullscreenElement ||
+      document.webkitFullscreenElement ||
+      document.mozFullScreenElement ||
+      document.msFullscreenElement ||
+      // $FlowFixMe for ios mobile
+      (!!videoElement && !!videoElement.webkitDisplayingFullscreen)
+    );
   }
 
   /**
@@ -60,13 +68,16 @@ class FullscreenController {
   /**
    * if mobile detected, get the video element and request fullscreen.
    * otherwise, request fullscreen to the parent player view than includes the GUI as well
-   * @param {?HTMLElement} element - element to enter fullscreen
+   * @param {?string} elementId - element to enter fullscreen
    * @memberof FullScreenController
    * @returns {void}
    */
-  enterFullscreen(element: ?HTMLElement): void {
+  enterFullscreen(elementId: ?string): void {
     if (!this.isFullscreen()) {
-      const fullScreenElement = element ? element : this._player.getView();
+      let fullScreenElement = elementId && Utils.Dom.getElementById(elementId);
+      if (!fullScreenElement) {
+        fullScreenElement = this._player.getView();
+      }
       if (this._player.env.os.name === 'iOS') {
         if (this._inBrowserFullscreenConfig) {
           this._enterInBrowserFullscreen(fullScreenElement);

--- a/src/player.js
+++ b/src/player.js
@@ -1192,11 +1192,11 @@ export default class Player extends FakeEventTarget {
   /**
    * Request the player to enter fullscreen.
    * @public
-   * @param {HTMLElement} fullScreenElement - set html element to full screen
+   * @param {string} elementId - element id to full screen
    * @returns {void}
    */
-  enterFullscreen(fullScreenElement: ?HTMLElement): void {
-    this._fullscreenController.enterFullscreen(fullScreenElement);
+  enterFullscreen(elementId: ?string): void {
+    this._fullscreenController.enterFullscreen(elementId);
   }
 
   /**

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1193,7 +1193,6 @@ describe('Player', function() {
 
     beforeEach(() => {
       player = new Player();
-      player._engine = {destroy: function() {}};
     });
 
     afterEach(() => {


### PR DESCRIPTION
### Description of the Changes

Change html element to id and add check for ios fullscreen (#353)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
