### PR TITLE
fix(FEC-9997): out of DVR window will lead to live edge

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2036,7 +2036,7 @@ export default class Player extends FakeEventTarget {
     }
     this.ready()
       .then(() => {
-        if (this.isLive() && !this.isDvr()) {
+        if (this.isLive() && (!this.isDvr() || (this.isDvr() && this.currentTime <= 0))) {
           this.seekToLiveEdge();
         }
         this._engine.play();

--- a/src/player.js
+++ b/src/player.js
@@ -2036,7 +2036,7 @@ export default class Player extends FakeEventTarget {
     }
     this.ready()
       .then(() => {
-        if (this.isLive() && (!this.isDvr() || (this.isDvr() && this.currentTime <= 0))) {
+        if (this.isLive() && (!this.isDvr() || (this.isDvr() && typeof this.currentTime === 'number' && this.currentTime <= 0))) {
           this.seekToLiveEdge();
         }
         this._engine.play();

--- a/src/player.js
+++ b/src/player.js
@@ -2036,7 +2036,7 @@ export default class Player extends FakeEventTarget {
     }
     this.ready()
       .then(() => {
-        if (this.isLive() && (!this.isDvr() || (this.isDvr() && typeof this.currentTime === 'number' && this.currentTime <= 0))) {
+        if (this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0))) {
           this.seekToLiveEdge();
         }
         this._engine.play();


### PR DESCRIPTION
### Description of the Changes

if the current time is negative then it means that the player is out of the DVR window.
DVR out of the window should seek to live edge.
Solve FEC-9997.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
