### PR TITLE
fix(FEC-9261): playback doesn't play with non-linear ads

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -646,10 +646,11 @@ export default class Player extends FakeEventTarget {
   /**
    * detach the engine's media source
    * @private
+   * @param {FakeEvent} event - loaded event
    * @returns {void}
    */
-  _detachMediaSource(): void {
-    if (this._engine) {
+  _detachMediaSource(event: FakeEvent): void {
+    if (this._engine && event.payload.ad.linear) {
       //added for case when decorator exist
       this._engine.detachMediaSource(this._engine.ended);
     }

--- a/src/player.js
+++ b/src/player.js
@@ -646,11 +646,10 @@ export default class Player extends FakeEventTarget {
   /**
    * detach the engine's media source
    * @private
-   * @param {FakeEvent} event - loaded event
    * @returns {void}
    */
-  _detachMediaSource(event: FakeEvent): void {
-    if (this._engine && event.payload.ad.linear) {
+  _detachMediaSource(): void {
+    if (this._engine) {
       //added for case when decorator exist
       this._engine.detachMediaSource(this._engine.ended);
     }
@@ -1679,7 +1678,11 @@ export default class Player extends FakeEventTarget {
         });
       }
       if (this.config.playback.playAdsWithMSE) {
-        this._eventManager.listen(this, AdEventType.AD_LOADED, this._detachMediaSource);
+        this._eventManager.listen(this, AdEventType.AD_LOADED, event => {
+          if (event.payload.ad.linear) {
+            this._detachMediaSource();
+          }
+        });
         this._eventManager.listen(this, AdEventType.AD_BREAK_END, this._attachMediaSource);
         this._eventManager.listen(this, AdEventType.AD_ERROR, this._attachMediaSource);
       }


### PR DESCRIPTION
### Description of the Changes

add check for non linear ads for attachMediaSource/detachMediaSource, shouldn't use attachMediaSource/detachMediaSource with non-linear ads

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
