### PR TITLE
FEC-9012 - We dont read mediaType VOD configuration

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -948,7 +948,10 @@ export default class Player extends FakeEventTarget {
    * @public
    */
   isLive(): boolean {
-    return !!(this._config.sources.type === MediaType.LIVE || (this._engine && this._engine.isLive()));
+    return !!(
+      this._config.sources.type !== MediaType.VOD &&
+      (this._config.sources.type === MediaType.LIVE || (this._engine && this._engine.isLive()))
+    );
   }
 
   /**


### PR DESCRIPTION
When we get in the configuration that mediatype is vod and the asset is live we return that the player is in live state - the actual result here should be that the player will load in VOD mode and not in Live mode (UI)

The change was to add a check that isLive in the player will return false if explicitly set as type VOD
