### PR TITLE
fix(FEC-9614): players get stuck when there are empty captions in ie11 - additional fix

### DIFF
--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -731,7 +731,7 @@ class BoxPosition {
     this.height = obj.height || height;
     this.bottom = obj.bottom || top + (obj.height || height);
     this.width = obj.width || width;
-    this.lineHeight = (lh !== undefined ? lh : obj.lineHeight) || 13;
+    this.lineHeight = lh || obj.lineHeight || 13;
   }
 
   // Move the box along a particular axis. Optionally pass in an amount to move

--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -731,7 +731,7 @@ class BoxPosition {
     this.height = obj.height || height;
     this.bottom = obj.bottom || top + (obj.height || height);
     this.width = obj.width || width;
-    this.lineHeight = lh !== undefined ? lh : obj.lineHeight || 13;
+    this.lineHeight = (lh !== undefined ? lh : obj.lineHeight) || 13;
   }
 
   // Move the box along a particular axis. Optionally pass in an amount to move


### PR DESCRIPTION
### Description of the Changes

Added brackets so lineHeight can never be 0


Solves FEC-9614

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
