### PR TITLE
fix(FEC-9585): when pre-roll+bumper exist need re-click to play the content - iOS

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -544,13 +544,13 @@ export default class Player extends FakeEventTarget {
     if (!this._playbackStart) {
       this._playbackStart = true;
       this.dispatchEvent(new FakeEvent(CustomEventType.PLAYBACK_START));
+      this._prepareVideoElement();
       this.load();
     }
     if (this._engine) {
       this._playbackMiddleware.play(() => this._play());
     } else if (this._loadingMedia) {
       // load media requested but the response is delayed
-      this._prepareVideoElement();
       this._playbackMiddleware.play(() => this._playAfterAsyncMiddleware());
     } else {
       this.dispatchEvent(

--- a/src/player.js
+++ b/src/player.js
@@ -544,7 +544,9 @@ export default class Player extends FakeEventTarget {
     if (!this._playbackStart) {
       this._playbackStart = true;
       this.dispatchEvent(new FakeEvent(CustomEventType.PLAYBACK_START));
-      this._prepareVideoElement();
+      if (!this.src) {
+        this._prepareVideoElement();
+      }
       this.load();
     }
     if (this._engine) {


### PR DESCRIPTION
### Description of the Changes

**Issue**: 
The first click loads the ad and the bumper but not the playback source. then the playback play failed as 'no-user-gesture'
**Solution**: 
Prepare the playback video element once click

Solves FEC-9585

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
