### PR TITLE
fix(FEC-9192): post bumper doesn't play

### DIFF
--- a/flow-typed/interfaces/ads-plugin-controller.js
+++ b/flow-typed/interfaces/ads-plugin-controller.js
@@ -6,4 +6,5 @@ declare interface IAdsPluginController {
   onPlaybackEnded(): Promise<void>;
   +active: boolean;
   +done: boolean;
+  +name: string;
 }

--- a/src/ads/ads-controller.js
+++ b/src/ads/ads-controller.js
@@ -165,7 +165,7 @@ class AdsController extends FakeEventTarget implements IAdsController {
     if (!this._adBreaksLayout.includes(-1)) {
       this._allAdsCompleted = true;
     } else {
-      const isBumper = controller => controller.constructor.name === 'BumperAdsController';
+      const isBumper = controller => controller.name === 'bumper';
       const bumperCtrl = this._adsPluginControllers.find(controller => isBumper(controller));
       const adCtrl = this._adsPluginControllers.find(controller => !isBumper(controller));
       const bumperCompletePromise = bumperCtrl ? bumperCtrl.onPlaybackEnded() : Promise.resolve();


### PR DESCRIPTION
### Description of the Changes

`IAdsPluginController` exposes `name` to filter bumper controller
(`controller.constructor.name` doesn't work in transpiled files)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
