### PR TITLE
fix(FEC-10122): clear drop frame watcher and DRM selection

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -211,13 +211,13 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   reset(): void {
     this._eventManager.removeAll();
-    if (this._mediaSourceAdapter) {
-      this._canLoadMediaSourceAdapterPromise = this._mediaSourceAdapter.destroy();
-      this._mediaSourceAdapter = null;
-    }
     if (this._droppedFramesWatcher) {
       this._droppedFramesWatcher.destroy();
       this._droppedFramesWatcher = null;
+    }
+    if (this._mediaSourceAdapter) {
+      this._canLoadMediaSourceAdapterPromise = this._mediaSourceAdapter.destroy();
+      this._mediaSourceAdapter = null;
     }
     if (this._el && this._el.src) {
       Utils.Dom.setAttribute(this._el, 'src', '');
@@ -239,13 +239,13 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     }
     this._eventManager.destroy();
     MediaSourceProvider.destroy();
-    if (this._mediaSourceAdapter) {
-      this._mediaSourceAdapter.destroy();
-      this._mediaSourceAdapter = null;
-    }
     if (this._droppedFramesWatcher) {
       this._droppedFramesWatcher.destroy();
       this._droppedFramesWatcher = null;
+    }
+    if (this._mediaSourceAdapter) {
+      this._mediaSourceAdapter.destroy();
+      this._mediaSourceAdapter = null;
     }
   }
 

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -51,7 +51,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @private
    */
   _canLoadMediaSourceAdapterPromise: Promise<*>;
