### PR TITLE
fix(FEC-9177): Smart TV showed as mobile device

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,10 +1,11 @@
 // @flow
 import UAParser from 'ua-parser-js';
 
-const LGDeviceRegex = [[/^.*(web0s).*(smarttv).*$/i], [[UAParser.DEVICE.VENDOR, 'LG'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]]];
-const LGOSRegex = [[/^.*(web0s).*(smarttv).*$/i], [UAParser.OS.NAME]];
+const LGTVRegex = /^.*(web0s).*(smarttv).*$/i;
+const LGDeviceParser = [[LGTVRegex], [[UAParser.DEVICE.VENDOR, 'LG'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]]];
+const LGOSParser = [[LGTVRegex], [UAParser.OS.NAME]];
 
-let Env = new UAParser(undefined, {device: LGDeviceRegex, os: LGOSRegex}).getResult();
+let Env = new UAParser(undefined, {device: LGDeviceParser, os: LGOSParser}).getResult();
 
 Env.isSmartTV = Env.device.type === UAParser.DEVICE.SMARTTV;
 Env.isMobile = Env.device.type === UAParser.DEVICE.MOBILE;

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,4 +1,15 @@
 // @flow
 import UAParser from 'ua-parser-js';
-const Env = new UAParser().getResult();
+
+const LGDeviceRegex = [[/^.*(web0s).*(smarttv).*$/i], [[UAParser.DEVICE.VENDOR, 'LG'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]]];
+const LGOSRegex = [[/^.*(web0s).*(smarttv).*$/i], [UAParser.OS.NAME]];
+
+let Env = new UAParser(undefined, {device: LGDeviceRegex, os: LGOSRegex}).getResult();
+
+Env.isSmartTV = Env.device.type === UAParser.DEVICE.SMARTTV;
+Env.isMobile = Env.device.type === UAParser.DEVICE.MOBILE;
+Env.isTablet = Env.device.type === UAParser.DEVICE.TABLET;
+Env.isWearable = Env.device.type === UAParser.DEVICE.WEARABLE;
+Env.isEmbedded = Env.device.type === UAParser.DEVICE.EMBEDDED;
+
 export default Env;

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -7,6 +7,7 @@ const LGOSParser = [[LGTVRegex], [UAParser.OS.NAME]];
 
 let Env = new UAParser(undefined, {device: LGDeviceParser, os: LGOSParser}).getResult();
 
+Env.isConsole = Env.device.type === UAParser.DEVICE.CONSOLE;
 Env.isSmartTV = Env.device.type === UAParser.DEVICE.SMARTTV;
 Env.isMobile = Env.device.type === UAParser.DEVICE.MOBILE;
 Env.isTablet = Env.device.type === UAParser.DEVICE.TABLET;


### PR DESCRIPTION
### Description of the Changes

Use UAParser enum for device type and add check for webos smart tv as extend of this lib.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
