### PR TITLE
fix(FEC-9600): new ad layout - pre-mid-post rolls - no replay button appears after post-roll ad finished

### DIFF
--- a/src/ads/ads-controller.js
+++ b/src/ads/ads-controller.js
@@ -143,6 +143,7 @@ class AdsController extends FakeEventTarget implements IAdsController {
     this._eventManager.listen(this._player, AdEventType.AD_ERROR, event => this._onAdError(event));
     this._eventManager.listen(this._player, CustomEventType.PLAYER_RESET, () => this._reset());
     this._eventManager.listenOnce(this._player, Html5EventType.ENDED, () => this._onEnded());
+    this._eventManager.listenOnce(this._player, CustomEventType.PLAYBACK_ENDED, () => this._onPlaybackEnded());
   }
 
   _handleConfiguredAdBreaks(): void {
@@ -342,6 +343,10 @@ class AdsController extends FakeEventTarget implements IAdsController {
           });
       });
     }
+  }
+
+  _onPlaybackEnded(): void {
+    this._configAdBreaks.forEach(adBreak => (adBreak.played = true));
   }
 
   _handleConfiguredPostroll(): void {

--- a/src/ads/ads-controller.js
+++ b/src/ads/ads-controller.js
@@ -143,7 +143,6 @@ class AdsController extends FakeEventTarget implements IAdsController {
     this._eventManager.listen(this._player, AdEventType.AD_ERROR, event => this._onAdError(event));
     this._eventManager.listen(this._player, CustomEventType.PLAYER_RESET, () => this._reset());
     this._eventManager.listenOnce(this._player, Html5EventType.ENDED, () => this._onEnded());
-    this._eventManager.listenOnce(this._player, CustomEventType.PLAYBACK_ENDED, () => this._onPlaybackEnded());
   }
 
   _handleConfiguredAdBreaks(): void {
@@ -345,16 +344,13 @@ class AdsController extends FakeEventTarget implements IAdsController {
     }
   }
 
-  _onPlaybackEnded(): void {
-    this._configAdBreaks.forEach(adBreak => (adBreak.played = true));
-  }
-
   _handleConfiguredPostroll(): void {
     const postrolls = this._configAdBreaks.filter(adBreak => !adBreak.played && adBreak.position === -1);
     if (postrolls.length) {
       const mergedPostroll = this._mergeAdBreaks(postrolls);
       mergedPostroll && this._playAdBreak(mergedPostroll);
     }
+    this._configAdBreaks.forEach(adBreak => (adBreak.played = true));
   }
 
   _reset(): void {


### PR DESCRIPTION
### Description of the Changes

mark all ads as `played` when playing the post-roll

Solves FEC-9600

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
