### PR TITLE
fix(FEC-9605): load middleware called twice when preload is 'auto'

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -544,7 +544,11 @@ export default class Player extends FakeEventTarget {
         this._eventManager.listenOnce(this, CustomEventType.SOURCE_SELECTED, () => this._load());
       }
     };
-    this._playbackMiddleware.load(() => loadPlayer());
+    if (!this.src) {
+      this._playbackMiddleware.load(() => loadPlayer());
+    } else {
+      Player._logger.debug('The source has already been loaded. load request ignored');
+    }
   }
 
   /**
@@ -558,8 +562,8 @@ export default class Player extends FakeEventTarget {
       this.dispatchEvent(new FakeEvent(CustomEventType.PLAYBACK_START));
       if (!this.src) {
         this._prepareVideoElement();
-        this.load();
       }
+      this.load();
     }
     if (this._engine) {
       this._playbackMiddleware.play(() => this._play());

--- a/src/player.js
+++ b/src/player.js
@@ -558,8 +558,8 @@ export default class Player extends FakeEventTarget {
       this.dispatchEvent(new FakeEvent(CustomEventType.PLAYBACK_START));
       if (!this.src) {
         this._prepareVideoElement();
+        this.load();
       }
-      this.load();
     }
     if (this._engine) {
       this._playbackMiddleware.play(() => this._play());

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -74,7 +74,7 @@ describe('Player', function() {
       player.load();
     });
 
-    it.only("should't load if source already exists", done => {
+    it("should't load if source already exists", done => {
       player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
         sandbox.stub(player, '_load').callsFake(function() {
           done(new Error("should't load if source already exists"));

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -34,7 +34,7 @@ describe('Player', function() {
   });
 
   describe('load', function() {
-    let config, player, playerContainer;
+    let config, player, playerContainer, sandbox;
 
     before(() => {
       playerContainer = createElement('DIV', targetId);
@@ -43,11 +43,13 @@ describe('Player', function() {
     });
 
     beforeEach(() => {
+      sandbox = sinon.sandbox.create();
       player = new Player(config);
       playerContainer.appendChild(player.getView());
     });
 
     afterEach(() => {
+      sandbox.restore();
       player.destroy();
     });
 
@@ -72,15 +74,13 @@ describe('Player', function() {
       player.load();
     });
 
-    it("should't load if source already exists", done => {
-      let loadCounter = 0;
-      setTimeout(() => {
-        loadCounter.should.equal(1);
-        done();
-      }, 1000);
+    it.only("should't load if source already exists", done => {
       player.addEventListener(CustomEventType.TRACKS_CHANGED, () => {
-        loadCounter++;
-        setTimeout(() => player.load(), 200);
+        sandbox.stub(player, '_load').callsFake(function() {
+          done(new Error("should't load if source already exists"));
+        });
+        player.load();
+        done();
       });
       player.load();
     });


### PR DESCRIPTION
### Description of the Changes

don't call `load` if `src` already exists

Sloves FEC-9605

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
