### PR TITLE
fix: plugin exception handling

### DIFF
--- a/src/error/code.js
+++ b/src/error/code.js
@@ -534,6 +534,10 @@ const Code: CodeType = {
    * An error occurred while trying to exit picture in picture mode, more info in the data
    */
   EXIT_PICTURE_IN_PICTURE_FAILED: 7009,
+  /**
+   * An error occurred while trying to init a plugin. The plugin not initialized.
+   */
+  NOT_INITIALIZED_PLUGIN: 7010,
 
   /**
    * The Cast API is unavailable.  This may be because of one of the following:

--- a/src/error/code.js
+++ b/src/error/code.js
@@ -537,7 +537,7 @@ const Code: CodeType = {
   /**
    * An error occurred while trying to init a plugin. The plugin not initialized.
    */
-  NOT_INITIALIZED_PLUGIN: 7010,
+  PLUGIN_LOAD_FAILED: 7010,
 
   /**
    * The Cast API is unavailable.  This may be because of one of the following:

--- a/src/player.js
+++ b/src/player.js
@@ -1514,7 +1514,12 @@ export default class Player extends FakeEventTarget {
               this._pluginManager.load(name, this, plugins[name]);
             } catch (e) {
               //bounce the plugin load error up
-              this.dispatchEvent(e);
+              this.dispatchEvent(
+                new FakeEvent(
+                  Html5EventType.ERROR,
+                  new PKError(PKError.Severity.RECOVERABLE, PKError.Category.PLAYER, PKError.Code.RUNTIME_ERROR_NOT_REGISTERED_PLUGIN, e)
+                )
+              );
             }
             let plugin = this._pluginManager.get(name);
             if (plugin) {

--- a/src/player.js
+++ b/src/player.js
@@ -1512,14 +1512,9 @@ export default class Player extends FakeEventTarget {
           if (!this._engine) {
             try {
               this._pluginManager.load(name, this, plugins[name]);
-            } catch (e) {
+            } catch (error) {
               //bounce the plugin load error up
-              this.dispatchEvent(
-                new FakeEvent(
-                  Html5EventType.ERROR,
-                  new PKError(PKError.Severity.RECOVERABLE, PKError.Category.PLAYER, PKError.Code.RUNTIME_ERROR_NOT_REGISTERED_PLUGIN, e)
-                )
-              );
+              this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
             }
             let plugin = this._pluginManager.get(name);
             if (plugin) {

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -1,6 +1,5 @@
 //@flow
 import BasePlugin from './base-plugin';
-import Error from '../error/error';
 import Player from '../player';
 import getLogger from '../utils/logger';
 

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -86,8 +86,7 @@ export default class PluginManager {
    */
   load(name: string, player: Player, config: Object = {}): boolean {
     if (!PluginManager._registry.has(name)) {
-      logger.warn(`Plugin <${name}> loading failed, plugin is not registered`);
-      throw new Error(Error.Severity.RECOVERABLE, Error.Category.PLAYER, Error.Code.RUNTIME_ERROR_NOT_REGISTERED_PLUGIN, name);
+      throw `Plugin <${name}> loading failed, plugin is not registered`;
     }
     let pluginClass = PluginManager._registry.get(name);
     if (typeof config.disable === 'boolean') {

--- a/src/plugin/plugin-manager.js
+++ b/src/plugin/plugin-manager.js
@@ -99,7 +99,7 @@ export default class PluginManager {
       try {
         this._plugins[name] = pluginClass.createPlugin(name, player, config);
       } catch (e) {
-        throw new Error(Error.Severity.RECOVERABLE, Error.Category.PLAYER, Error.Code.NOT_INITIALIZED_PLUGIN, e);
+        throw new Error(Error.Severity.RECOVERABLE, Error.Category.PLAYER, Error.Code.PLUGIN_LOAD_FAILED, e);
       }
       this._isDisabledPluginMap.set(name, false);
       logger.debug(`Plugin <${name}> has been loaded`);


### PR DESCRIPTION
### Description of the Changes

**Issues:**

1. An unhandled exception from plugin not handled
2. The plugin manager throws loading error instead of dispatching error event 

**Solution:**
dispatching an error event from the player for both unhandled exception and loading error

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
