### PR TITLE
fix(FEC-9277): inBrowserFullscreen doesn't work on ios

### DIFF
--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -17,8 +17,6 @@ const IN_BROWSER_FULLSCREEN_FOR_IOS: string = 'playkit-in-browser-fullscreen-mod
  */
 class FullscreenController {
   _player: Player;
-  _inBrowserFullscreenConfig: boolean;
-  _playsinlineConfig: boolean;
   _isInBrowserFullscreen: boolean;
   _isEnterFullscreenEventFired: boolean;
 
@@ -30,8 +28,6 @@ class FullscreenController {
    */
   constructor(player: Player): void {
     this._player = player;
-    this._inBrowserFullscreenConfig = this._player.config.playback.inBrowserFullscreen;
-    this._playsinlineConfig = this._player.config.playback.playsinline;
     //flag to cover the option that inBrowserFullscreen selected and we should know if it's full screen
     this._isInBrowserFullscreen = false;
     //added to avoid duplicate dispatch event
@@ -84,7 +80,7 @@ class FullscreenController {
         fullScreenElement = this._player.getView();
       }
       if (this._player.env.os.name === 'iOS') {
-        if (this._inBrowserFullscreenConfig && this._playsinlineConfig) {
+        if (this._player.config.playback.inBrowserFullscreen && this._player.config.playback.playsinline) {
           this._enterInBrowserFullscreen(fullScreenElement);
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();
@@ -108,7 +104,7 @@ class FullscreenController {
     if (this.isFullscreen()) {
       if (this._player.env.os.name === 'iOS') {
         // player will be in full screen with this flag or otherwise will be natively full screen
-        if (this._inBrowserFullscreenConfig && this._playsinlineConfig) {
+        if (this._isInBrowserFullscreen) {
           this._exitInBrowserFullscreen();
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -9,7 +9,7 @@ import * as Utils from '../utils/util';
  * @type {string}
  * @const
  */
-const IN_BROWSER_FULLSCREEN_FOR_IOS: string = 'playkit-in-browser-fullscreen-mode';
+const IN_BROWSER_FULLSCREEN: string = 'playkit-in-browser-fullscreen-mode';
 
 /**
  * @class FullscreenController
@@ -76,11 +76,12 @@ class FullscreenController {
   enterFullscreen(elementId: ?string): void {
     if (!this.isFullscreen()) {
       let fullScreenElement = elementId && Utils.Dom.getElementById(elementId);
+      const playbackConfig = this._player.config.playback;
       if (!fullScreenElement) {
         fullScreenElement = this._player.getView();
       }
       if (this._player.env.os.name === 'iOS') {
-        if (this._player.config.playback.inBrowserFullscreen && this._player.config.playback.playsinline) {
+        if (playbackConfig.inBrowserFullscreen && playbackConfig.playsinline) {
           this._enterInBrowserFullscreen(fullScreenElement);
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();
@@ -165,7 +166,7 @@ class FullscreenController {
    */
   _enterInBrowserFullscreen(fullScreenElement: HTMLElement): void {
     // add class for fullscreen
-    Utils.Dom.addClassName(fullScreenElement, IN_BROWSER_FULLSCREEN_FOR_IOS);
+    Utils.Dom.addClassName(fullScreenElement, IN_BROWSER_FULLSCREEN);
     this._isInBrowserFullscreen = true;
     this._fullscreenEnterHandler();
     this._player.dispatchEvent(new FakeEvent(this._player.Event.RESIZE));
@@ -178,9 +179,9 @@ class FullscreenController {
    */
   _exitInBrowserFullscreen(): void {
     //get the element with relevant css, otherwise keep the flow of exit manually
-    const fullScreenElement = Utils.Dom.getElementBySelector('.' + IN_BROWSER_FULLSCREEN_FOR_IOS);
+    const fullScreenElement = Utils.Dom.getElementBySelector('.' + IN_BROWSER_FULLSCREEN);
     if (fullScreenElement) {
-      Utils.Dom.removeClassName(fullScreenElement, IN_BROWSER_FULLSCREEN_FOR_IOS);
+      Utils.Dom.removeClassName(fullScreenElement, IN_BROWSER_FULLSCREEN);
     }
     this._isInBrowserFullscreen = false;
     this._fullscreenExitHandler();

--- a/test/src/fullscreen/fullscreen-controller.spec.js
+++ b/test/src/fullscreen/fullscreen-controller.spec.js
@@ -66,7 +66,7 @@ describe('check inBrowserFullscreen config', function() {
     player.isFullscreen().should.be.true;
   });
 
-  it('should fullscreen change mode correctly', () => {
+  it('should change fullscreen mode correctly', () => {
     player.configure({
       playback: {
         inBrowserFullscreen: false,

--- a/test/src/fullscreen/fullscreen-controller.spec.js
+++ b/test/src/fullscreen/fullscreen-controller.spec.js
@@ -1,0 +1,87 @@
+import {createElement, removeElement} from '../utils/test-utils';
+import Player from '../../../src/player';
+import {Object as PKObject} from '../../../src/utils/util';
+import SourcesConfig from '../configs/sources';
+import {EngineProvider} from '../../../src/engines/engine-provider';
+import Html5 from '../../../src/engines/html5/html5';
+
+const targetId = 'player-placeholder_inBrowserFullscreen.spec';
+const sourcesConfig = PKObject.copyDeep(SourcesConfig);
+
+describe('check inBrowserFullscreen config', function() {
+  let config, player, playerContainer, sandbox;
+
+  before(() => {
+    EngineProvider.destroy();
+    EngineProvider.register(Html5.id, Html5);
+    playerContainer = createElement('DIV', targetId);
+    config = {
+      playback: {
+        inBrowserFullscreen: true,
+        playsinline: true
+      }
+    };
+    config.sources = sourcesConfig.Mp4;
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    player = new Player(config);
+    playerContainer.appendChild(player.getView());
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    player.destroy();
+  });
+
+  after(() => {
+    removeElement(targetId);
+  });
+
+  it('should ios fullscreen switch correctly between native and inBrowserFullscreen config', () => {
+    sandbox.stub(player._fullscreenController, '_isNativeFullscreen', () => {
+      return false;
+    });
+    player.env.os.name = 'iOS';
+    player.enterFullscreen();
+    player.isFullscreen().should.be.true;
+    player._fullscreenController._isInBrowserFullscreen.should.be.true;
+    player.configure({
+      playback: {
+        inBrowserFullscreen: false,
+        playsinline: false
+      }
+    });
+    player.isFullscreen().should.be.true;
+    player.enterFullscreen();
+    player.isFullscreen().should.be.true;
+    player.exitFullscreen();
+    player.isFullscreen().should.be.false;
+    player.enterFullscreen();
+    sandbox.restore();
+    sandbox.stub(player._fullscreenController, '_isNativeFullscreen', () => {
+      return true;
+    });
+    player.isFullscreen().should.be.true;
+  });
+
+  it('should fullscreen change mode correctly', () => {
+    player.configure({
+      playback: {
+        inBrowserFullscreen: false,
+        playsinline: false
+      }
+    });
+    sandbox.stub(player._fullscreenController, '_isNativeFullscreen', () => {
+      return true;
+    });
+    player.enterFullscreen();
+    player.isFullscreen().should.be.true;
+    sandbox.restore();
+    sandbox.stub(player._fullscreenController, '_isNativeFullscreen', () => {
+      return false;
+    });
+    player.isFullscreen().should.be.false;
+  });
+});

--- a/test/src/fullscreen/fullscreen-controller.spec.js
+++ b/test/src/fullscreen/fullscreen-controller.spec.js
@@ -39,7 +39,7 @@ describe('check inBrowserFullscreen config', function() {
     removeElement(targetId);
   });
 
-  it('should ios fullscreen switch correctly between native and inBrowserFullscreen config', () => {
+  it('should switch correctly to fullscreen in iOS between native and inBrowserFullscreen config', () => {
     sandbox.stub(player._fullscreenController, '_isNativeFullscreen', () => {
       return false;
     });


### PR DESCRIPTION
### Description of the Changes

**Problem**: config doesn't changed yet on controller.
**Solution**: remove config from controller state to keep the configuration up to date from player.
`exitFullscreen` will check the state of non native fullscreen mode instead checking the config, `enterFullscreen` will check the config for fullscreen mode

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
