### PR TITLE
fix(FEC-9434): the first frame of content flashes for a second before the ad playback.

### DIFF
--- a/src/ads/ads-controller.js
+++ b/src/ads/ads-controller.js
@@ -191,7 +191,6 @@ class AdsController extends FakeEventTarget implements IAdsController {
 
   _onAdBreakStart(event: FakeEvent): void {
     this._adBreak = event.payload.adBreak;
-    this.dispatchEvent(event);
   }
 
   _onAdLoaded(event: FakeEvent): void {

--- a/src/player.js
+++ b/src/player.js
@@ -1691,14 +1691,12 @@ export default class Player extends FakeEventTarget {
         this._onTextTrackChanged(event)
       );
       this._eventManager.listen(this._externalCaptionsHandler, Html5EventType.ERROR, (event: FakeEvent) => this.dispatchEvent(event));
-      if (this._adsController) {
-        this._eventManager.listen(this, AdEventType.AD_STARTED, () => {
-          if (this._firstPlay) {
-            this._posterManager.hide();
-            this._hideBlackCover();
-          }
-        });
-      }
+      this._eventManager.listen(this, AdEventType.AD_STARTED, () => {
+        if (this._firstPlay) {
+          this._posterManager.hide();
+          this._hideBlackCover();
+        }
+      });
       if (this.config.playback.playAdsWithMSE) {
         this._eventManager.listen(this, AdEventType.AD_LOADED, event => {
           if (event.payload.ad.linear) {

--- a/src/player.js
+++ b/src/player.js
@@ -1692,7 +1692,7 @@ export default class Player extends FakeEventTarget {
       );
       this._eventManager.listen(this._externalCaptionsHandler, Html5EventType.ERROR, (event: FakeEvent) => this.dispatchEvent(event));
       if (this._adsController) {
-        this._eventManager.listen(this._adsController, AdEventType.AD_BREAK_START, () => {
+        this._eventManager.listen(this, AdEventType.AD_STARTED, () => {
           if (this._firstPlay) {
             this._posterManager.hide();
             this._hideBlackCover();


### PR DESCRIPTION
### Description of the Changes
**Issue:** Comes from https://github.com/kaltura/playkit-js/pull/324/files#diff-29cfd888e32c875acb1a2dd113e516dbR1628
**Solution:** Hide the poster only on `AD_STARTED`

Solves [FEC-9434](https://kaltura.atlassian.net/browse/FEC-9434)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
