### PR TITLE
fix(FEC-9534): changing the bitrate post completion of any content changes replay to play icon

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -634,6 +634,7 @@ export default class Player extends FakeEventTarget {
     this._resetStateFlags();
     this._engineType = '';
     this._streamType = '';
+    this._pendingSelectedVideoTrack = null;
     if (this._engine) {
       this._engine.reset();
     }
@@ -668,6 +669,7 @@ export default class Player extends FakeEventTarget {
     this._engineType = '';
     this._streamType = '';
     this._readyPromise = null;
+    this._pendingSelectedVideoTrack = null;
     this._resetStateFlags();
     this._playbackAttributesState = {};
     if (this._engine) {
@@ -1720,10 +1722,6 @@ export default class Player extends FakeEventTarget {
         if (browser === 'Edge' || browser === 'IE') {
           this._removeTextCuePatch();
         }
-        if (this._engine && this._pendingSelectedVideoTrack) {
-          this._engine.selectVideoTrack(this._pendingSelectedVideoTrack);
-          this._pendingSelectedVideoTrack = null;
-        }
       });
       this._eventManager.listen(this._engine, CustomEventType.VIDEO_TRACK_CHANGED, (event: FakeEvent) => {
         this._markActiveTrack(event.payload.selectedVideoTrack);
@@ -2096,6 +2094,10 @@ export default class Player extends FakeEventTarget {
     if (!this._firstPlaying) {
       this._firstPlaying = true;
       this.dispatchEvent(new FakeEvent(CustomEventType.FIRST_PLAYING));
+    }
+    if (this._engine && this._pendingSelectedVideoTrack) {
+      this._engine.selectVideoTrack(this._pendingSelectedVideoTrack);
+      this._pendingSelectedVideoTrack = null;
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -268,7 +268,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
 
-  _pendingSelectedVideoTrack: VideoTrack;
+  _pendingSelectedVideoTrack: ?VideoTrack;
   /**
    * The available playback rates for the player.
    * @type {Array<number>}

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -77,7 +77,11 @@ export default class StateManager {
         this._dispatchEvent();
       },
       [Html5EventType.SEEKED]: () => {
-        if (this._player.currentTime < Math.floor(this._player.duration)) {
+        if (
+          typeof this._player.currentTime === 'number' &&
+          typeof this._player.duration === 'number' &&
+          this._player.currentTime < Math.floor(this._player.duration)
+        ) {
           this._updateState(StateType.PAUSED);
           this._dispatchEvent();
         }

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -77,11 +77,7 @@ export default class StateManager {
         this._dispatchEvent();
       },
       [Html5EventType.SEEKED]: () => {
-        if (
-          typeof this._player.currentTime === 'number' &&
-          typeof this._player.duration === 'number' &&
-          this._player.currentTime < Math.floor(this._player.duration)
-        ) {
+        if (this._player.currentTime < Math.floor(this._player.duration)) {
           this._updateState(StateType.PAUSED);
           this._dispatchEvent();
         }

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -77,10 +77,8 @@ export default class StateManager {
         this._dispatchEvent();
       },
       [Html5EventType.SEEKED]: () => {
-        if (this._player.currentTime < Math.floor(this._player.duration)) {
-          this._updateState(StateType.PAUSED);
-          this._dispatchEvent();
-        }
+        this._updateState(StateType.PAUSED);
+        this._dispatchEvent();
       }
     },
     [StateType.LOADING]: {

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -77,8 +77,10 @@ export default class StateManager {
         this._dispatchEvent();
       },
       [Html5EventType.SEEKED]: () => {
-        this._updateState(StateType.PAUSED);
-        this._dispatchEvent();
+        if (this._player.currentTime < Math.floor(this._player.duration)) {
+          this._updateState(StateType.PAUSED);
+          this._dispatchEvent();
+        }
       }
     },
     [StateType.LOADING]: {


### PR DESCRIPTION
### Description of the Changes

to fix bug in hls that seek event is fired when changing qualities - if state was idle (i.e end of playback) and seeked event fired don't change state to paused if current time is at the end of the playback

solves FEC-9534

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
