### PR TITLE
Set aria-live attribute to 'assertive' for playkit-subtitles element

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1482,6 +1482,7 @@ export default class Player extends FakeEventTarget {
   _appendDomElements(): void {
     // Append playkit-subtitles
     this._textDisplayEl = Utils.Dom.createElement('div');
+    Utils.Dom.setAttribute(this._textDisplayEl, 'aria-live', 'assertive');
     Utils.Dom.addClassName(this._textDisplayEl, SUBTITLES_CLASS_NAME);
     Utils.Dom.appendChild(this._el, this._textDisplayEl);
     // Append playkit-black-cover


### PR DESCRIPTION
After this screen readers will read the subtitles then they are updated.

### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
