### PR TITLE
fix(FEC-9313): weird behaviour IOS when configuration autoplay native 

### DIFF
--- a/flow-typed/interfaces/engine-capabilty.js
+++ b/flow-typed/interfaces/engine-capabilty.js
@@ -2,6 +2,6 @@
 declare type CapabilityResult = {[capabilityName: string]: any};
 
 declare interface ICapability {
-  static runCapability(playsinline:boolean): void;
-  static getCapability(playsinline:boolean): Promise<CapabilityResult>;
+  static runCapability(playsinline:?boolean): void;
+  static getCapability(playsinline:?boolean): Promise<CapabilityResult>;
 }

--- a/flow-typed/interfaces/engine-capabilty.js
+++ b/flow-typed/interfaces/engine-capabilty.js
@@ -2,6 +2,6 @@
 declare type CapabilityResult = {[capabilityName: string]: any};
 
 declare interface ICapability {
-  static runCapability(): void;
-  static getCapability(): Promise<CapabilityResult>;
+  static runCapability(playsinline:boolean): void;
+  static getCapability(playsinline:boolean): Promise<CapabilityResult>;
 }

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -14,16 +14,16 @@ export default class Html5AutoPlayCapability implements ICapability {
   /**
    * Runs the test for autoplay capability.
    * @public
+   * @param {boolean} playsinline - content playsinline
    * @static
    * @returns {void}
    */
-  static runCapability(): void {
+  static runCapability(playsinline: boolean): void {
     if (!Html5AutoPlayCapability._vid) {
       Html5AutoPlayCapability._vid = Utils.Dom.createElement('video');
       Html5AutoPlayCapability._vid.src = EncodingSources.Base64Mp4Source;
-      // For iOS devices needs to turn the playsinline attribute on
-      Html5AutoPlayCapability._vid.setAttribute('playsinline', '');
     }
+    Html5AutoPlayCapability._setPlaysinline(playsinline);
     Html5AutoPlayCapability._playPromiseResult = new Promise(resolve => {
       Html5AutoPlayCapability._setMuted(false);
       Html5AutoPlayCapability._getPlayPromise()
@@ -40,14 +40,15 @@ export default class Html5AutoPlayCapability implements ICapability {
   /**
    * Gets the test result for autoplay capability.
    * @returns {Promise<CapabilityResult>} - The result object for autoplay capability.
+   * @param {boolean} playsinline - content playsinline
    * @static
    * @public
    */
-  static getCapability(): Promise<CapabilityResult> {
+  static getCapability(playsinline: boolean): Promise<CapabilityResult> {
     return Html5AutoPlayCapability._playPromiseResult.then(res => {
       // If autoplay is not allowed - try again and return the updated result
       if (!res.autoplay) {
-        Html5AutoPlayCapability.runCapability();
+        Html5AutoPlayCapability.runCapability(playsinline);
         return Html5AutoPlayCapability._playPromiseResult;
       }
       return res;
@@ -77,6 +78,21 @@ export default class Html5AutoPlayCapability implements ICapability {
     } else {
       Html5AutoPlayCapability._vid.muted = false;
       Html5AutoPlayCapability._vid.removeAttribute('muted');
+    }
+  }
+
+  /**
+   * Sets the test video element playsinline value.
+   * @param {boolean} playsinline - The playsinline value.
+   * @private
+   * @returns {void}
+   * @static
+   */
+  static _setPlaysinline(playsinline: boolean): void {
+    if (playsinline) {
+      Html5AutoPlayCapability._vid.setAttribute('playsinline', '');
+    } else {
+      Html5AutoPlayCapability._vid.removeAttribute('playsinline');
     }
   }
 

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -14,11 +14,11 @@ export default class Html5AutoPlayCapability implements ICapability {
   /**
    * Runs the test for autoplay capability.
    * @public
-   * @param {boolean} playsinline - content playsinline
+   * @param {?boolean} playsinline - content playsinline
    * @static
    * @returns {void}
    */
-  static runCapability(playsinline: boolean): void {
+  static runCapability(playsinline: ?boolean): void {
     if (!Html5AutoPlayCapability._vid) {
       Html5AutoPlayCapability._vid = Utils.Dom.createElement('video');
       Html5AutoPlayCapability._vid.src = EncodingSources.Base64Mp4Source;
@@ -40,11 +40,11 @@ export default class Html5AutoPlayCapability implements ICapability {
   /**
    * Gets the test result for autoplay capability.
    * @returns {Promise<CapabilityResult>} - The result object for autoplay capability.
-   * @param {boolean} playsinline - content playsinline
+   * @param {?boolean} playsinline - content playsinline
    * @static
    * @public
    */
-  static getCapability(playsinline: boolean): Promise<CapabilityResult> {
+  static getCapability(playsinline: ?boolean): Promise<CapabilityResult> {
     return Html5AutoPlayCapability._playPromiseResult.then(res => {
       // If autoplay is not allowed - try again and return the updated result
       if (!res.autoplay) {
@@ -83,12 +83,12 @@ export default class Html5AutoPlayCapability implements ICapability {
 
   /**
    * Sets the test video element playsinline value.
-   * @param {boolean} playsinline - The playsinline value.
+   * @param {?boolean} playsinline - The playsinline value.
    * @private
    * @returns {void}
    * @static
    */
-  static _setPlaysinline(playsinline: boolean): void {
+  static _setPlaysinline(playsinline: ?boolean): void {
     if (playsinline) {
       Html5AutoPlayCapability._vid.setAttribute('playsinline', '');
     } else {

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -133,12 +133,12 @@ export default class Html5 extends FakeEventTarget implements IEngine {
 
   /**
    * Gets the html5 capabilities.
-   * @param {boolean} playsinline - content playsinline
+   * @param {?boolean} playsinline - content playsinline
    * @return {Promise<Object>} - The html5 capabilities object.
    * @public
    * @static
    */
-  static getCapabilities(playsinline: boolean): Promise<Object> {
+  static getCapabilities(playsinline: ?boolean): Promise<Object> {
     let promises = [];
     Html5._capabilities.forEach(capability => promises.push(capability.getCapability(playsinline)));
     return Promise.all(promises).then(arrayOfResults => {

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -122,23 +122,25 @@ export default class Html5 extends FakeEventTarget implements IEngine {
 
   /**
    * Runs the html5 capabilities tests.
+   * @param {boolean} playsinline - content playsinline
    * @returns {void}
    * @public
    * @static
    */
-  static runCapabilities(): void {
-    Html5._capabilities.forEach(capability => capability.runCapability());
+  static runCapabilities(playsinline: boolean): void {
+    Html5._capabilities.forEach(capability => capability.runCapability(playsinline));
   }
 
   /**
    * Gets the html5 capabilities.
+   * @param {boolean} playsinline - content playsinline
    * @return {Promise<Object>} - The html5 capabilities object.
    * @public
    * @static
    */
-  static getCapabilities(): Promise<Object> {
+  static getCapabilities(playsinline: boolean): Promise<Object> {
     let promises = [];
-    Html5._capabilities.forEach(capability => promises.push(capability.getCapability()));
+    Html5._capabilities.forEach(capability => promises.push(capability.getCapability(playsinline)));
     return Promise.all(promises).then(arrayOfResults => {
       const mergedResults = {};
       arrayOfResults.forEach(res => Object.assign(mergedResults, res));

--- a/src/player.js
+++ b/src/player.js
@@ -133,12 +133,12 @@ export default class Player extends FakeEventTarget {
 
   /**
    * Runs the engines capabilities tests.
-   * @param {boolean} playsinline - content playsinline
+   * @param {?boolean} playsinline - content playsinline
    * @returns {void}
    * @public
    * @static
    */
-  static runCapabilities(playsinline: boolean): void {
+  static runCapabilities(playsinline: ?boolean): void {
     Player._logger.debug('Running player capabilities');
     EngineProvider.getEngines().forEach(Engine => Engine.runCapabilities(playsinline));
   }
@@ -146,12 +146,12 @@ export default class Player extends FakeEventTarget {
   /**
    * Gets the engines capabilities.
    * @param {?string} engineType - The engine type.
-   * @param {boolean} playsinline - content playsinline
+   * @param {?boolean} playsinline - content playsinline
    * @return {Promise<Object>} - The engines capabilities object.
    * @public
    * @static
    */
-  static getCapabilities(engineType: ?string, playsinline: boolean): Promise<{[name: string]: any}> {
+  static getCapabilities(engineType: ?string, playsinline: ?boolean): Promise<{[name: string]: any}> {
     Player._logger.debug('Get player capabilities', engineType);
     const promises = [];
     EngineProvider.getEngines().forEach(Engine => promises.push(Engine.getCapabilities(playsinline)));

--- a/src/player.js
+++ b/src/player.js
@@ -409,7 +409,8 @@ export default class Player extends FakeEventTarget {
     this._setConfigLogLevel(config);
     this._playerId = Utils.Generator.uniqueId(5);
     this._prepareVideoElement();
-    Player.runCapabilities(config.playback.playsinline);
+    const playsInline = Utils.Object.getPropertyPath(config, 'playback.playsinline');
+    Player.runCapabilities(playsInline);
     this._env = Env;
     this._tracks = [];
     this._uiComponents = [];
@@ -1831,8 +1832,7 @@ export default class Player extends FakeEventTarget {
   _handleAutoPlay(): void {
     if (this._config.playback.autoplay === true) {
       const allowMutedAutoPlay = this._config.playback.allowMutedAutoPlay;
-      const playsinline = this._config.playback.playsinline;
-      Player.getCapabilities(this.engineType, playsinline).then(capabilities => {
+      Player.getCapabilities(this.engineType, this.playsinline).then(capabilities => {
         if (capabilities.autoplay) {
           onAutoPlay();
         } else {

--- a/src/player.js
+++ b/src/player.js
@@ -133,26 +133,28 @@ export default class Player extends FakeEventTarget {
 
   /**
    * Runs the engines capabilities tests.
+   * @param {boolean} playsinline - content playsinline
    * @returns {void}
    * @public
    * @static
    */
-  static runCapabilities(): void {
+  static runCapabilities(playsinline: boolean): void {
     Player._logger.debug('Running player capabilities');
-    EngineProvider.getEngines().forEach(Engine => Engine.runCapabilities());
+    EngineProvider.getEngines().forEach(Engine => Engine.runCapabilities(playsinline));
   }
 
   /**
    * Gets the engines capabilities.
    * @param {?string} engineType - The engine type.
+   * @param {boolean} playsinline - content playsinline
    * @return {Promise<Object>} - The engines capabilities object.
    * @public
    * @static
    */
-  static getCapabilities(engineType: ?string): Promise<{[name: string]: any}> {
+  static getCapabilities(engineType: ?string, playsinline: boolean): Promise<{[name: string]: any}> {
     Player._logger.debug('Get player capabilities', engineType);
     const promises = [];
-    EngineProvider.getEngines().forEach(Engine => promises.push(Engine.getCapabilities()));
+    EngineProvider.getEngines().forEach(Engine => promises.push(Engine.getCapabilities(playsinline)));
     return Promise.all(promises).then(arrayOfResults => {
       const playerCapabilities = {};
       arrayOfResults.forEach(res => Object.assign(playerCapabilities, res));
@@ -407,7 +409,7 @@ export default class Player extends FakeEventTarget {
     this._setConfigLogLevel(config);
     this._playerId = Utils.Generator.uniqueId(5);
     this._prepareVideoElement();
-    Player.runCapabilities();
+    Player.runCapabilities(config.playback.playsinline);
     this._env = Env;
     this._tracks = [];
     this._uiComponents = [];
@@ -1829,7 +1831,8 @@ export default class Player extends FakeEventTarget {
   _handleAutoPlay(): void {
     if (this._config.playback.autoplay === true) {
       const allowMutedAutoPlay = this._config.playback.allowMutedAutoPlay;
-      Player.getCapabilities(this.engineType).then(capabilities => {
+      const playsinline = this._config.playback.playsinline;
+      Player.getCapabilities(this.engineType, playsinline).then(capabilities => {
         if (capabilities.autoplay) {
           onAutoPlay();
         } else {


### PR DESCRIPTION
### Description of the Changes

`playsinline` false on IOS can't play automatically medias and audio instead fix the weird behaviour.
ACT:IOS try to start playing instead return false from capability check
EXP: won't try to start playing when it's not possible.
SOL: add `playsinline` config to autoplay capability check instead set false.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
