### PR TITLE
fix(FEC-9527): The poster is hidden when auto play is failed

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1676,6 +1676,7 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEventType.PLAY_FAILED, (event: FakeEvent) => {
         this.pause();
         if (this._firstPlay && this._config.playback.autoplay) {
+          this._posterManager.show();
           this.dispatchEvent(new FakeEvent(CustomEventType.AUTOPLAY_FAILED, event.payload));
         }
         this.dispatchEvent(event);

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1367,7 +1367,7 @@ describe('Player', function() {
         removeElement(targetId);
       });
 
-      it('should fire first play only once', done => {
+      it('should fire auto play failed and show the poster', done => {
         player.addEventListener(CustomEventType.AUTOPLAY_FAILED, () => {
           player._posterManager._el.style.display.should.equal('');
           done();

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1343,6 +1343,53 @@ describe('Player', function() {
       });
     });
 
+    describe('auto play failed', function() {
+      let config;
+      let player;
+      let playerContainer;
+
+      before(() => {
+        playerContainer = createElement('DIV', targetId);
+      });
+
+      beforeEach(() => {
+        config = getConfigStructure();
+        player = new Player(config);
+        playerContainer.appendChild(player.getView());
+      });
+
+      afterEach(() => {
+        player.destroy();
+      });
+
+      after(() => {
+        removeVideoElementsFromTestPage();
+        removeElement(targetId);
+      });
+
+      it('should fire first play only once', done => {
+        player.addEventListener(CustomEventType.AUTOPLAY_FAILED, () => {
+          player._posterManager._el.style.display.should.equal('');
+          done();
+        });
+        player.configure({
+          playback: {
+            autoplay: true
+          },
+          sources: {
+            poster: '//cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042/height/360/width/640',
+            progressive: [
+              {
+                mimetype: 'video/mp4',
+                url: 'bad/url',
+                id: '1_rsrdfext_10081,url'
+              }
+            ]
+          }
+        });
+      });
+    });
+
     describe('source selected', () => {
       let config;
       let player;


### PR DESCRIPTION
### Description of the Changes

Show the poster once `AUTOPLAY_FAILED`

Solves [FEC-9527](https://kaltura.atlassian.net/browse/FEC-9527)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
