### PR TITLE
fix(FEC-9084): Add duration to source change event

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -445,7 +445,12 @@ export default class Player extends FakeEventTarget {
       Utils.Object.mergeDeep(this._config, config);
       this._reset = false;
       if (this._selectEngineByPriority()) {
-        this.dispatchEvent(new FakeEvent(CustomEventType.SOURCE_SELECTED, {selectedSource: this._config.sources[this._streamType]}));
+        this.dispatchEvent(
+          new FakeEvent(CustomEventType.SOURCE_SELECTED, {
+            selectedSource: this._config.sources[this._streamType],
+            duration: this._config.sources.duration
+          })
+        );
         this._attachMedia();
         this._handlePlaybackOptions();
         this._posterManager.setSrc(this._config.sources.poster);


### PR DESCRIPTION
### Description of the Changes

Add duration to source change event for saving duration in case we playing ads on the same player

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
