### PR TITLE
feat(FEC-9109): add DRM Load time metric

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -294,6 +294,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.TEXT_CUE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.TRACKS_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.FRAG_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
+      this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.DRM_LICENSE_RESPONSE, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.MANIFEST_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, Html5EventType.ERROR, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, Html5EventType.TIME_UPDATE, (event: FakeEvent) => this.dispatchEvent(event));

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -294,7 +294,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.TEXT_CUE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.TRACKS_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.FRAG_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
-      this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.DRM_LICENSE_RESPONSE, (event: FakeEvent) => this.dispatchEvent(event));
+      this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.DRM_LICENSE_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, CustomEventType.MANIFEST_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, Html5EventType.ERROR, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._mediaSourceAdapter, Html5EventType.TIME_UPDATE, (event: FakeEvent) => this.dispatchEvent(event));

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -6,7 +6,7 @@ import {RequestType} from '../../../../request-type';
 import type {CodeType} from '../../../../error/code';
 import type {SeverityType} from '../../../../error/severity';
 import type {CategoryType} from '../../../../error/category';
-import {DrmScheme} from '../../../../playkit';
+import {DrmScheme} from '../../../../drm/drm-scheme';
 
 const KeySystem: string = 'com.apple.fps.1_0';
 type WebkitEventsType = {[name: string]: string};

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -25,6 +25,7 @@ class FairplayDrmHandler {
   _config: FairplayDrmConfigType;
   _onWebkitNeedKeyHandler: Function;
   _errorCallback: Function;
+  _drmResponseCallback: Function;
   _videoElement: HTMLVideoElement;
   _retryLicenseRequest: number = 4;
   _licenseRequestTime: number;
@@ -61,10 +62,12 @@ class FairplayDrmHandler {
    * @param {HTMLVideoElement} videoElement - the video element
    * @param {FairplayDrmConfigType} config - config object
    * @param {Function} errorCallback - error callback function
+   * @param {Function} drmResponseCallback - drm license response callback function
    */
-  constructor(videoElement: HTMLVideoElement, config: FairplayDrmConfigType, errorCallback: Function): void {
+  constructor(videoElement: HTMLVideoElement, config: FairplayDrmConfigType, errorCallback: Function, drmResponseCallback: Function): void {
     this._config = Utils.Object.mergeDeep({}, this._defaultConfig, config);
     this._errorCallback = errorCallback;
+    this._drmResponseCallback = drmResponseCallback;
     this._videoElement = videoElement;
     this._onWebkitNeedKeyHandler = e => this._onWebkitNeedKey(e);
     this._videoElement.addEventListener(WebkitEvents.NEED_KEY, this._onWebkitNeedKeyHandler, false);
@@ -183,6 +186,11 @@ class FairplayDrmHandler {
       });
       return;
     }
+    if (this._drmResponseCallback) {
+      const licenseTime = Date.now() - this._licenseRequestTime;
+      this._drmResponseCallback(licenseTime);
+    }
+
     const response = {data: request.response};
     this._logger.debug('Apply response filter');
     let responseFilterPromise;

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -27,6 +27,7 @@ class FairplayDrmHandler {
   _errorCallback: Function;
   _videoElement: HTMLVideoElement;
   _retryLicenseRequest: number = 4;
+  _licenseRequestTime: number;
   _defaultConfig: FairplayDrmConfigType = {
     licenseUrl: '',
     certificate: '',
@@ -144,6 +145,7 @@ class FairplayDrmHandler {
             responseText: request.responseText
           });
         };
+        this._licenseRequestTime = Date.now();
         request.send(updatedRequest.body);
       })
       .catch(error => {
@@ -192,6 +194,7 @@ class FairplayDrmHandler {
     responseFilterPromise = responseFilterPromise || Promise.resolve(response);
     responseFilterPromise
       .then(updatedResponse => {
+        // const licenseRequestResponse = Date.now();
         this._keySession.update(updatedResponse.data);
       })
       .catch(error => {

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -6,6 +6,7 @@ import {RequestType} from '../../../../request-type';
 import type {CodeType} from '../../../../error/code';
 import type {SeverityType} from '../../../../error/severity';
 import type {CategoryType} from '../../../../error/category';
+import {DrmScheme} from '../../../../playkit';
 
 const KeySystem: string = 'com.apple.fps.1_0';
 type WebkitEventsType = {[name: string]: string};
@@ -188,7 +189,7 @@ class FairplayDrmHandler {
     }
     if (this._drmResponseCallback) {
       const licenseTime = Date.now() - this._licenseRequestTime;
-      this._drmResponseCallback(licenseTime / 1000);
+      this._drmResponseCallback({licenseTime: licenseTime / 1000, scheme: DrmScheme.FAIRPLAY});
     }
 
     const response = {data: request.response};
@@ -202,7 +203,6 @@ class FairplayDrmHandler {
     responseFilterPromise = responseFilterPromise || Promise.resolve(response);
     responseFilterPromise
       .then(updatedResponse => {
-        // const licenseRequestResponse = Date.now();
         this._keySession.update(updatedResponse.data);
       })
       .catch(error => {

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -188,7 +188,7 @@ class FairplayDrmHandler {
     }
     if (this._drmResponseCallback) {
       const licenseTime = Date.now() - this._licenseRequestTime;
-      this._drmResponseCallback(licenseTime);
+      this._drmResponseCallback(licenseTime / 1000);
     }
 
     const response = {data: request.response};

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -233,11 +233,11 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   /**
    * dispatches the license response time after received
    * @private
-   * @param {number} licenseTime - the time between request and response of the license request
+   * @param {number} data - an object containing metrics regarding the license load
    * @returns {void}
    */
-  _dispatchDRMLicenseResponse(licenseTime: number): void {
-    this._trigger(CustomEventType.DRM_LICENSE_RESPONSE, {licenseTime: licenseTime});
+  _dispatchDRMLicenseResponseMetrics(data: any): void {
+    this._trigger(CustomEventType.DRM_LICENSE_LOADED, data);
   }
   /**
    * Sets the DRM playback in case such needed.
@@ -256,7 +256,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._videoElement,
         drmConfig,
         error => this._dispatchErrorCallback(error),
-        licenseTime => this._dispatchDRMLicenseResponse(licenseTime)
+        metrics => this._dispatchDRMLicenseResponseMetrics(metrics)
       );
     }
   }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -231,6 +231,15 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   }
 
   /**
+   * dispatches the license response time after received
+   * @private
+   * @param {number} licenseTime - the time between request and response of the license request
+   * @returns {void}
+   */
+  _dispatchDRMLicenseResponse(licenseTime: number): void {
+    this._trigger(CustomEventType.DRM_LICENSE_RESPONSE, {licenseTime: licenseTime});
+  }
+  /**
    * Sets the DRM playback in case such needed.
    * @private
    * @returns {void}
@@ -243,7 +252,12 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         network: this._config.network
       };
       NativeAdapter._drmProtocol.setDrmPlayback(drmConfig, this._sourceObj.drmData);
-      this._drmHandler = new FairplayDrmHandler(this._videoElement, drmConfig, error => this._dispatchErrorCallback(error));
+      this._drmHandler = new FairplayDrmHandler(
+        this._videoElement,
+        drmConfig,
+        error => this._dispatchErrorCallback(error),
+        licenseTime => this._dispatchDRMLicenseResponse(licenseTime)
+      );
     }
   }
 

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -233,10 +233,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   /**
    * dispatches the license response time after received
    * @private
-   * @param {number} data - an object containing metrics regarding the license load
+   * @param {number} data - an object containing data regarding the license load
    * @returns {void}
    */
-  _dispatchDRMLicenseResponseMetrics(data: any): void {
+  _dispatchDRMLicenseLoaded(data: any): void {
     this._trigger(CustomEventType.DRM_LICENSE_LOADED, data);
   }
   /**
@@ -256,7 +256,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._videoElement,
         drmConfig,
         error => this._dispatchErrorCallback(error),
-        metrics => this._dispatchDRMLicenseResponseMetrics(metrics)
+        data => this._dispatchDRMLicenseLoaded(data)
       );
     }
   }

--- a/src/event/event-type.js
+++ b/src/event/event-type.js
@@ -243,7 +243,11 @@ const CustomEventType: PKEventTypes = {
   /**
    * Fired when the user interact with the player ui
    */
-  USER_GESTURE: 'usergesture'
+  USER_GESTURE: 'usergesture',
+  /**
+   * Fired when the drm license request has been responded from DRM server
+   */
+  DRM_LICENSE_RESPONSE: 'drmlicenseresponse'
 };
 
 const EventType: PKEventTypes = Utils.Object.merge([Html5EventType, CustomEventType, AdEventType]);

--- a/src/event/event-type.js
+++ b/src/event/event-type.js
@@ -245,9 +245,9 @@ const CustomEventType: PKEventTypes = {
    */
   USER_GESTURE: 'usergesture',
   /**
-   * Fired when the drm license request has been responded from DRM server
+   * Fired when the drm license is responded from the DRM server
    */
-  DRM_LICENSE_RESPONSE: 'drmlicenseresponse'
+  DRM_LICENSE_LOADED: 'drmlicenseloaded'
 };
 
 const EventType: PKEventTypes = Utils.Object.merge([Html5EventType, CustomEventType, AdEventType]);

--- a/src/player.js
+++ b/src/player.js
@@ -1736,6 +1736,7 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this, AdEventType.AD_AUTOPLAY_FAILED, (event: FakeEvent) => this._onPlayFailed(event));
       this._eventManager.listen(this._engine, CustomEventType.FPS_DROP, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.FRAG_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
+      this._eventManager.listen(this._engine, CustomEventType.DRM_LICENSE_RESPONSE, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.MANIFEST_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this, Html5EventType.PLAY, this._onPlay.bind(this));
       this._eventManager.listen(this, Html5EventType.PAUSE, this._onPause.bind(this));

--- a/src/player.js
+++ b/src/player.js
@@ -1736,7 +1736,7 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this, AdEventType.AD_AUTOPLAY_FAILED, (event: FakeEvent) => this._onPlayFailed(event));
       this._eventManager.listen(this._engine, CustomEventType.FPS_DROP, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.FRAG_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
-      this._eventManager.listen(this._engine, CustomEventType.DRM_LICENSE_RESPONSE, (event: FakeEvent) => this.dispatchEvent(event));
+      this._eventManager.listen(this._engine, CustomEventType.DRM_LICENSE_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.MANIFEST_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this, Html5EventType.PLAY, this._onPlay.bind(this));
       this._eventManager.listen(this, Html5EventType.PAUSE, this._onPause.bind(this));


### PR DESCRIPTION
### Description of the Changes

Created new CustomEventType DRM_LICENSE_RESPONSE which bubble till the player and added code to FairplayDrmHandler to calc the license time from request to response

Solves FEC-9109

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
