### PR TITLE
feat: enrich the response filter params

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1043,11 +1043,61 @@ var config = {
 > >
 > > ### config.network.requestFilter
 > >
-> > ##### Type: `function`
+> > ##### Type: `function(type: PKRequestType, request: PKRequestObject): (void | Promise<PKRequestObject>)`
 > >
 > > ##### Default: `-`
 > >
 > > ##### Description: Defines a filter for requests. This filter takes the request and modifies it before it is sent. A request filter can run asynchronously by returning a promise; in this case, the request will not be sent until the promise is resolved.
+> >
+> >  ##
+> >
+> > > ##### Type: PKRequestType
+> > >
+> > > ```js
+> > > {
+> > >   MANIFEST: 0,
+> > >   SEGMENT: 1,
+> > >   LICENSE: 2
+> > > }
+> > > ```
+> > >
+> > > ##
+> > >
+> > > ##### Type: PKRequestObject
+> > >
+> > > ```js
+> > > {
+> > >   url: string,
+> > >   body: ?string | ArrayBuffer,
+> > >   headers: { [header: string] : string }
+> > > }
+> > > ```
+> > >
+> > > ##
+> > > 
+> > > > ##### `PKRequestObject.url`
+> > > >
+> > > > ##### Type: `string`
+> > > >
+> > > > ##### Description: The request URL.
+> > > >
+> > > > ##
+> > > >
+> > > > ##### `PKRequestObject.body`
+> > > >
+> > > > ##### Type: `string || ArrayBuffer`
+> > > >
+> > > > ##### Description: The body of the request.
+> > > >
+> > > > ##
+> > > >
+> > > > ##### `PKRequestObject.headers`
+> > > >
+> > > > ##### Type: `{ [header: string] : string }`
+> > > >
+> > > > ##### Description: A mapping of headers for the request. e.g.: {'HEADER': 'VALUE'}.
+> >
+> > ##
 > >
 > > #### Examples:
 > >
@@ -1081,11 +1131,70 @@ var config = {
 > >
 > > ### config.network.responseFilter
 > >
-> > ##### Type: `function`
+> > ##### Type: `function(type: PKRequestType, request: PKResponseObject): (void | Promise<PKResponseObject>)`
 > >
 > > ##### Default: `-`
 > >
 > > ##### Description: Defines a filter for responses. This filter takes the response and modifies it before it is returned. A response filter can run asynchronously by returning a promise.
+> >
+> >  ##
+> >
+> > > ##### Type: PKRequestType
+> > >
+> > > ```js
+> > > {
+> > >   MANIFEST: 0,
+> > >   SEGMENT: 1,
+> > >   LICENSE: 2
+> > > }
+> > > ```
+> > >
+> > > ##
+> > >
+> > > ##### Type: PKResponseObject
+> > >
+> > > ```js
+> > > {
+> > >   url: string,
+> > >   originalUrl: string,
+> > >   data: ArrayBuffer,
+> > >   headers: { [header: string] : string }
+> > > }
+> > > ```
+> > >
+> > > ##
+> > > 
+> > > > ##### `PKResponseObject.url`
+> > > >
+> > > > ##### Type: `string`
+> > > >
+> > > > ##### Description: The URI which was loaded. Request filters and server redirects can cause this to be different from the original request URIs.
+> > > >
+> > > > ##
+> > > >
+> > > > ##### `PKResponseObject.originalUrl`
+> > > >
+> > > > ##### Type: `string`
+> > > >
+> > > > ##### Description: The original URI passed to the browser for networking. This is before any redirects, but after request filters are executed.
+> > > >
+> > > > ##
+> > > >
+> > > > ##### `PKResponseObject.body`
+> > > >
+> > > > ##### Type: `ArrayBuffer`
+> > > >
+> > > > ##### Description: The body of the response.
+> > > >
+> > > > ##
+> > > >
+> > > > ##### `PKResponseObject.headers`
+> > > >
+> > > > ##### Type: `{ [header: string] : string }`
+> > > >
+> > > > ##### Description: A map of response headers, if supported by the underlying protocol. All keys should be lowercased. For HTTP/HTTPS, may not be available cross-origin.
+> >
+> > ##
 > >
 > > #### Examples:
 > >

--- a/flow-typed/types/response.js
+++ b/flow-typed/types/response.js
@@ -1,0 +1,4 @@
+// @flow
+declare type PKResponseObject = {
+  data: ArrayBuffer
+};

--- a/flow-typed/types/response.js
+++ b/flow-typed/types/response.js
@@ -1,4 +1,7 @@
 // @flow
 declare type PKResponseObject = {
-  data: ArrayBuffer
+  url: string,
+  originalUrl: string,
+  data: ArrayBuffer,
+  headers: { [header: string] : string }
 };

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -192,15 +192,15 @@ class FairplayDrmHandler {
       this._drmResponseCallback({licenseTime: licenseTime / 1000, scheme: DrmScheme.FAIRPLAY});
     }
 
-    const response = {data: request.response};
+    const pkResponse: PKResponseObject = {data: request.response};
     this._logger.debug('Apply response filter');
     let responseFilterPromise;
     try {
-      responseFilterPromise = this._config.network.responseFilter(RequestType.LICENSE, response);
+      responseFilterPromise = this._config.network.responseFilter(RequestType.LICENSE, pkResponse);
     } catch (error) {
       responseFilterPromise = Promise.reject(error);
     }
-    responseFilterPromise = responseFilterPromise || Promise.resolve(response);
+    responseFilterPromise = responseFilterPromise || Promise.resolve(pkResponse);
     responseFilterPromise
       .then(updatedResponse => {
         this._keySession.update(updatedResponse.data);

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -191,8 +191,11 @@ class FairplayDrmHandler {
       const licenseTime = Date.now() - this._licenseRequestTime;
       this._drmResponseCallback({licenseTime: licenseTime / 1000, scheme: DrmScheme.FAIRPLAY});
     }
+    const {responseURL: url, response: data} = request;
+    const originalUrl = this._config.licenseUrl;
+    const headers = Utils.Http.convertHeaderRowToMap(request.getAllResponseHeaders());
 
-    const pkResponse: PKResponseObject = {data: request.response};
+    const pkResponse: PKResponseObject = {url, originalUrl, data, headers};
     this._logger.debug('Apply response filter');
     let responseFilterPromise;
     try {

--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.js
@@ -193,7 +193,7 @@ class FairplayDrmHandler {
     }
     const {responseURL: url, response: data} = request;
     const originalUrl = this._config.licenseUrl;
-    const headers = Utils.Http.convertHeaderRowToMap(request.getAllResponseHeaders());
+    const headers = Utils.Http.convertHeadersToDictionary(request.getAllResponseHeaders());
 
     const pkResponse: PKResponseObject = {url, originalUrl, data, headers};
     this._logger.debug('Apply response filter');

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -495,7 +495,7 @@ const _Http = {
     });
   },
   jsonp: jsonp,
-  convertHeaderRowToMap: function(headerRow: string): {[header: string]: string} {
+  convertHeadersToDictionary: function(headerRow: string): {[header: string]: string} {
     let headerMap = {};
     try {
       // Convert the header string into an array of individual headers

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -494,7 +494,25 @@ const _Http = {
       request.send(params);
     });
   },
-  jsonp: jsonp
+  jsonp: jsonp,
+  convertHeaderRowToMap: function(headerRow: string): {[header: string]: string} {
+    let headerMap = {};
+    try {
+      // Convert the header string into an array of individual headers
+      const arr = headerRow.trim().split(/[\r\n]+/);
+
+      // Create a map of header names to values
+      arr.forEach(function(line) {
+        const parts = line.split(': ');
+        const header = parts.shift().toLowerCase();
+        const value = parts.join(': ');
+        headerMap[header] = value;
+      });
+    } catch (e) {
+      // do nothing
+    }
+    return headerMap;
+  }
 };
 
 const _VERSION = {

--- a/test/src/engines/html5/media-source/adapters/fairplay-drm-handler.spec.js
+++ b/test/src/engines/html5/media-source/adapters/fairplay-drm-handler.spec.js
@@ -89,6 +89,30 @@ describe('Fairplay Drm Handler', function() {
       e.data.should.equal('error');
     };
 
+    it('should pass the params to the request filter', done => {
+      Utils.Object.mergeDeep(fpsDrmData, {
+        network: {
+          requestFilter: function(type, request) {
+            try {
+              type.should.equal(RequestType.LICENSE);
+              request.url.should.equal(fpsDrmData.licenseUrl);
+              request.body.should.be.exist;
+              request.headers.should.be.exist;
+            } catch (e) {
+              done(e);
+            }
+          }
+        }
+      });
+      sandbox.stub(XMLHttpRequest.prototype, 'open', () => {
+        done();
+      });
+      const fp = new FairplayDrmHandler(videoElement, fpsDrmData, () => {});
+      fp._onWebkitKeyMessage({
+        message: new Uint8Array(new ArrayBuffer(1))
+      });
+    });
+
     it('should apply void filter for license', done => {
       Utils.Object.mergeDeep(fpsDrmData, {
         network: {
@@ -231,6 +255,29 @@ describe('Fairplay Drm Handler', function() {
       e.data.should.equal('error');
     };
 
+    it('should pass the params to the response filter', done => {
+      Utils.Object.mergeDeep(fpsDrmData, {
+        network: {
+          responseFilter: function(type, response) {
+            try {
+              type.should.equal(RequestType.LICENSE);
+              response.url.should.be.exist;
+              response.originalUrl.should.equal(fpsDrmData.licenseUrl);
+              response.data.should.be.exist;
+              response.headers.should.be.exist;
+              done();
+            } catch (e) {
+              done(e);
+            }
+          }
+        }
+      });
+      const fp = new FairplayDrmHandler(videoElement, fpsDrmData, () => {});
+      fp._licenseRequestLoaded({
+        target: new XMLHttpRequest()
+      });
+    });
+
     it('should apply void filter for license', done => {
       Utils.Object.mergeDeep(fpsDrmData, {
         network: {
@@ -253,9 +300,7 @@ describe('Fairplay Drm Handler', function() {
         }
       };
       fp._licenseRequestLoaded({
-        target: {
-          response: {}
-        }
+        target: new XMLHttpRequest()
       });
     });
 
@@ -284,9 +329,7 @@ describe('Fairplay Drm Handler', function() {
         }
       };
       fp._licenseRequestLoaded({
-        target: {
-          response: {}
-        }
+        target: new XMLHttpRequest()
       });
     });
 
@@ -307,9 +350,7 @@ describe('Fairplay Drm Handler', function() {
         }
       });
       fp._licenseRequestLoaded({
-        target: {
-          response: {}
-        }
+        target: new XMLHttpRequest()
       });
     });
 
@@ -332,9 +373,7 @@ describe('Fairplay Drm Handler', function() {
         }
       });
       fp._licenseRequestLoaded({
-        target: {
-          response: {}
-        }
+        target: new XMLHttpRequest()
       });
     });
 
@@ -357,9 +396,7 @@ describe('Fairplay Drm Handler', function() {
         }
       });
       fp._licenseRequestLoaded({
-        target: {
-          response: {}
-        }
+        target: new XMLHttpRequest()
       });
     });
   });

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -1051,6 +1051,25 @@ describe('NativeAdapter: request filter', () => {
     e.payload.data.should.equal('error');
   };
 
+  it('should pass the params to the request filter', done => {
+    nativeInstance = NativeAdapter.createAdapter(video, sourcesConfig.Mp4.progressive[0], {
+      network: {
+        requestFilter: function(type, request) {
+          try {
+            type.should.equal(RequestType.MANIFEST);
+            request.url.should.equal(sourcesConfig.Mp4.progressive[0].url);
+            request.hasOwnProperty('body').should.be.true;
+            request.headers.should.be.exist;
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+      }
+    });
+    nativeInstance.load();
+  });
+
   it('should apply void filter for manifest', done => {
     nativeInstance = NativeAdapter.createAdapter(video, sourcesConfig.Mp4.progressive[0], {
       network: {

--- a/test/src/utils/util.spec.js
+++ b/test/src/utils/util.spec.js
@@ -225,7 +225,7 @@ describe('util', () => {
   });
 
   describe('Http', function() {
-    describe('convertHeaderRowToMap', function() {
+    describe('convertHeadersToDictionary', function() {
       it('Should convert header row to map', function() {
         const headerRow = `cache-control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
 content-length: 3201
@@ -237,7 +237,7 @@ server: Apache/2.4.18 (Ubuntu)
 x-kaltura-session: 2089078255
 x-me: qa-apache-php7, qa-apache-php7
     `;
-        const headerMap = Utils.Http.convertHeaderRowToMap(headerRow);
+        const headerMap = Utils.Http.convertHeadersToDictionary(headerRow);
         headerMap['cache-control'].should.equal('no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
         headerMap['content-length'].should.equal('3201');
         headerMap['content-type'].should.equal('application/json');
@@ -255,7 +255,7 @@ content-lenGth: 3201
 conTent-type: application/json
 date: Wed, 25 Mar 2020 12:48:28 GMT
       `;
-        const headerMap = Utils.Http.convertHeaderRowToMap(headerRow);
+        const headerMap = Utils.Http.convertHeadersToDictionary(headerRow);
         headerMap['cache-control'].should.equal('no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
         headerMap['content-length'].should.equal('3201');
         headerMap['content-type'].should.equal('application/json');
@@ -263,7 +263,7 @@ date: Wed, 25 Mar 2020 12:48:28 GMT
       });
 
       it('Should return empty object for null', function() {
-        Utils.Http.convertHeaderRowToMap().should.deep.equals({});
+        Utils.Http.convertHeadersToDictionary().should.deep.equals({});
       });
     });
   });

--- a/test/src/utils/util.spec.js
+++ b/test/src/utils/util.spec.js
@@ -223,4 +223,48 @@ describe('util', () => {
       });
     });
   });
+
+  describe('Http', function() {
+    describe('convertHeaderRowToMap', function() {
+      it('Should convert header row to map', function() {
+        const headerRow = `cache-control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+content-length: 3201
+content-type: application/json
+date: Wed, 25 Mar 2020 12:48:28 GMT
+expires: Sun, 19 Nov 2000 08:52:00 GMT
+pragma: no-cache
+server: Apache/2.4.18 (Ubuntu)
+x-kaltura-session: 2089078255
+x-me: qa-apache-php7, qa-apache-php7
+    `;
+        const headerMap = Utils.Http.convertHeaderRowToMap(headerRow);
+        headerMap['cache-control'].should.equal('no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+        headerMap['content-length'].should.equal('3201');
+        headerMap['content-type'].should.equal('application/json');
+        headerMap['date'].should.equal('Wed, 25 Mar 2020 12:48:28 GMT');
+        headerMap['expires'].should.equal('Sun, 19 Nov 2000 08:52:00 GMT');
+        headerMap['pragma'].should.equal('no-cache');
+        headerMap['server'].should.equal('Apache/2.4.18 (Ubuntu)');
+        headerMap['x-kaltura-session'].should.equal('2089078255');
+        headerMap['x-me'].should.equal('qa-apache-php7, qa-apache-php7');
+      });
+
+      it('Should convert All keys to lowercased', function() {
+        const headerRow = `cache-CONTROL: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+content-lenGth: 3201
+conTent-type: application/json
+date: Wed, 25 Mar 2020 12:48:28 GMT
+      `;
+        const headerMap = Utils.Http.convertHeaderRowToMap(headerRow);
+        headerMap['cache-control'].should.equal('no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+        headerMap['content-length'].should.equal('3201');
+        headerMap['content-type'].should.equal('application/json');
+        headerMap['date'].should.equal('Wed, 25 Mar 2020 12:48:28 GMT');
+      });
+
+      it('Should return empty object for null', function() {
+        Utils.Http.convertHeaderRowToMap().should.deep.equals({});
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description of the Changes

* add `url, originalUrl, header` to the `responseFilter` handler
* add `PKResponseObject` type with `url, originalUrl, data, headers`
* add new util `Http. convertHeadersToDictionary`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
