### PR TITLE
fix: browser detection for samsung

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -5,7 +5,13 @@ const LGTVRegex = /^.*(web0s).*(smarttv).*$/i;
 const LGDeviceParser = [[LGTVRegex], [[UAParser.DEVICE.VENDOR, 'LG'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]]];
 const LGOSParser = [[LGTVRegex], [UAParser.OS.NAME]];
 
-let Env = new UAParser(undefined, {device: LGDeviceParser, os: LGOSParser}).getResult();
+const SAMSUNGTVRegex = /^.*(smart-tv).*(tizen).*$/i;
+const SAMSUNGBrowserParser = [
+  [SAMSUNGTVRegex],
+  [[UAParser.BROWSER.NAME, 'SAMSUNG_TV_BROWSER'], [UAParser.BROWSER.MAJOR, ''], [UAParser.BROWSER.VERSION, '']]
+];
+
+let Env = new UAParser(undefined, {browser: SAMSUNGBrowserParser, device: LGDeviceParser, os: LGOSParser}).getResult();
 
 Env.isConsole = Env.device.type === UAParser.DEVICE.CONSOLE;
 Env.isSmartTV = Env.device.type === UAParser.DEVICE.SMARTTV;

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -2,16 +2,25 @@
 import UAParser from 'ua-parser-js';
 
 const LGTVRegex = /^.*(web0s).*(smarttv).*$/i;
-const LGDeviceParser = [[LGTVRegex], [[UAParser.DEVICE.VENDOR, 'LG'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]]];
+//doesn't recognize lg at all
 const LGOSParser = [[LGTVRegex], [UAParser.OS.NAME]];
 
 const SAMSUNGTVRegex = /^.*(smart-tv).*(tizen).*$/i;
+//recognize as safari
 const SAMSUNGBrowserParser = [
   [SAMSUNGTVRegex],
   [[UAParser.BROWSER.NAME, 'SAMSUNG_TV_BROWSER'], [UAParser.BROWSER.MAJOR, ''], [UAParser.BROWSER.VERSION, '']]
 ];
 
-let Env = new UAParser(undefined, {browser: SAMSUNGBrowserParser, device: LGDeviceParser, os: LGOSParser}).getResult();
+//add smart tv as smart tv devices
+const DeviceParser = [
+  [LGTVRegex],
+  [[UAParser.DEVICE.VENDOR, 'LG'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]],
+  [SAMSUNGTVRegex],
+  [[UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]]
+];
+
+let Env = new UAParser(undefined, {browser: SAMSUNGBrowserParser, device: DeviceParser, os: LGOSParser}).getResult();
 
 Env.isConsole = Env.device.type === UAParser.DEVICE.CONSOLE;
 Env.isSmartTV = Env.device.type === UAParser.DEVICE.SMARTTV;


### PR DESCRIPTION
### Description of the Changes

fix fake safari for Samsung TV browser detection.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
