### PR TITLE
fix(FEC-9075): dai - resume ad from toolbar doesn't work

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -371,8 +371,11 @@ const _Dom = {
    * @returns {void}
    */
   removeChild(parent: ?Node, child: ?Element): void {
-    if (parent && child && parent.removeChild) {
+    try {
+      // $FlowFixMe
       parent.removeChild(child);
+    } catch (e) {
+      return;
     }
   },
   /**


### PR DESCRIPTION
### Description of the Changes

Catch when trying to remove child from non-parnet node

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
