### PR TITLE
fix(FEC-9262): playback doesn't return to start after playback with ads in LG TV

### DIFF
--- a/flow-typed/interfaces/engine-decorator.js
+++ b/flow-typed/interfaces/engine-decorator.js
@@ -29,8 +29,8 @@ declare interface IEngineDecorator {
   +exitPictureInPicture?: () => void;
   +isPictureInPictureSupported?: () => boolean;
   +resetAllCues?: () => void;
-  +attachMediaSource?: (playbackEnded: ?boolean) => void;
-  +detachMediaSource?: (playbackEnded: ?boolean) => void;
+  +attachMediaSource?: () => void;
+  +detachMediaSource?: (playbackEnded: boolean) => void;
   +id?: string;
   src?: string;
   currentTime?: number;

--- a/flow-typed/interfaces/engine-decorator.js
+++ b/flow-typed/interfaces/engine-decorator.js
@@ -30,7 +30,7 @@ declare interface IEngineDecorator {
   +isPictureInPictureSupported?: () => boolean;
   +resetAllCues?: () => void;
   +attachMediaSource?: () => void;
-  +detachMediaSource?: (playbackEnded: boolean) => void;
+  +detachMediaSource?: () => void;
   +id?: string;
   src?: string;
   currentTime?: number;

--- a/flow-typed/interfaces/engine.js
+++ b/flow-typed/interfaces/engine.js
@@ -33,8 +33,8 @@ declare interface IEngine {
   isLive(): boolean;
   getVideoElement(): HTMLVideoElement;
   resetAllCues(): void;
-  attachMediaSource(playbackEnded: ?boolean): void;
-  detachMediaSource(playbackEnded: ?boolean): void;
+  attachMediaSource(): void;
+  detachMediaSource(playbackEnded: boolean): void;
   +id: string;
   currentTime: number;
   +duration: number;

--- a/flow-typed/interfaces/engine.js
+++ b/flow-typed/interfaces/engine.js
@@ -34,7 +34,7 @@ declare interface IEngine {
   getVideoElement(): HTMLVideoElement;
   resetAllCues(): void;
   attachMediaSource(): void;
-  detachMediaSource(playbackEnded: boolean): void;
+  detachMediaSource(): void;
   +id: string;
   currentTime: number;
   +duration: number;

--- a/flow-typed/interfaces/media-source-adapter.js
+++ b/flow-typed/interfaces/media-source-adapter.js
@@ -21,7 +21,7 @@ declare interface IMediaSourceAdapter {
   isLive(): boolean;
   getStartTimeOfDvrWindow(): number;
   setMaxBitrate(bitrate: number): void;
-  attachMediaSource(playbackEnded: boolean): void;
+  attachMediaSource(): void;
   detachMediaSource(): void;
   +targetBuffer: number;
   static +id: string;

--- a/flow-typed/interfaces/media-source-adapter.js
+++ b/flow-typed/interfaces/media-source-adapter.js
@@ -21,8 +21,8 @@ declare interface IMediaSourceAdapter {
   isLive(): boolean;
   getStartTimeOfDvrWindow(): number;
   setMaxBitrate(bitrate: number): void;
-  attachMediaSource(playbackEnded: ?boolean): void;
-  detachMediaSource(playbackEnded: ?boolean): void;
+  attachMediaSource(playbackEnded: boolean): void;
+  detachMediaSource(): void;
   +targetBuffer: number;
   static +id: string;
   static isSupported(): boolean;

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -46,12 +46,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   _config: Object;
   /**
-   * The player ended
-   * @type {boolean}
-   * @private
-   */
-  _playbackEndedOnDetach: boolean = false;
-  /**
    * Promise to indicate when a media source adapter can be loaded.
    * @type {Promise<*>}
    * @private
@@ -205,7 +199,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @returns {void}
    */
   reset(): void {
-    this._playbackEndedOnDetach = false;
     this._eventManager.removeAll();
     if (this._mediaSourceAdapter) {
       this._canLoadMediaSourceAdapterPromise = this._mediaSourceAdapter.destroy();
@@ -253,18 +246,16 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   attachMediaSource(): void {
     if (this._mediaSourceAdapter) {
-      this._mediaSourceAdapter.attachMediaSource(this._playbackEndedOnDetach);
+      this._mediaSourceAdapter.attachMediaSource();
     }
   }
   /**
    * detach media - will remove the media source from handling the video
    * @public
-   * @param {boolean} playbackEnded playback ended after ads and media
    * @returns {void}
    */
-  detachMediaSource(playbackEnded: boolean): void {
+  detachMediaSource(): void {
     if (this._mediaSourceAdapter) {
-      this._playbackEndedOnDetach = playbackEnded;
       this._mediaSourceAdapter.detachMediaSource();
     }
   }

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -256,8 +256,12 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       //added to mask problematic behavior in shaka - init fire loadstart event, only for last init to avoid spinner
       this._mediaSourceAdapter.attachMediaSource(this._playbackEndedOnDetach);
       if (this._playbackEndedOnDetach) {
-        this._eventManager.listen(this._el, Html5EventType.LOAD_START, () => {
-          this.dispatchEvent(new FakeEvent(Html5EventType.LOAD_START));
+        this._eventManager.unlisten(this._el, Html5EventType.LOAD_START);
+        this._eventManager.listenOnce(this._el, Html5EventType.LOAD_START, () => {
+          this._eventManager.listen(this._el, Html5EventType.LOAD_START, () => {
+            Html5._logger.debug('Html5EventType.LOAD_START');
+            this.dispatchEvent(new FakeEvent(Html5EventType.LOAD_START));
+          });
         });
       }
     }
@@ -271,10 +275,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   detachMediaSource(playbackEnded: boolean): void {
     if (this._mediaSourceAdapter) {
       this._playbackEndedOnDetach = playbackEnded;
-      //added to mask problematic behavior in shaka - init fire loadstart event, only for last init to avoid spinner
-      if (this._playbackEndedOnDetach) {
-        this._eventManager.unlisten(this._el, Html5EventType.LOAD_START);
-      }
       this._mediaSourceAdapter.detachMediaSource();
     }
   }

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -205,6 +205,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @returns {void}
    */
   reset(): void {
+    this._playbackEndedOnDetach = false;
     this._eventManager.removeAll();
     if (this._mediaSourceAdapter) {
       this._canLoadMediaSourceAdapterPromise = this._mediaSourceAdapter.destroy();

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -253,17 +253,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   attachMediaSource(): void {
     if (this._mediaSourceAdapter) {
-      //added to mask problematic behavior in shaka - init fire loadstart event, only for last init to avoid spinner
       this._mediaSourceAdapter.attachMediaSource(this._playbackEndedOnDetach);
-      if (this._playbackEndedOnDetach) {
-        this._eventManager.unlisten(this._el, Html5EventType.LOAD_START);
-        this._eventManager.listenOnce(this._el, Html5EventType.LOAD_START, () => {
-          this._eventManager.listen(this._el, Html5EventType.LOAD_START, () => {
-            Html5._logger.debug('Html5EventType.LOAD_START');
-            this.dispatchEvent(new FakeEvent(Html5EventType.LOAD_START));
-          });
-        });
-      }
     }
   }
   /**

--- a/src/engines/html5/media-source/base-media-source-adapter.js
+++ b/src/engines/html5/media-source/base-media-source-adapter.js
@@ -166,8 +166,8 @@ export default class BaseMediaSourceAdapter extends FakeEventTarget implements I
     return;
   }
 
-  attachMediaSource(playbackEnded: ?boolean): void {}
-  detachMediaSource(playbackEnded: ?boolean): void {}
+  attachMediaSource(): void {}
+  detachMediaSource(): void {}
   /**
    * Handling live time update (as is not triggered when video is paused, but the current time changed)
    * @function _handleLiveTimeUpdate

--- a/src/player.js
+++ b/src/player.js
@@ -633,8 +633,7 @@ export default class Player extends FakeEventTarget {
    */
   _attachMediaSource(): void {
     if (this._engine) {
-      //added for case when decorator exist
-      this._engine.attachMediaSource(this._engine.ended);
+      this._engine.attachMediaSource();
       this._eventManager.listenOnce(this, Html5EventType.CAN_PLAY, () => {
         if (typeof this._playbackAttributesState.rate === 'number') {
           this.playbackRate = this._playbackAttributesState.rate;

--- a/src/player.js
+++ b/src/player.js
@@ -649,8 +649,7 @@ export default class Player extends FakeEventTarget {
    */
   _detachMediaSource(): void {
     if (this._engine) {
-      //added for case when decorator exist
-      this._engine.detachMediaSource(this._engine.ended);
+      this._engine.detachMediaSource();
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

Add support for replay after ads finish to return to beginning. 
fix bug engine.ended on `attachMediaSource` will not give always true on the end of the media as expected, instead on `detachMediaSource` which will return true when ad playing and decorator is active or when decorator is not active engine will return true from video element.
keeps the value form `detachMediaSource` to know in `attachMediaSource` if media ended.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
