### PR TITLE
fix(FEC-9459): load implementation in middleware is not working as expected

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2001,9 +2001,6 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   _play(): void {
-    if (!this._engine.src) {
-      this._load();
-    }
     this.ready()
       .then(() => {
         if (this.isLive() && !this.isDvr()) {

--- a/test/src/middleware/playback-middleware.spec.js
+++ b/test/src/middleware/playback-middleware.spec.js
@@ -15,6 +15,11 @@ class PM1 extends BaseMiddleware {
     this.logger.debug('pause');
     this.callNext(next);
   }
+
+  load(next) {
+    this.logger.debug('load');
+    this.callNext(next);
+  }
 }
 
 class PM2 extends BaseMiddleware {
@@ -37,9 +42,19 @@ class PM3 extends BaseMiddleware {
   }
 }
 
+class PM4 extends BaseMiddleware {
+  id = 'PM4';
+  logger = getLogger(this.id);
+
+  load(next) {
+    this.logger.debug('load');
+    this.callNext(next);
+  }
+}
+
 describe('PlaybackMiddleware', function() {
-  let pm1, pm2, pm3;
-  let spyPm1, spyPm2, spyPm3;
+  let pm1, pm2, pm3, pm4;
+  let spyPm1, spyPm2, spyPm3, spyPm4;
   let playbackMiddleware;
   let sandbox;
 
@@ -56,11 +71,14 @@ describe('PlaybackMiddleware', function() {
     pm1 = new PM1();
     pm2 = new PM2();
     pm3 = new PM3();
+    pm4 = new PM4();
     playbackMiddleware.use(pm1);
     playbackMiddleware.use(pm2);
     playbackMiddleware.use(pm3);
+    playbackMiddleware.use(pm4);
     playbackMiddleware._middleware._middlewares.get('pause').should.have.lengthOf(2);
     playbackMiddleware._middleware._middlewares.get('play').should.have.lengthOf(2);
+    playbackMiddleware._middleware._middlewares.get('load').should.have.lengthOf(2);
   });
 
   it('should run playback middleware for action pause', function(done) {
@@ -89,6 +107,21 @@ describe('PlaybackMiddleware', function() {
       spyPm1.should.have.been.calledOnce;
       spyPm2.should.have.been.calledOnce;
       spyPm2.should.have.been.calledAfter(spyPm1);
+      done();
+    });
+  });
+
+  it('should run playback middleware for action load', function(done) {
+    spyPm1 = sandbox.spy(PM1.prototype, 'load');
+    spyPm4 = sandbox.spy(PM4.prototype, 'load');
+    pm1 = new PM1();
+    pm4 = new PM4();
+    playbackMiddleware.use(pm1);
+    playbackMiddleware.use(pm4);
+    playbackMiddleware.load(() => {
+      spyPm1.should.have.been.calledOnce;
+      spyPm4.should.have.been.calledOnce;
+      spyPm4.should.have.been.calledAfter(spyPm1);
       done();
     });
   });


### PR DESCRIPTION
### Description of the Changes

The issue is when only `load` middleware implemented.
**Issue**: 
`play` calls to `_play` immediately (as no `play` middleware provided). Then `_play` calls to `_load` and actually bypasses the `load` middleware mechanism.
**Solution**: 
`_play` doesn't call to `_load`. only `play` calls to `load`

Solves FEC-9459
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
