### PR TITLE
fix(FEC-9283): trigger RESIZE events in Firefox

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -61,8 +61,8 @@
   width: 100%;
   height: 100%;
   position: absolute;
-  visibility: hidden;
-  z-index: -1;
+  border: 0;
+  z-index: -100;
 }
 
 .playkit-in-browser-fullscreen-mode {


### PR DESCRIPTION
### Description of the Changes
When a user resize browser / element a resize event is used to relayout everything. As this is a bug in the player, the mentioned functionality and any other that rely on resize will not work.
Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
