### PR TITLE
fix(FEC-9583): race condition on load ios playback

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -297,9 +297,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         }
         if (this._sourceObj && this._sourceObj.url) {
           this._setSrc().then(() => {
+            this._trigger(CustomEventType.ABR_MODE_CHANGED, {mode: this._isProgressivePlayback() ? 'manual' : 'auto'});
             this._videoElement.load();
           });
-          this._trigger(CustomEventType.ABR_MODE_CHANGED, {mode: this._isProgressivePlayback() ? 'manual' : 'auto'});
         } else {
           this._videoElement.load();
         }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -296,10 +296,13 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           this._setProgressiveSource();
         }
         if (this._sourceObj && this._sourceObj.url) {
-          this._setSrc();
+          this._setSrc().then(() => {
+            this._videoElement.load();
+          });
           this._trigger(CustomEventType.ABR_MODE_CHANGED, {mode: this._isProgressivePlayback() ? 'manual' : 'auto'});
+        } else {
+          this._videoElement.load();
         }
-        this._videoElement.load();
       });
     }
     return this._loadPromise;
@@ -373,7 +376,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     this._loadPromise = null;
   }
 
-  _setSrc(): void {
+  _setSrc(): Promise<*> {
     const pkRequest: PKRequestObject = {url: this._sourceObj ? this._sourceObj.url : '', body: null, headers: {}};
     let requestFilterPromise;
     if (typeof Utils.Object.getPropertyPath(this._config, 'network.requestFilter') === 'function') {
@@ -392,6 +395,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       .catch(error => {
         this._trigger(Html5EventType.ERROR, new Error(Error.Severity.CRITICAL, Error.Category.NETWORK, Error.Code.REQUEST_FILTER_ERROR, error));
       });
+    return requestFilterPromise;
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Issue: promise resolve on the next tick so video load and then we are setting the src, no src on loading.
Solution: handle the load when promise resolve

Solve: FEC-9583.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
