### PR TITLE
fix(FEC-9291): player without engine get error after reset

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -583,7 +583,9 @@ export default class Player extends FakeEventTarget {
     this._resetStateFlags();
     this._engineType = '';
     this._streamType = '';
-    this._engine.reset();
+    if (this._engine) {
+      this._engine.reset();
+    }
     this._showBlackCover();
     this._reset = true;
     this.dispatchEvent(new FakeEvent(CustomEventType.PLAYER_RESET));


### PR DESCRIPTION
### Description of the Changes

add check for engine existence
This may happen when trying to load a media for first time where player doesn’t have an engine for it.
We init the reset flag and then when another loadMedia is called or just calling rest method the reset flag is set and we will go into reset calling the engine reset method although engine is not set.
We already have this protection in destroy for calling engine so this was required in reset as well.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
