### PR TITLE
fix(FEC-9187): LG TV different  behavior for LIVE

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -337,6 +337,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           this._trigger(Html5EventType.PLAYING);
         }
         this._resetHeartbeatTimeout();
+      } else if (this._videoElement.currentTime < this._lastTimeUpdate) {
+        this._syncCurrentTime();
       } else {
         this._waitingEventTriggered = true;
         this._trigger(Html5EventType.WAITING);


### PR DESCRIPTION
### Description of the Changes

LG have static duration and they are jumping back when in safari they are changing the duration.
LG jumping 15 sec back on the first 15 available and 10 sec after so this._lastTimeUpdate will never be lower than this._videoElement.currentTime after first time.
whenever they are equal only we would like to fire waiting event because we are actually weren't moved.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
