### PR TITLE
fix(FEC-9037): When entering/exiting fullscreen, the events are sent twice

### DIFF
--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -20,6 +20,7 @@ class FullscreenController {
   _inBrowserFullscreenConfig: boolean;
   _playsinlineConfig: boolean;
   _isInBrowserFullscreen: boolean;
+  _isEnterFullscreenEventFired: boolean;
 
   /**
    * after component mounted, set up event listeners to window fullscreen state change
@@ -33,6 +34,8 @@ class FullscreenController {
     this._playsinlineConfig = this._player.config.playback.playsinline;
     //flag to cover the option that inBrowserFullscreen selected and we should know if it's full screen
     this._isInBrowserFullscreen = false;
+    //added to avoid duplicate dispatch event
+    this._isEnterFullscreenEventFired = false;
     this.registerFullScreenEvents();
   }
 
@@ -242,8 +245,9 @@ class FullscreenController {
    * @returns {void}
    */
   _fullscreenEnterHandler(): void {
-    if (this.isFullscreen()) {
+    if (this.isFullscreen() && !this._isEnterFullscreenEventFired) {
       this._player.dispatchEvent(new FakeEvent(this._player.Event.ENTER_FULLSCREEN));
+      this._isEnterFullscreenEventFired = true;
     }
   }
 
@@ -253,8 +257,9 @@ class FullscreenController {
    * @returns {void}
    */
   _fullscreenExitHandler(): void {
-    if (!this.isFullscreen()) {
+    if (!this.isFullscreen() && this._isEnterFullscreenEventFired) {
       this._player.dispatchEvent(new FakeEvent(this._player.Event.EXIT_FULLSCREEN));
+      this._isEnterFullscreenEventFired = false;
     }
   }
 }


### PR DESCRIPTION

### Description of the Changes

shaka creates a new fullscreen event and dispatch it, add fullscreen flag to avoid from player to dispatch twice

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
