### PR TITLE
fix(FEC-9041): 'HTMLVideoElement.webkitDisplayingFullscreen' deprecation warning

### DIFF
--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -53,7 +53,7 @@ class FullscreenController {
       document.mozFullScreenElement ||
       document.msFullscreenElement ||
       // $FlowFixMe for ios mobile
-      (!!videoElement && !!videoElement.webkitDisplayingFullscreen)
+      (this._player.env.os.name === 'iOS' && !!videoElement && !!videoElement.webkitDisplayingFullscreen)
     );
   }
 


### PR DESCRIPTION
### Description of the Changes

[Deprecation] 'HTMLVideoElement.webkitDisplayingFullscreen' is deprecated. relevant only for ios devices

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
