### PR TITLE
fix(FEC-9513): bumper - endless spinner when auto play is failed

### DIFF
--- a/flow-typed/interfaces/engine.js
+++ b/flow-typed/interfaces/engine.js
@@ -15,7 +15,7 @@ declare interface IEngine {
   destroy(): void;
   attach(): void;
   detach(): void;
-  play(): void;
+  play(): ?Promise<*>;
   pause(): void;
   load(startTime: ?number): Promise<Object>;
   reset(): void;

--- a/src/ads/ad-event-type.js
+++ b/src/ads/ad-event-type.js
@@ -99,7 +99,7 @@ const AdEventType: PKEventTypes = {
   /**
    * Fires when browser fails to autoplay an ad.
    */
-  AD_AUTO_PLAY_FAILED: 'adautoplayfailed'
+  AD_AUTOPLAY_FAILED: 'adautoplayfailed'
 };
 
 export {AdEventType};

--- a/src/ads/ad-event-type.js
+++ b/src/ads/ad-event-type.js
@@ -97,9 +97,9 @@ const AdEventType: PKEventTypes = {
    */
   AD_WATERFALLING_FAILED: 'adwaterfallingfailed',
   /**
-   * Fires when browser fails to play an ad.
+   * Fires when browser fails to autoplay an ad.
    */
-  AD_PLAY_FAILED: 'adplayfailed'
+  AD_AUTO_PLAY_FAILED: 'adautoplayfailed'
 };
 
 export {AdEventType};

--- a/src/ads/ad-event-type.js
+++ b/src/ads/ad-event-type.js
@@ -95,7 +95,11 @@ const AdEventType: PKEventTypes = {
   /**
    * Fired when an ad waterfalling failed
    */
-  AD_WATERFALLING_FAILED: 'adwaterfallingfailed'
+  AD_WATERFALLING_FAILED: 'adwaterfallingfailed',
+  /**
+   * Fires when browser fails to play an ad.
+   */
+  AD_PLAY_FAILED: 'adplayfailed'
 };
 
 export {AdEventType};

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -429,13 +429,14 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   /**
    * Start/resume playback.
    * @public
-   * @returns {void}
+   * @returns {?Promise<*>} - play promise
    */
-  play(): void {
+  play(): ?Promise<*> {
     let playPromise = this._el.play();
     if (playPromise) {
       playPromise.catch(err => this.dispatchEvent(new FakeEvent(CustomEventType.PLAY_FAILED, {error: err})));
     }
+    return playPromise;
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -1678,7 +1678,7 @@ export default class Player extends FakeEventTarget {
         this._onPlayFailed(event);
         this.dispatchEvent(event);
       });
-      this._eventManager.listen(this, AdEventType.AD_PLAY_FAILED, (event: FakeEvent) => this._onPlayFailed(event));
+      this._eventManager.listen(this, AdEventType.AD_AUTO_PLAY_FAILED, (event: FakeEvent) => this._onPlayFailed(event));
       this._eventManager.listen(this._engine, CustomEventType.FPS_DROP, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.FRAG_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.MANIFEST_LOADED, (event: FakeEvent) => this.dispatchEvent(event));

--- a/src/player.js
+++ b/src/player.js
@@ -1675,12 +1675,10 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEventType.TIMED_METADATA, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.PLAY_FAILED, (event: FakeEvent) => {
         this.pause();
-        if (this._firstPlay && this._config.playback.autoplay) {
-          this._posterManager.show();
-          this.dispatchEvent(new FakeEvent(CustomEventType.AUTOPLAY_FAILED, event.payload));
-        }
+        this._onPlayFailed(event);
         this.dispatchEvent(event);
       });
+      this._eventManager.listen(this, AdEventType.AD_PLAY_FAILED, (event: FakeEvent) => this._onPlayFailed(event));
       this._eventManager.listen(this._engine, CustomEventType.FPS_DROP, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.FRAG_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.MANIFEST_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
@@ -2018,6 +2016,19 @@ export default class Player extends FakeEventTarget {
     if (!this._firstPlaying) {
       this._firstPlaying = true;
       this.dispatchEvent(new FakeEvent(CustomEventType.FIRST_PLAYING));
+    }
+  }
+
+  /**
+   * @function _onPlayFailed
+   * @param {FakeEvent} event - the play failed event
+   * @return {void}
+   * @private
+   */
+  _onPlayFailed(event: FakeEvent): void {
+    if (this._firstPlay && this._config.playback.autoplay) {
+      this._posterManager.show();
+      this.dispatchEvent(new FakeEvent(CustomEventType.AUTOPLAY_FAILED, event.payload));
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -1709,7 +1709,7 @@ export default class Player extends FakeEventTarget {
         this._onPlayFailed(event);
         this.dispatchEvent(event);
       });
-      this._eventManager.listen(this, AdEventType.AD_AUTO_PLAY_FAILED, (event: FakeEvent) => this._onPlayFailed(event));
+      this._eventManager.listen(this, AdEventType.AD_AUTOPLAY_FAILED, (event: FakeEvent) => this._onPlayFailed(event));
       this._eventManager.listen(this._engine, CustomEventType.FPS_DROP, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.FRAG_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.MANIFEST_LOADED, (event: FakeEvent) => this.dispatchEvent(event));

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1357,14 +1357,14 @@ describe('Player', function() {
 
       beforeEach(() => {
         sandbox = sinon.sandbox.create();
-        config = getConfigStructure();
-        config.sources = sourcesConfig.Mp4;
-        player = new Player(config);
-        player.configure({
+        config = PKObject.mergeDeep(getConfigStructure(), {
+          sources: sourcesConfig.Mp4,
           playback: {
             autoplay: true
           }
         });
+        config.sources = sourcesConfig.Mp4;
+        player = new Player(config);
         playerContainer.appendChild(player.getView());
       });
 
@@ -1391,7 +1391,6 @@ describe('Player', function() {
         sandbox.stub(player._engine._el, 'play').callsFake(function() {
           return Promise.reject('mock failure');
         });
-        player.play();
       });
 
       it('should fire auto play failed and show the poster once get AD_PLAY_FAILED', done => {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1393,7 +1393,7 @@ describe('Player', function() {
         });
       });
 
-      it('should fire auto play failed and show the poster once get AD_AUTO_PLAY_FAILED', done => {
+      it('should fire auto play failed and show the poster once get AD_AUTOPLAY_FAILED', done => {
         player.addEventListener(CustomEventType.AUTOPLAY_FAILED, error => {
           try {
             player._posterManager._el.style.display.should.equal('');
@@ -1403,7 +1403,7 @@ describe('Player', function() {
             done(e);
           }
         });
-        player.dispatchEvent(new FakeEvent(AdEventType.AD_AUTO_PLAY_FAILED, {error: 'mock failure'}));
+        player.dispatchEvent(new FakeEvent(AdEventType.AD_AUTOPLAY_FAILED, {error: 'mock failure'}));
       });
     });
 

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1379,10 +1379,10 @@ describe('Player', function() {
       });
 
       it('should fire auto play failed and show the poster once get PLAY_FAILED', done => {
-        player.addEventListener(CustomEventType.AUTOPLAY_FAILED, error => {
+        player.addEventListener(CustomEventType.AUTOPLAY_FAILED, event => {
           try {
             player._posterManager._el.style.display.should.equal('');
-            error.payload.error.should.equal('mock failure');
+            event.payload.error.should.equal('mock failure');
             done();
           } catch (e) {
             done(e);
@@ -1394,10 +1394,10 @@ describe('Player', function() {
       });
 
       it('should fire auto play failed and show the poster once get AD_AUTOPLAY_FAILED', done => {
-        player.addEventListener(CustomEventType.AUTOPLAY_FAILED, error => {
+        player.addEventListener(CustomEventType.AUTOPLAY_FAILED, event => {
           try {
             player._posterManager._el.style.display.should.equal('');
-            error.payload.error.should.equal('mock failure');
+            event.payload.error.should.equal('mock failure');
             done();
           } catch (e) {
             done(e);

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -17,6 +17,8 @@ import Error from '../../src/error/error';
 import {Object as PKObject} from '../../src/utils/util';
 import {LabelOptions} from '../../src/track/label-options';
 import {EngineProvider} from '../../src/engines/engine-provider';
+import {AdEventType} from '../../src/ads/ad-event-type';
+import FakeEvent from '../../src/event/fake-event';
 
 const targetId = 'player-placeholder_player.spec';
 let sourcesConfig = PKObject.copyDeep(SourcesConfig);
@@ -1347,19 +1349,28 @@ describe('Player', function() {
       let config;
       let player;
       let playerContainer;
+      let sandbox;
 
       before(() => {
         playerContainer = createElement('DIV', targetId);
       });
 
       beforeEach(() => {
+        sandbox = sinon.sandbox.create();
         config = getConfigStructure();
+        config.sources = sourcesConfig.Mp4;
         player = new Player(config);
+        player.configure({
+          playback: {
+            autoplay: true
+          }
+        });
         playerContainer.appendChild(player.getView());
       });
 
       afterEach(() => {
         player.destroy();
+        sandbox.restore();
       });
 
       after(() => {
@@ -1367,26 +1378,33 @@ describe('Player', function() {
         removeElement(targetId);
       });
 
-      it('should fire auto play failed and show the poster', done => {
-        player.addEventListener(CustomEventType.AUTOPLAY_FAILED, () => {
-          player._posterManager._el.style.display.should.equal('');
-          done();
-        });
-        player.configure({
-          playback: {
-            autoplay: true
-          },
-          sources: {
-            poster: '//cdntesting.qa.mkaltura.com/p/1091/sp/109100/thumbnail/entry_id/0_wifqaipd/version/100042/height/360/width/640',
-            progressive: [
-              {
-                mimetype: 'video/mp4',
-                url: 'bad/url',
-                id: '1_rsrdfext_10081,url'
-              }
-            ]
+      it('should fire auto play failed and show the poster once get PLAY_FAILED', done => {
+        player.addEventListener(CustomEventType.AUTOPLAY_FAILED, error => {
+          try {
+            player._posterManager._el.style.display.should.equal('');
+            error.payload.error.should.equal('mock failure');
+            done();
+          } catch (e) {
+            done(e);
           }
         });
+        sandbox.stub(player._engine._el, 'play').callsFake(function() {
+          return Promise.reject('mock failure');
+        });
+        player.play();
+      });
+
+      it('should fire auto play failed and show the poster once get AD_PLAY_FAILED', done => {
+        player.addEventListener(CustomEventType.AUTOPLAY_FAILED, error => {
+          try {
+            player._posterManager._el.style.display.should.equal('');
+            error.payload.error.should.equal('mock failure');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+        player.dispatchEvent(new FakeEvent(AdEventType.AD_PLAY_FAILED, {error: 'mock failure'}));
       });
     });
 

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1393,7 +1393,7 @@ describe('Player', function() {
         });
       });
 
-      it('should fire auto play failed and show the poster once get AD_PLAY_FAILED', done => {
+      it('should fire auto play failed and show the poster once get AD_AUTO_PLAY_FAILED', done => {
         player.addEventListener(CustomEventType.AUTOPLAY_FAILED, error => {
           try {
             player._posterManager._el.style.display.should.equal('');
@@ -1403,7 +1403,7 @@ describe('Player', function() {
             done(e);
           }
         });
-        player.dispatchEvent(new FakeEvent(AdEventType.AD_PLAY_FAILED, {error: 'mock failure'}));
+        player.dispatchEvent(new FakeEvent(AdEventType.AD_AUTO_PLAY_FAILED, {error: 'mock failure'}));
       });
     });
 


### PR DESCRIPTION
### Description of the Changes

* New `AD_AUTOPLAY_FAILED` event
* Fire `AUTOPLAY_FAILED` once get `AD_AUTOPLAY_FAILED `
* Html5 returns the play promise (required when a plugin plays an ad using the engine)

Solves [FEC-9513](https://kaltura.atlassian.net/browse/FEC-9513)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
