### PR TITLE
fix(FEC-9629): Player is not inline when rendered after the DOM loads

### DIFF
--- a/flow-typed/interfaces/engine-capabilty.js
+++ b/flow-typed/interfaces/engine-capabilty.js
@@ -2,6 +2,6 @@
 declare type CapabilityResult = {[capabilityName: string]: any};
 
 declare interface ICapability {
-  static runCapability(playsinline:?boolean): void;
-  static getCapability(playsinline:?boolean): Promise<CapabilityResult>;
+  static runCapability(): void;
+  static getCapability(): Promise<CapabilityResult>;
 }

--- a/src/engines/html5/capabilities/html5-autoplay.js
+++ b/src/engines/html5/capabilities/html5-autoplay.js
@@ -14,16 +14,16 @@ export default class Html5AutoPlayCapability implements ICapability {
   /**
    * Runs the test for autoplay capability.
    * @public
-   * @param {?boolean} playsinline - content playsinline
    * @static
    * @returns {void}
    */
-  static runCapability(playsinline: ?boolean): void {
+  static runCapability(): void {
     if (!Html5AutoPlayCapability._vid) {
       Html5AutoPlayCapability._vid = Utils.Dom.createElement('video');
       Html5AutoPlayCapability._vid.src = EncodingSources.Base64Mp4Source;
+      // For iOS devices needs to turn the playsinline attribute on
+      Html5AutoPlayCapability._vid.setAttribute('playsinline', '');
     }
-    Html5AutoPlayCapability._setPlaysinline(playsinline);
     Html5AutoPlayCapability._playPromiseResult = new Promise(resolve => {
       Html5AutoPlayCapability._setMuted(false);
       Html5AutoPlayCapability._getPlayPromise()
@@ -40,15 +40,14 @@ export default class Html5AutoPlayCapability implements ICapability {
   /**
    * Gets the test result for autoplay capability.
    * @returns {Promise<CapabilityResult>} - The result object for autoplay capability.
-   * @param {?boolean} playsinline - content playsinline
    * @static
    * @public
    */
-  static getCapability(playsinline: ?boolean): Promise<CapabilityResult> {
+  static getCapability(): Promise<CapabilityResult> {
     return Html5AutoPlayCapability._playPromiseResult.then(res => {
       // If autoplay is not allowed - try again and return the updated result
       if (!res.autoplay) {
-        Html5AutoPlayCapability.runCapability(playsinline);
+        Html5AutoPlayCapability.runCapability();
         return Html5AutoPlayCapability._playPromiseResult;
       }
       return res;
@@ -78,21 +77,6 @@ export default class Html5AutoPlayCapability implements ICapability {
     } else {
       Html5AutoPlayCapability._vid.muted = false;
       Html5AutoPlayCapability._vid.removeAttribute('muted');
-    }
-  }
-
-  /**
-   * Sets the test video element playsinline value.
-   * @param {?boolean} playsinline - The playsinline value.
-   * @private
-   * @returns {void}
-   * @static
-   */
-  static _setPlaysinline(playsinline: ?boolean): void {
-    if (playsinline) {
-      Html5AutoPlayCapability._vid.setAttribute('playsinline', '');
-    } else {
-      Html5AutoPlayCapability._vid.removeAttribute('playsinline');
     }
   }
 

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -122,25 +122,23 @@ export default class Html5 extends FakeEventTarget implements IEngine {
 
   /**
    * Runs the html5 capabilities tests.
-   * @param {boolean} playsinline - content playsinline
    * @returns {void}
    * @public
    * @static
    */
-  static runCapabilities(playsinline: boolean): void {
-    Html5._capabilities.forEach(capability => capability.runCapability(playsinline));
+  static runCapabilities(): void {
+    Html5._capabilities.forEach(capability => capability.runCapability());
   }
 
   /**
    * Gets the html5 capabilities.
-   * @param {?boolean} playsinline - content playsinline
    * @return {Promise<Object>} - The html5 capabilities object.
    * @public
    * @static
    */
-  static getCapabilities(playsinline: ?boolean): Promise<Object> {
+  static getCapabilities(): Promise<Object> {
     let promises = [];
-    Html5._capabilities.forEach(capability => promises.push(capability.getCapability(playsinline)));
+    Html5._capabilities.forEach(capability => promises.push(capability.getCapability()));
     return Promise.all(promises).then(arrayOfResults => {
       const mergedResults = {};
       arrayOfResults.forEach(res => Object.assign(mergedResults, res));

--- a/src/player.js
+++ b/src/player.js
@@ -433,7 +433,8 @@ export default class Player extends FakeEventTarget {
     this._setConfigLogLevel(config);
     this._playerId = Utils.Generator.uniqueId(5);
     this._prepareVideoElement();
-    const playsInline = Utils.Object.getPropertyPath(config, 'playback.playsinline');
+    const defaultPlaysInline = Utils.Object.getPropertyPath(Player._defaultConfig, 'playback.playsinline');
+    const playsInline = Utils.Object.getPropertyPath(config, 'playback.playsinline') || defaultPlaysInline;
     Player.runCapabilities(playsInline);
     this._env = Env;
     this._tracks = [];

--- a/src/player.js
+++ b/src/player.js
@@ -140,28 +140,26 @@ export default class Player extends FakeEventTarget {
 
   /**
    * Runs the engines capabilities tests.
-   * @param {?boolean} playsinline - content playsinline
    * @returns {void}
    * @public
    * @static
    */
-  static runCapabilities(playsinline: ?boolean): void {
+  static runCapabilities(): void {
     Player._logger.debug('Running player capabilities');
-    EngineProvider.getEngines().forEach(Engine => Engine.runCapabilities(playsinline));
+    EngineProvider.getEngines().forEach(Engine => Engine.runCapabilities());
   }
 
   /**
    * Gets the engines capabilities.
    * @param {?string} engineType - The engine type.
-   * @param {?boolean} playsinline - content playsinline
    * @return {Promise<Object>} - The engines capabilities object.
    * @public
    * @static
    */
-  static getCapabilities(engineType: ?string, playsinline: ?boolean): Promise<{[name: string]: any}> {
+  static getCapabilities(engineType: ?string): Promise<{[name: string]: any}> {
     Player._logger.debug('Get player capabilities', engineType);
     const promises = [];
-    EngineProvider.getEngines().forEach(Engine => promises.push(Engine.getCapabilities(playsinline)));
+    EngineProvider.getEngines().forEach(Engine => promises.push(Engine.getCapabilities()));
     return Promise.all(promises).then(arrayOfResults => {
       const playerCapabilities = {};
       arrayOfResults.forEach(res => Object.assign(playerCapabilities, res));
@@ -433,9 +431,7 @@ export default class Player extends FakeEventTarget {
     this._setConfigLogLevel(config);
     this._playerId = Utils.Generator.uniqueId(5);
     this._prepareVideoElement();
-    const defaultPlaysInline = Utils.Object.getPropertyPath(Player._defaultConfig, 'playback.playsinline');
-    const playsInline = Utils.Object.getPropertyPath(config, 'playback.playsinline') || defaultPlaysInline;
-    Player.runCapabilities(playsInline);
+    Player.runCapabilities();
     this._env = Env;
     this._tracks = [];
     this._uiComponents = [];
@@ -1904,7 +1900,7 @@ export default class Player extends FakeEventTarget {
   _handleAutoPlay(): void {
     if (this._config.playback.autoplay === true) {
       const allowMutedAutoPlay = this._config.playback.allowMutedAutoPlay;
-      Player.getCapabilities(this.engineType, this.playsinline).then(capabilities => {
+      Player.getCapabilities(this.engineType).then(capabilities => {
         if (capabilities.autoplay) {
           onAutoPlay();
         } else {


### PR DESCRIPTION
### Description of the Changes

This reverts commit 1b4a3ca as is unneeded any more due to https://github.com/kaltura/kaltura-player-js/pull/302

Solves FEC-9629

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
