### PR TITLE
fix(FEC-10267): Ad controls are disappearing in DAI LIVE playback

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2073,8 +2073,13 @@ export default class Player extends FakeEventTarget {
     this.ready()
       .then(() => {
         const liveOrDvrOutOfDvrWindow = this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0));
-        if (!(this._adsController && this._adsController.isAdBreak()) && liveOrDvrOutOfDvrWindow) {
-          this.seekToLiveEdge();
+        if (liveOrDvrOutOfDvrWindow) {
+          if (this._adsController && this._adsController.isAdBreak()) {
+            this._eventManager.unlisten(this, AdEventType.AD_BREAK_END, this.seekToLiveEdge);
+            this._eventManager.listenOnce(this, AdEventType.AD_BREAK_END, this.seekToLiveEdge);
+          } else {
+            this.seekToLiveEdge();
+          }
         }
         this._engine.play();
       })

--- a/src/player.js
+++ b/src/player.js
@@ -2072,7 +2072,8 @@ export default class Player extends FakeEventTarget {
     }
     this.ready()
       .then(() => {
-        if (this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0))) {
+        const liveOrDvrOutOfDvrWindow = (this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0)));
+        if (!this._adsController.isAdBreak() && liveOrDvrOutOfDvrWindow) {
           this.seekToLiveEdge();
         }
         this._engine.play();

--- a/src/player.js
+++ b/src/player.js
@@ -2075,8 +2075,11 @@ export default class Player extends FakeEventTarget {
         const liveOrDvrOutOfDvrWindow = this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0));
         if (liveOrDvrOutOfDvrWindow) {
           if (this._adsController && this._adsController.isAdBreak()) {
-            this._eventManager.unlisten(this, AdEventType.AD_BREAK_END, this.seekToLiveEdge);
-            this._eventManager.listenOnce(this, AdEventType.AD_BREAK_END, this.seekToLiveEdge);
+            this._eventManager.listenOnce(this, AdEventType.AD_BREAK_END, () => {
+              if (!this._isOnLiveEdge) {
+                this.seekToLiveEdge();
+              }
+            });
           } else {
             this.seekToLiveEdge();
           }

--- a/src/player.js
+++ b/src/player.js
@@ -2072,8 +2072,8 @@ export default class Player extends FakeEventTarget {
     }
     this.ready()
       .then(() => {
-        const liveOrDvrOutOfDvrWindow = (this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0)));
-        if (!this._adsController.isAdBreak() && liveOrDvrOutOfDvrWindow) {
+        const liveOrDvrOutOfDvrWindow = this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0));
+        if (!(this._adsController && this._adsController.isAdBreak()) && liveOrDvrOutOfDvrWindow) {
           this.seekToLiveEdge();
         }
         this._engine.play();


### PR DESCRIPTION
### Description of the Changes

Issue: IMA DAI live, player seek to live edge during ad since it's our expected behavior on live.
Solution: add a check for an active ad break, don't seek an active ad break.

Solve FEC-10267

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
