### PR TITLE
fix(FEC-8821): css fullscreen doesn't work with youtube iframe

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -21,6 +21,10 @@
   object-fit: contain;
 }
 
+.playkit-in-browser-fullscreen-mode .playkit-engine-youtube {
+  object-fit: fill;
+}
+
 .playkit-engine video::-webkit-media-controls-panel,
 .playkit-engine video::-webkit-media-controls-panel-container,
 .playkit-engine video::-webkit-media-controls-start-playback-button,


### PR DESCRIPTION
### Description of the Changes

object-fit: contain doesn't work as excepted on IOS iframe

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
