### PR TITLE
fix(FEC-9420): PIP button is showed but not working

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -548,7 +548,8 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     if (typeof this._el.webkitSupportsPresentationMode === 'function') {
       return this._el.webkitSupportsPresentationMode('picture-in-picture');
     } else {
-      return document.pictureInPictureEnabled ? !!document.pictureInPictureEnabled : false;
+      // $FlowFixMe
+      return !!document.pictureInPictureEnabled;
     }
   }
 

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -543,10 +543,13 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @return {boolean} if the engine is in picture in picture mode or not
    */
   isPictureInPictureSupported(): boolean {
-    return (
-      !!document.pictureInPictureEnabled ||
-      (typeof this._el.webkitSupportsPresentationMode === 'function' && this._el.webkitSupportsPresentationMode('picture-in-picture'))
-    );
+    // due to a bug in shaka pip_webkit which sets pictureInPictureEnabled to true in unsupported devices like iphones we will
+    // first rely on the response of webkitSupportsPresentationMode (if exists) and only if not on the pictureInPictureEnabled property
+    if (typeof this._el.webkitSupportsPresentationMode === 'function') {
+      return this._el.webkitSupportsPresentationMode('picture-in-picture');
+    } else {
+      return document.pictureInPictureEnabled ? !!document.pictureInPictureEnabled : false;
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes
Due to a bug in shaka pip_webkit which sets pictureInPictureEnabled to true in unsupported devices like iphones we will first rely on the response of webkitSupportsPresentationMode (if exists) and only if not on the pictureInPictureEnabled property
The fix has been tested on Android Chrome, Mac Chrome and Safari, XCode iphone and ipad simulator
### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
