### PR TITLE
fix(FEC-9603): load doesn't call on play after attach detach

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1016,6 +1016,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   _onCueChange(e: FakeEvent): void {
     let textTrack: TextTrack = e.currentTarget;
     let activeCues: Array<Cue> = [];
+    if (!textTrack || !textTrack.activeCues) return;
     for (let cue of textTrack.activeCues) {
       //Normalize cues to be of type of VTT model
       if (window.VTTCue && cue instanceof window.VTTCue) {

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1016,7 +1016,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   _onCueChange(e: FakeEvent): void {
     let textTrack: TextTrack = e.currentTarget;
     let activeCues: Array<Cue> = [];
-    if (!textTrack || !textTrack.activeCues) return;
     for (let cue of textTrack.activeCues) {
       //Normalize cues to be of type of VTT model
       if (window.VTTCue && cue instanceof window.VTTCue) {

--- a/src/player.js
+++ b/src/player.js
@@ -547,7 +547,6 @@ export default class Player extends FakeEventTarget {
       if (!this.src) {
         this._prepareVideoElement();
       }
-      this.load();
     }
     if (this._engine) {
       this._playbackMiddleware.play(() => this._play());
@@ -2003,6 +2002,9 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   _play(): void {
+    if (!this._engine.src) {
+      this.load();
+    }
     this.ready()
       .then(() => {
         if (this.isLive() && !this.isDvr()) {

--- a/src/player.js
+++ b/src/player.js
@@ -547,6 +547,7 @@ export default class Player extends FakeEventTarget {
       if (!this.src) {
         this._prepareVideoElement();
       }
+      this.load();
     }
     if (this._engine) {
       this._playbackMiddleware.play(() => this._play());
@@ -672,6 +673,7 @@ export default class Player extends FakeEventTarget {
           this.playbackRate = this._playbackAttributesState.rate;
         }
       });
+      this._load();
     }
   }
 
@@ -682,6 +684,8 @@ export default class Player extends FakeEventTarget {
    */
   _detachMediaSource(): void {
     if (this._engine) {
+      this.pause();
+      this.hideTextTrack();
       this._createReadyPromise();
       this._engine.detachMediaSource();
     }
@@ -2002,9 +2006,6 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   _play(): void {
-    if (!this._engine.src) {
-      this.load();
-    }
     this.ready()
       .then(() => {
         if (this.isLive() && !this.isDvr()) {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -140,15 +140,28 @@ describe('Player', function() {
     describe('attach detach', function() {
       it('should success play after detach attach', done => {
         const playing = () => {
-          player.removeEventListener('playing', playing);
-          player.addEventListener('playing', () => {
+          player.removeEventListener(Html5EventType.PLAYING, playing);
+          player.addEventListener(Html5EventType.PLAYING, () => {
             done();
           });
           player._detachMediaSource();
           player._attachMediaSource();
           player.play();
         };
-        player.addEventListener('playing', playing);
+        player.addEventListener(Html5EventType.PLAYING, playing);
+        player.play();
+      });
+
+      it('should attach return to time before detach', () => {
+        let currentTime = NaN;
+        const playing = () => {
+          player.removeEventListener(Html5EventType.PLAYING, playing);
+          currentTime = Math.floor(player.currentTime);
+          player._detachMediaSource();
+          player._attachMediaSource();
+          Math.floor(player.currentTime).should.equal(currentTime);
+        };
+        player.addEventListener(Html5EventType.PLAYING, playing);
         player.play();
       });
     });

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -137,6 +137,21 @@ describe('Player', function() {
         player.play();
       });
     });
+    describe('attach detach', function() {
+      it('should success play after detach attach', done => {
+        const playing = () => {
+          player.removeEventListener('playing', playing);
+          player.addEventListener('playing', () => {
+            done();
+          });
+          player._detachMediaSource();
+          player._attachMediaSource();
+          player.play();
+        };
+        player.addEventListener('playing', playing);
+        player.play();
+      });
+    });
   });
 
   describe('ready', function() {


### PR DESCRIPTION
### Description of the Changes

Issue: load doesn't call on play after attach detach.
Solution: add load to attachMedia.
pause and hideTextTracks added to avoid textTracks and update state of player after detach.

Solve FEC-9603.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
