### PR TITLE
fix(FEC-9577): Hisense playback doesn't work

### DIFF
--- a/flow-typed/interfaces/engine-capabilty.js
+++ b/flow-typed/interfaces/engine-capabilty.js
@@ -4,4 +4,5 @@ declare type CapabilityResult = {[capabilityName: string]: any};
 declare interface ICapability {
   static runCapability(playsinline:?boolean): void;
   static getCapability(playsinline:?boolean): Promise<CapabilityResult>;
+  static setCapabilities(capabilities: {[name: string]: any}): void;
 }

--- a/flow-typed/interfaces/engine.js
+++ b/flow-typed/interfaces/engine.js
@@ -9,6 +9,7 @@ declare interface IEngine {
   static canPlaySource(source: PKMediaSourceObject, preferNative: boolean, drmConfig: PKDrmConfigObject): boolean;
   static runCapabilities(): void;
   static getCapabilities(): Promise<Object>;
+  static setCapabilities(capabilities: {[name: string]: any}): void;
   static prepareVideoElement(playerId: string): void;
   static isSupported(): boolean;
   restore(source: PKMediaSourceObject, config: Object): void;

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -20,8 +20,12 @@ export default class Html5AutoPlayCapability implements ICapability {
    * @returns {void}
    */
   static runCapability(playsinline: ?boolean): void {
-    if (this._capabilities.autoplay || (typeof this._capabilities.autoplay === 'boolean' && typeof this._capabilities.mutedAutoPlay === 'boolean')) {
-      Html5AutoPlayCapability._playPromiseResult = new Promise(resolve => resolve(this._capabilities));
+    if (
+      Html5AutoPlayCapability._capabilities.autoplay ||
+      (typeof Html5AutoPlayCapability._capabilities.autoplay === 'boolean' &&
+        typeof Html5AutoPlayCapability._capabilities.mutedAutoPlay === 'boolean')
+    ) {
+      Html5AutoPlayCapability._playPromiseResult = new Promise(resolve => resolve(Html5AutoPlayCapability._capabilities));
       return;
     }
     if (!Html5AutoPlayCapability._vid) {
@@ -33,13 +37,13 @@ export default class Html5AutoPlayCapability implements ICapability {
       Html5AutoPlayCapability._setMuted(false);
       Html5AutoPlayCapability._getPlayPromise()
         .then(() => {
-          resolve(Utils.Object.mergeDeep({autoplay: true, mutedAutoPlay: true}, this._capabilities));
+          resolve(Utils.Object.mergeDeep({autoplay: true, mutedAutoPlay: true}, Html5AutoPlayCapability._capabilities));
         })
         .catch(() => {
           Html5AutoPlayCapability._setMuted(true);
           Html5AutoPlayCapability._getPlayPromise()
-            .then(() => resolve(Utils.Object.mergeDeep({autoplay: false, mutedAutoPlay: true}, this._capabilities)))
-            .catch(() => resolve(Utils.Object.mergeDeep({autoplay: false, mutedAutoPlay: false}, this._capabilities)));
+            .then(() => resolve(Utils.Object.mergeDeep({autoplay: false, mutedAutoPlay: true}, Html5AutoPlayCapability._capabilities)))
+            .catch(() => resolve(Utils.Object.mergeDeep({autoplay: false, mutedAutoPlay: false}, Html5AutoPlayCapability._capabilities)));
         });
     });
   }
@@ -71,7 +75,7 @@ export default class Html5AutoPlayCapability implements ICapability {
    */
   static setCapabilities(capabilities: {[name: string]: any}): void {
     Html5AutoPlayCapability._logger.debug('Set player capabilities', capabilities);
-    this._capabilities = (({autoplay, mutedAutoPlay}) => {
+    Html5AutoPlayCapability._capabilities = (({autoplay, mutedAutoPlay}) => {
       let res = {};
       if (typeof autoplay === 'boolean') {
         res = {...res, ...{autoplay}};

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -58,9 +58,9 @@ export default class Html5AutoPlayCapability implements ICapability {
   static getCapability(playsinline: ?boolean): Promise<CapabilityResult> {
     return Html5AutoPlayCapability._playPromiseResult.then(playCapability => {
       let fallbackPlayCapabilityTest;
-      // If autoplay is not allowed - try again and return the updated result
       if (playCapability.autoplay) {
         fallbackPlayCapabilityTest = Promise.resolve(playCapability);
+        // If autoplay is not allowed - try again and return the updated result
       } else {
         Html5AutoPlayCapability.runCapability(playsinline);
         fallbackPlayCapabilityTest = Html5AutoPlayCapability._playPromiseResult;

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -36,9 +36,7 @@ export default class Html5AutoPlayCapability implements ICapability {
     Html5AutoPlayCapability._playPromiseResult = new Promise(resolve => {
       Html5AutoPlayCapability._setMuted(false);
       Html5AutoPlayCapability._getPlayPromise()
-        .then(() => {
-          resolve({autoplay: true, mutedAutoPlay: true});
-        })
+        .then(() => resolve({autoplay: true, mutedAutoPlay: true}))
         .catch(() => {
           Html5AutoPlayCapability._setMuted(true);
           Html5AutoPlayCapability._getPlayPromise()
@@ -60,8 +58,8 @@ export default class Html5AutoPlayCapability implements ICapability {
       let fallbackPlayCapabilityTest;
       if (playCapability.autoplay) {
         fallbackPlayCapabilityTest = Promise.resolve(playCapability);
-        // If autoplay is not allowed - try again and return the updated result
       } else {
+        // If autoplay is not allowed - try again and return the updated result
         Html5AutoPlayCapability.runCapability(playsinline);
         fallbackPlayCapabilityTest = Html5AutoPlayCapability._playPromiseResult;
       }

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -82,7 +82,8 @@ export default class Html5AutoPlayCapability implements ICapability {
       return res;
     })(capabilities);
     if (Html5AutoPlayCapability._playPromiseResult) {
-      Html5AutoPlayCapability.runCapability(Html5AutoPlayCapability._vid.getAttribute('playsinline'));
+      const playsinline = !!Html5AutoPlayCapability._vid.getAttribute('playsinline');
+      Html5AutoPlayCapability.runCapability(playsinline);
     }
   }
 

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -57,10 +57,14 @@ export default class Html5AutoPlayCapability implements ICapability {
    */
   static getCapability(playsinline: ?boolean): Promise<CapabilityResult> {
     return Html5AutoPlayCapability._playPromiseResult.then(playCapability => {
+      let fallbackPlayCapabilityTest;
       // If autoplay is not allowed - try again and return the updated result
-      const fallbackPlayCapabilityTest = playCapability.autoplay
-        ? Promise.resolve(playCapability)
-        : Html5AutoPlayCapability.runCapability(playsinline);
+      if (playCapability.autoplay) {
+        fallbackPlayCapabilityTest = Promise.resolve(playCapability);
+      } else {
+        Html5AutoPlayCapability.runCapability(playsinline);
+        fallbackPlayCapabilityTest = Html5AutoPlayCapability._playPromiseResult;
+      }
       return fallbackPlayCapabilityTest.then(fallbackPlayCapability =>
         Utils.Object.mergeDeep(fallbackPlayCapability, Html5AutoPlayCapability._capabilities)
       );

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -149,6 +149,17 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   }
 
   /**
+   * Sets an engine capabilities.
+   * @param {Object} capabilities - The engine capabilities.
+   * @returns {void}
+   * @public
+   * @static
+   */
+  static setCapabilities(capabilities: {[name: string]: any}): void {
+    Html5._capabilities.forEach(capability => capability.setCapabilities(capabilities));
+  }
+
+  /**
    * For browsers which block auto play, use the user gesture to open the video element and enable playing via API.
    * @returns {void}
    * @param {string} playerId - the id to be set as the key of the video element

--- a/src/player.js
+++ b/src/player.js
@@ -172,9 +172,10 @@ export default class Player extends FakeEventTarget {
    */
   static setCapabilities(engineType: string, capabilities: {[name: string]: any}): void {
     Player._logger.debug('Set player capabilities', engineType, capabilities);
-    EngineProvider.getEngines()
-      .find(Engine => Engine.id === engineType)
-      .setCapabilities(capabilities);
+    const selectedEngine = EngineProvider.getEngines().find(Engine => Engine.id === engineType);
+    if (selectedEngine) {
+      selectedEngine.setCapabilities(capabilities);
+    }
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -148,7 +148,7 @@ export default class Player extends FakeEventTarget {
   static runCapabilities(playsinline: ?boolean): void {
     Player._logger.debug('Running player capabilities');
     EngineProvider.getEngines().forEach(Engine => {
-      if (!Player._playerCapabilities[Engine]) {
+      if (!Player._playerCapabilities[Engine.id]) {
         Engine.runCapabilities(playsinline);
       }
     });

--- a/src/player.js
+++ b/src/player.js
@@ -147,11 +147,7 @@ export default class Player extends FakeEventTarget {
    */
   static runCapabilities(playsinline: ?boolean): void {
     Player._logger.debug('Running player capabilities');
-    EngineProvider.getEngines().forEach(Engine => {
-      if (!Player._playerCapabilities[Engine.id]) {
-        Engine.runCapabilities(playsinline);
-      }
-    });
+    EngineProvider.getEngines().forEach(Engine => Engine.runCapabilities(playsinline));
   }
 
   /**
@@ -169,7 +165,6 @@ export default class Player extends FakeEventTarget {
     return Promise.all(promises).then(arrayOfResults => {
       const playerCapabilities = {};
       arrayOfResults.forEach(res => Object.assign(playerCapabilities, res));
-      Utils.Object.mergeDeep(playerCapabilities, Player._playerCapabilities);
       return engineType ? playerCapabilities[engineType] : playerCapabilities;
     });
   }
@@ -184,7 +179,9 @@ export default class Player extends FakeEventTarget {
    */
   static setCapabilities(engineType: string, capabilities: {[name: string]: any}): void {
     Player._logger.debug('Set player capabilities', engineType, capabilities);
-    Player._playerCapabilities[engineType] = Utils.Object.mergeDeep({}, Player._playerCapabilities[engineType], capabilities);
+    EngineProvider.getEngines()
+      .filter(Engine => Engine.id === engineType)
+      .forEach(engine => engine.setCapabilities(capabilities));
   }
 
   /**
@@ -645,7 +642,6 @@ export default class Player extends FakeEventTarget {
     if (this._destroyed) return;
     //make sure all services are destroyed before engine and engine attributes are destroyed
     this._externalCaptionsHandler.destroy();
-    Player._playerCapabilities = {};
     this._posterManager.destroy();
     this._pluginManager.destroy();
     this._stateManager.destroy();

--- a/src/player.js
+++ b/src/player.js
@@ -147,7 +147,11 @@ export default class Player extends FakeEventTarget {
    */
   static runCapabilities(playsinline: ?boolean): void {
     Player._logger.debug('Running player capabilities');
-    EngineProvider.getEngines().forEach(Engine => Engine.runCapabilities(playsinline));
+    EngineProvider.getEngines().forEach(Engine => {
+      if (!Player._playerCapabilities[Engine]) {
+        Engine.runCapabilities(playsinline);
+      }
+    });
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -173,8 +173,8 @@ export default class Player extends FakeEventTarget {
   static setCapabilities(engineType: string, capabilities: {[name: string]: any}): void {
     Player._logger.debug('Set player capabilities', engineType, capabilities);
     EngineProvider.getEngines()
-      .filter(Engine => Engine.id === engineType)
-      .forEach(engine => engine.setCapabilities(capabilities));
+      .find(Engine => Engine.id === engineType)
+      .setCapabilities(capabilities);
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -130,13 +130,6 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   static _logger: any = getLogger('Player');
-  /**
-   * The player capabilities result object.
-   * @type {Object}
-   * @private
-   * @static
-   */
-  static _playerCapabilities: Object = {};
 
   /**
    * Runs the engines capabilities tests.

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,22 +1,32 @@
 // @flow
 import UAParser from 'ua-parser-js';
 
+const SmartTvRegex = /^.*(smart-tv|smarttv).*$/i;
+
 const LGTVRegex = /^.*(web0s).*(smarttv).*$/i;
-//doesn't recognize lg at all
-const LGOSParser = [[LGTVRegex], [UAParser.OS.NAME]];
 
 const SAMSUNGTVRegex = /^.*(smart-tv).*(tizen).*$/i;
+
+const HISENSETVRegex = /^.*(vidaa).*(smarttv).*$/i;
+
 //recognize as safari
 const SAMSUNGBrowserParser = [
   [SAMSUNGTVRegex],
   [[UAParser.BROWSER.NAME, 'SAMSUNG_TV_BROWSER'], [UAParser.BROWSER.MAJOR, ''], [UAParser.BROWSER.VERSION, '']]
 ];
 
+//recognize os of smartTV devices
+const OSParser = [[LGTVRegex], [UAParser.OS.NAME], [HISENSETVRegex], [UAParser.OS.NAME]];
+
 //add smart tv as smart tv devices
 const DeviceParser = [
   [LGTVRegex],
   [[UAParser.DEVICE.VENDOR, 'LG'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]],
   [SAMSUNGTVRegex],
+  [[UAParser.DEVICE.VENDOR, 'SAMSUNG'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]],
+  [HISENSETVRegex],
+  [[UAParser.DEVICE.VENDOR, 'HISENSE'], [UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]],
+  [SmartTvRegex],
   [[UAParser.DEVICE.TYPE, UAParser.DEVICE.SMARTTV]]
 ];
 
@@ -24,7 +34,7 @@ const EdgeChromiumParser = [[/(edg)\/((\d+)?[\w.]+)/i], [[UAParser.BROWSER.NAME,
 
 const BrowserParser = [...EdgeChromiumParser, ...SAMSUNGBrowserParser];
 
-let Env = new UAParser(undefined, {browser: BrowserParser, device: DeviceParser, os: LGOSParser}).getResult();
+let Env = new UAParser(undefined, {browser: BrowserParser, device: DeviceParser, os: OSParser}).getResult();
 
 Env.isConsole = Env.device.type === UAParser.DEVICE.CONSOLE;
 Env.isSmartTV = Env.device.type === UAParser.DEVICE.SMARTTV;

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -19,6 +19,7 @@ import {LabelOptions} from '../../src/track/label-options';
 import {EngineProvider} from '../../src/engines/engine-provider';
 import {AdEventType} from '../../src/ads/ad-event-type';
 import FakeEvent from '../../src/event/fake-event';
+import Html5AutoPlayCapability from '../../src/engines/html5/capabilities/html5-autoplay';
 
 const targetId = 'player-placeholder_player.spec';
 let sourcesConfig = PKObject.copyDeep(SourcesConfig);
@@ -2910,7 +2911,7 @@ describe('Player', function() {
   describe('setCapabilities', () => {
     let initialOrigCapabilities;
 
-    before(done => {
+    beforeEach(done => {
       Player.runCapabilities();
       Player.getCapabilities().then(capabilities => {
         initialOrigCapabilities = capabilities;
@@ -2919,7 +2920,7 @@ describe('Player', function() {
     });
 
     afterEach(() => {
-      Player._playerCapabilities = PKObject.copyDeep(initialOrigCapabilities);
+      Html5AutoPlayCapability._capabilities = {};
     });
 
     it('should not change the original capabilities by reference', done => {
@@ -2935,30 +2936,79 @@ describe('Player', function() {
 
     it('should set custom capabilities successfully', done => {
       let newCapabilities = {
-        autoplay: 1,
-        mutedAutoPlay: 2,
-        isSupported: 3
+        autoplay: true,
+        mutedAutoPlay: false,
+        isSupported: false,
+        fakeAttribute: true
       };
+      const existingCapabilities = (({autoplay, mutedAutoPlay}) => ({autoplay, mutedAutoPlay}))(newCapabilities);
       Player.setCapabilities('html5', newCapabilities);
       Player.getCapabilities().then(c2 => {
-        c2.html5.should.deep.equal(newCapabilities);
+        c2.html5.should.deep.equal(existingCapabilities);
         done();
       });
     });
 
     it('should set custom capabilities successfully after getCapabilities() call', done => {
       let newCapabilities = {
-        autoplay: 3,
-        mutedAutoPlay: 4,
+        autoplay: false,
+        mutedAutoPlay: false,
         isSupported: 5
       };
+      const existingCapabilities = (({autoplay, mutedAutoPlay}) => ({autoplay, mutedAutoPlay}))(newCapabilities);
       Player.getCapabilities().then(c1 => {
         c1.should.deep.equal(initialOrigCapabilities);
+        Player.setCapabilities('html5', newCapabilities);
+        Player.getCapabilities()
+          .then(c2 => {
+            try {
+              c2.html5.should.deep.equal(existingCapabilities);
+              done();
+            } catch (err) {
+              done(err);
+            }
+          })
+          .catch(err => done(err));
+      });
+    });
+
+    it('should set custom capabilities after runCapabilities() successfully', done => {
+      let newCapabilities = {
+        autoplay: false,
+        mutedAutoPlay: false
+      };
+      Player.runCapabilities();
+      Player.getCapabilities().then(c1 => {
+        c1.html5.should.deep.not.equal(newCapabilities);
         Player.setCapabilities('html5', newCapabilities);
         Player.getCapabilities().then(c2 => {
           c2.html5.should.deep.equal(newCapabilities);
           done();
         });
+      });
+    });
+
+    it('should check for mutedAutoPlay possibility if autoplay set to false', done => {
+      let newCapabilities = {
+        autoplay: false
+      };
+      Player.setCapabilities('html5', newCapabilities);
+      Player.getCapabilities().then(c2 => {
+        c2.html5.autoplay.should.equal(newCapabilities.autoplay);
+        c2.html5.mutedAutoPlay.should.not.equal(newCapabilities.mutedAutoPlay);
+        done();
+      });
+    });
+
+    it('should check for autoPlay possibility if mutedAutoPlay set', done => {
+      let newCapabilities = {
+        mutedAutoPlay: true
+      };
+      Player.setCapabilities('html5', newCapabilities);
+      Player.getCapabilities().then(c2 => {
+        c2.html5.autoplay.should.not.equal(newCapabilities.autoplay);
+        c2.html5.mutedAutoPlay.should.equal(newCapabilities.mutedAutoPlay);
+        done();
       });
     });
   });

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2944,8 +2944,30 @@ describe('Player', function() {
       const existingCapabilities = (({autoplay, mutedAutoPlay}) => ({autoplay, mutedAutoPlay}))(newCapabilities);
       Player.setCapabilities('html5', newCapabilities);
       Player.getCapabilities().then(c2 => {
-        c2.html5.should.deep.equal(existingCapabilities);
-        done();
+        try {
+          c2.html5.should.deep.equal(existingCapabilities);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+    });
+
+    it('should support only correct type', done => {
+      let newCapabilities = {
+        autoplay: 1,
+        mutedAutoPlay: 2,
+        isSupported: false,
+        fakeAttribute: true
+      };
+      Player.setCapabilities('html5', newCapabilities);
+      Player.getCapabilities().then(c2 => {
+        try {
+          c2.should.deep.equal(initialOrigCapabilities);
+          done();
+        } catch (err) {
+          done(err);
+        }
       });
     });
 
@@ -2979,11 +3001,19 @@ describe('Player', function() {
       };
       Player.runCapabilities();
       Player.getCapabilities().then(c1 => {
-        c1.html5.should.deep.not.equal(newCapabilities);
+        try {
+          c1.html5.should.deep.not.equal(newCapabilities);
+        } catch (err) {
+          done(err);
+        }
         Player.setCapabilities('html5', newCapabilities);
         Player.getCapabilities().then(c2 => {
-          c2.html5.should.deep.equal(newCapabilities);
-          done();
+          try {
+            c2.html5.should.deep.equal(newCapabilities);
+            done();
+          } catch (err) {
+            done(err);
+          }
         });
       });
     });
@@ -2994,9 +3024,13 @@ describe('Player', function() {
       };
       Player.setCapabilities('html5', newCapabilities);
       Player.getCapabilities().then(c2 => {
-        c2.html5.autoplay.should.equal(newCapabilities.autoplay);
-        c2.html5.mutedAutoPlay.should.not.equal(newCapabilities.mutedAutoPlay);
-        done();
+        try {
+          c2.html5.autoplay.should.equal(newCapabilities.autoplay);
+          c2.html5.mutedAutoPlay.should.not.equal(newCapabilities.mutedAutoPlay);
+          done();
+        } catch (err) {
+          done(err);
+        }
       });
     });
 
@@ -3006,9 +3040,13 @@ describe('Player', function() {
       };
       Player.setCapabilities('html5', newCapabilities);
       Player.getCapabilities().then(c2 => {
-        c2.html5.autoplay.should.not.equal(newCapabilities.autoplay);
-        c2.html5.mutedAutoPlay.should.equal(newCapabilities.mutedAutoPlay);
-        done();
+        try {
+          c2.html5.autoplay.should.not.equal(newCapabilities.autoplay);
+          c2.html5.mutedAutoPlay.should.equal(newCapabilities.mutedAutoPlay);
+          done();
+        } catch (err) {
+          done(err);
+        }
       });
     });
   });


### PR DESCRIPTION
### Description of the Changes

**Issue**: Hisense can't contain base64 as source.
**Solution**: add the set capability to engines and then handle it inside the engines, add partial possibility assignment the rest capability will be checked as well, if not needed it won't check.
add regex to detect correctly hisense TV and add smart tv detection fallback for tv which doesn't support yet.

Depends on https://github.com/kaltura/kaltura-player-js/pull/298

Solves FEC-9577

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
