### PR TITLE
fix(FEC-9510): auto play failed in ios

### DIFF
--- a/flow-typed/interfaces/engine.js
+++ b/flow-typed/interfaces/engine.js
@@ -5,7 +5,7 @@ import TextTrack from '../../src/track/text-track';
 
 declare interface IEngine {
   static id: string;
-  static createEngine(source: PKMediaSourceObject, config: Object): IEngine;
+  static createEngine(source: PKMediaSourceObject, config: Object, playerId: string): IEngine;
   static canPlaySource(source: PKMediaSourceObject, preferNative: boolean, drmConfig: PKDrmConfigObject): boolean;
   static runCapabilities(): void;
   static getCapabilities(): Promise<Object>;

--- a/src/player.js
+++ b/src/player.js
@@ -1636,7 +1636,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _createEngine(Engine: typeof IEngine, source: PKMediaSourceObject): void {
-    const engine = Engine.createEngine(source, this._config);
+    const engine = Engine.createEngine(source, this._config, this._playerId);
     const plugins = (Object.values(this._pluginManager.getAll()): any);
     this._engine = EngineDecorator.getDecorator(engine, plugins) || engine;
   }


### PR DESCRIPTION
### Description of the Changes

pass the player id to the engine creation to use the already prepared one (was missing in mistake)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