-  _droppedFramesWatcher: DroppedFramesWatcher;
+  _droppedFramesWatcher: ?DroppedFramesWatcher;
 
   /**
    * The html5 class logger.

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -212,10 +212,12 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   reset(): void {
     this._eventManager.removeAll();
     if (this._mediaSourceAdapter) {
-      this._droppedFramesWatcher.destroy();
-      this._droppedFramesWatcher = null;
       this._canLoadMediaSourceAdapterPromise = this._mediaSourceAdapter.destroy();
       this._mediaSourceAdapter = null;
+    }
+    if (this._droppedFramesWatcher) {
+      this._droppedFramesWatcher.destroy();
+      this._droppedFramesWatcher = null;
     }
     if (this._el && this._el.src) {
       Utils.Dom.setAttribute(this._el, 'src', '');
@@ -230,7 +232,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   destroy(): void {
     this.detach();
-    this._droppedFramesWatcher.destroy();
     if (this._el) {
       this.pause();
       Utils.Dom.removeAttribute(this._el, 'src');
@@ -241,6 +242,10 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     if (this._mediaSourceAdapter) {
       this._mediaSourceAdapter.destroy();
       this._mediaSourceAdapter = null;
+    }
+    if (this._droppedFramesWatcher) {
+      this._droppedFramesWatcher.destroy();
+      this._droppedFramesWatcher = null;
     }
   }
 

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -212,6 +212,8 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   reset(): void {
     this._eventManager.removeAll();
     if (this._mediaSourceAdapter) {
+      this._droppedFramesWatcher.destroy();
+      this._droppedFramesWatcher = null;
       this._canLoadMediaSourceAdapterPromise = this._mediaSourceAdapter.destroy();
       this._mediaSourceAdapter = null;
     }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -157,6 +157,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @static
    */
   static canPlayDrm(drmData: Array<Object>, drmConfig: PKDrmConfigObject): boolean {
+    NativeAdapter._drmProtocol = null;
     for (let drmProtocol of NativeAdapter._drmProtocols) {
       if (drmProtocol.isConfigured(drmData, drmConfig)) {
         NativeAdapter._drmProtocol = drmProtocol;

--- a/test/src/engines/html5/html5.spec.js
+++ b/test/src/engines/html5/html5.spec.js
@@ -1,6 +1,7 @@
 import Html5 from '../../../../src/engines/html5/html5';
 import BaseMediaSourceAdapter from '../../../../src/engines/html5/media-source/base-media-source-adapter';
 import sourcesConfig from '../../configs/sources.json';
+import {DroppedFramesWatcher} from '../../../../src/engines/dropped-frames-watcher';
 
 describe('Html5', () => {
   let sandbox;
@@ -67,6 +68,7 @@ describe('Html5', () => {
     const pauseSpy = sandbox.spy(engine, 'pause');
     const eventMgrSpy = sandbox.spy(engine._eventManager, 'destroy');
     const mediaSourceAdapterSpy = sandbox.spy(engine._mediaSourceAdapter, 'destroy');
+    const droppedFramesWatcherSpy = sandbox.spy(engine._droppedFramesWatcher, 'destroy');
     engine._eventManager.should.exist;
     engine._config.should.deep.equal(config);
     engine._mediaSourceAdapter.should.be.instanceof(BaseMediaSourceAdapter);
@@ -76,6 +78,41 @@ describe('Html5', () => {
     pauseSpy.should.have.been.calledOnce;
     eventMgrSpy.should.have.been.calledOnce;
     mediaSourceAdapterSpy.should.have.been.calledOnce;
+    droppedFramesWatcherSpy.should.have.been.calledOnce;
     engine._el.src.should.be.empty;
+  });
+
+  it('should create, reset and init html5 engine', () => {
+    const hlsSource = sourcesConfig.Mp4.progressive[0];
+    const config = {
+      sources: sourcesConfig.Hls,
+      abr: {
+        fpsDroppedFramesInterval: 5000,
+        fpsDroppedMonitoringThreshold: 0.2,
+        capLevelOnFPSDrop: true
+      }
+    };
+    let engine = Html5.createEngine(hlsSource, config);
+    const eventMgrSpy = sandbox.spy(engine._eventManager, 'removeAll');
+    engine._eventManager.should.exist;
+    engine._config.should.deep.equal(config);
+    engine._mediaSourceAdapter.should.be.instanceof(BaseMediaSourceAdapter);
+    const mediaSourceAdapterSpy = sandbox.spy(engine._mediaSourceAdapter, 'destroy');
+    engine._droppedFramesWatcher.should.be.instanceof(DroppedFramesWatcher);
+    const droppedFramesWatcherSpy = sandbox.spy(engine._droppedFramesWatcher, 'destroy');
+    engine._el.should.be.a('HTMLVideoElement');
+    engine.reset();
+    eventMgrSpy.should.have.been.calledOnce;
+    engine._el.src.should.be.empty;
+    (engine._mediaSourceAdapter === null).should.be.equal(true);
+    (engine._droppedFramesWatcher === null).should.be.equal(true);
+    mediaSourceAdapterSpy.should.have.been.calledOnce;
+    droppedFramesWatcherSpy.should.have.been.calledOnce;
+    engine._init(hlsSource, config);
+    engine._eventManager.should.exist;
+    engine._config.should.deep.equal(config);
+    engine._mediaSourceAdapter.should.be.instanceof(BaseMediaSourceAdapter);
+    engine._droppedFramesWatcher.should.be.instanceof(DroppedFramesWatcher);
+    engine._el.should.be.a('HTMLVideoElement');
   });
 });

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -56,13 +56,11 @@ describe('NativeAdapter: canPlayType', () => {
 describe('NativeAdapter: canPlayDrm', () => {
   const fpDrmData = [{licenseUrl: 'LICENSE_URL', scheme: FairPlay.DrmScheme.FAIRPLAY}];
 
-  beforeEach(() => {
-    NativeAdapter._drmProtocol = null;
-  });
-
-  it('should return true for fairplay data if configured', function() {
+  it('should return true for fairplay data if configured and false to configuration without fairplay', function() {
     NativeAdapter.canPlayDrm(fpDrmData, {keySystem: FairPlay.DrmScheme.FAIRPLAY}).should.be.true;
     NativeAdapter._drmProtocol._KeySystem.should.equal(FairPlay._KeySystem);
+    NativeAdapter.canPlayDrm(fpDrmData, {}).should.be.false;
+    (NativeAdapter._drmProtocol === null).should.be.true;
   });
 });
 


### PR DESCRIPTION
### Description of the Changes

destroy dropped frames watcher on reset to avoid a memory leak.
clear the DRM selection for the use case of loading another media without DRM keeps selection.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
