### PR TITLE
fix(FEC-9333): when playing a playlist and closing the countdown window, the next entry starts automatically

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1602,7 +1602,8 @@ export default class Player extends FakeEventTarget {
       this._appendEngineEl();
     } else {
       if (this._engine.id === Engine.id) {
-        this._engine.restore(source, this._config);
+        // The restoring must be done by the engine itself not by the proxy (engine decorator is exists) to make sure the engine events fired by the engine itself.
+        this._engine.restore.call(this._engine._engine || this._engine, source, this._config);
       } else {
         this._engine.destroy();
         this._createEngine(Engine, source);

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -103,6 +103,10 @@ export default class StateManager {
       [Html5EventType.ENDED]: () => {
         this._updateState(StateType.IDLE);
         this._dispatchEvent();
+      },
+      [CustomEventType.PLAYBACK_ENDED]: () => {
+        this._updateState(StateType.IDLE);
+        this._dispatchEvent();
       }
     },
     [StateType.PLAYING]: {
@@ -116,6 +120,10 @@ export default class StateManager {
         this._dispatchEvent();
       },
       [Html5EventType.ENDED]: () => {
+        this._updateState(StateType.IDLE);
+        this._dispatchEvent();
+      },
+      [CustomEventType.PLAYBACK_ENDED]: () => {
         this._updateState(StateType.IDLE);
         this._dispatchEvent();
       },
@@ -179,6 +187,7 @@ export default class StateManager {
     this._eventManager.listen(this._player, Html5EventType.WAITING, this._doTransition.bind(this));
     this._eventManager.listen(this._player, Html5EventType.SEEKED, this._doTransition.bind(this));
     this._eventManager.listen(this._player, Html5EventType.TIME_UPDATE, this._doTransition.bind(this));
+    this._eventManager.listen(this._player, CustomEventType.PLAYBACK_ENDED, this._doTransition.bind(this));
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

* move to `idle` when the postroll (dai) is done
* make sure the engine events fired by the engine itself not by the proxy

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
