### PR TITLE
fix(FEC-10014): Content playback fails when user minimise the browser on IOS

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -307,7 +307,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
         this._eventManager.listen(window, 'focus', () =>
           setTimeout(() => {
-            this._videoElement.currentTime = Math.max(0, this._videoElement.currentTime - 0.1);
+            this._videoElement.currentTime = this._videoElement.currentTime > 0.1 ? this._videoElement.currentTime - 0.1 : 0;
             this._syncCurrentTime();
           }, BACK_TO_FOCUS_TIMEOUT)
         );

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -17,6 +17,7 @@ import type {FairplayDrmConfigType} from './fairplay-drm-handler';
 
 const BACK_TO_FOCUS_TIMEOUT: number = 1000;
 const MAX_MEDIA_RECOVERY_ATTEMPTS: number = 3;
+const NUDGE_SEEK_AFTER_FOCUS: number = 0.1;
 
 /**
  * An illustration of media source extension for progressive download
@@ -307,7 +308,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
         this._eventManager.listen(window, 'focus', () =>
           setTimeout(() => {
-            this._videoElement.currentTime = this._videoElement.currentTime > 0.1 ? this._videoElement.currentTime - 0.1 : 0;
+            // In IOS HLS, sometimes when coming back from lock screen/Idle mode, the stream will get stuck, and only a small seek nudge will fix it.
+            this._videoElement.currentTime =
+              this._videoElement.currentTime > NUDGE_SEEK_AFTER_FOCUS ? this._videoElement.currentTime - NUDGE_SEEK_AFTER_FOCUS : 0;
             this._syncCurrentTime();
           }, BACK_TO_FOCUS_TIMEOUT)
         );

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -17,6 +17,7 @@ import type {FairplayDrmConfigType} from './fairplay-drm-handler';
 
 const BACK_TO_FOCUS_TIMEOUT: number = 1000;
 const MAX_MEDIA_RECOVERY_ATTEMPTS: number = 3;
+let SEEK_AFTER_FOCUS: boolean = false;
 
 /**
  * An illustration of media source extension for progressive download
@@ -305,7 +306,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._eventManager.listen(this._videoElement, Html5EventType.ABORT, () => this._clearHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.SEEKED, () => this._syncCurrentTime());
         // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
-        this._eventManager.listen(window, 'focus', () => setTimeout(() => this._syncCurrentTime(), BACK_TO_FOCUS_TIMEOUT));
+        this._eventManager.listen(window, 'focus', () => setTimeout(() => this._syncCurrentTime(), BACK_TO_FOCUS_TIMEOUT, (SEEK_AFTER_FOCUS = true)));
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();
         }
@@ -461,6 +462,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   }
 
   _syncCurrentTime(): void {
+    if (SEEK_AFTER_FOCUS) {
+      this._videoElement.currentTime -= 0.1;
+    }
+    SEEK_AFTER_FOCUS = false;
     this._lastTimeUpdate = this._videoElement.currentTime;
   }
 

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -306,7 +306,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._eventManager.listen(this._videoElement, Html5EventType.SEEKED, () => this._syncCurrentTime());
         // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
         this._eventManager.listen(window, 'focus', () =>
-          setTimeout(() => this._syncCurrentTime((this._videoElement.currentTime -= 0.1)), BACK_TO_FOCUS_TIMEOUT)
+          setTimeout(() => {
+            this._videoElement.currentTime = Math.max(0, this._videoElement.currentTime - 0.1);
+            this._syncCurrentTime();
+          }, BACK_TO_FOCUS_TIMEOUT)
         );
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -17,7 +17,6 @@ import type {FairplayDrmConfigType} from './fairplay-drm-handler';
 
 const BACK_TO_FOCUS_TIMEOUT: number = 1000;
 const MAX_MEDIA_RECOVERY_ATTEMPTS: number = 3;
-let SEEK_AFTER_FOCUS: boolean = false;
 
 /**
  * An illustration of media source extension for progressive download
@@ -306,7 +305,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._eventManager.listen(this._videoElement, Html5EventType.ABORT, () => this._clearHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.SEEKED, () => this._syncCurrentTime());
         // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
-        this._eventManager.listen(window, 'focus', () => setTimeout(() => this._syncCurrentTime(), BACK_TO_FOCUS_TIMEOUT, (SEEK_AFTER_FOCUS = true)));
+        this._eventManager.listen(window, 'focus', () =>
+          setTimeout(() => this._syncCurrentTime((this._videoElement.currentTime -= 0.1)), BACK_TO_FOCUS_TIMEOUT)
+        );
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();
         }
@@ -462,10 +463,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   }
 
   _syncCurrentTime(): void {
-    if (SEEK_AFTER_FOCUS) {
-      this._videoElement.currentTime -= 0.1;
-    }
-    SEEK_AFTER_FOCUS = false;
     this._lastTimeUpdate = this._videoElement.currentTime;
   }
 


### PR DESCRIPTION
### Description of the Changes

The player is broken when switching between tabs or just minimising Safari.
The original issue has occurred here FEC-8873  however was resolved only for ad use case.
In addition, the main issue is still occuring and the bug is still open with apple: https://bugs.webkit.org/show_bug.cgi?id=195452

As a current solutions I have implemented a nudge to the seek in order to bypass the issue when returning from "Idle" mode.

### CheckLists

- [X] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [X] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
