### PR TITLE
fix(FEC-9493): new ad layout - dragging to the end causes the midroll to play with replay button

### DIFF
--- a/src/ads/ads-controller.js
+++ b/src/ads/ads-controller.js
@@ -175,9 +175,10 @@ class AdsController extends FakeEventTarget implements IAdsController {
   }
 
   _playAdBreak(adBreak: PKAdBreakObject): void {
-    adBreak.played = true;
     const adController = this._adsPluginControllers.find(controller => !this._isBumper(controller));
     if (adController) {
+      adBreak.played = true;
+      this._adBreak = adBreak;
       adController.playAdNow(adBreak.ads);
     } else {
       AdsController._logger.warn('No ads plugin registered');
@@ -208,6 +209,7 @@ class AdsController extends FakeEventTarget implements IAdsController {
   }
 
   _onAdsCompleted(): void {
+    this._adBreak = null;
     if (this._adsPluginControllers.every(controller => controller.done) && this._configAdBreaks.every(adBreak => adBreak.played)) {
       this._allAdsCompleted = true;
       AdsController._logger.debug(AdEventType.ALL_ADS_COMPLETED);
@@ -234,6 +236,9 @@ class AdsController extends FakeEventTarget implements IAdsController {
   }
 
   _onEnded(): void {
+    if (this.isAdBreak()) {
+      return;
+    }
     if (!this._adBreaksLayout.includes(-1)) {
       this._allAdsCompleted = true;
     } else {


### PR DESCRIPTION
### Description of the Changes

Do not run the ended flow while ad is loading

(This is for the new ad layout. The same issue with ima vmap fixed by https://github.com/kaltura/playkit-js-ui/pull/454)

Solves [FEC-9493](https://kaltura.atlassian.net/browse/FEC-9493)
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
