### PR TITLE
fix(FEC-10335): ad doesn't play correctly on same video tag with MSE

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1811,11 +1811,10 @@ export default class Player extends FakeEventTarget {
         }
       });
       if (this.config.playback.playAdsWithMSE) {
-        this._eventManager.listen(this, AdEventType.AD_LOADED, event => {
-          if (event.payload.ad.linear) {
-            this._eventManager.listenOnce(this, AdEventType.AD_BREAK_START, () => {
-              this._detachMediaSource();
-            });
+        this._eventManager.listen(this, AdEventType.AD_BREAK_START, () => {
+          const adData = this._adsController ? this._adsController.getAd() : null;
+          if (!!adData && adData.linear) {
+            this._detachMediaSource();
           }
         });
         this._eventManager.listen(this, AdEventType.AD_BREAK_END, () => this._attachMediaSource());

--- a/src/player.js
+++ b/src/player.js
@@ -1811,13 +1811,15 @@ export default class Player extends FakeEventTarget {
         }
       });
       if (this.config.playback.playAdsWithMSE) {
-        this._eventManager.listen(this, AdEventType.AD_LOADED, (event: FakeEvent) => {
+        this._eventManager.listen(this, AdEventType.AD_LOADED, event => {
           if (event.payload.ad.linear) {
-            this._detachMediaSource();
+            this._eventManager.listenOnce(this, AdEventType.AD_BREAK_START, () => {
+              this._detachMediaSource();
+            });
           }
         });
-        this._eventManager.listen(this, AdEventType.AD_BREAK_END, this._attachMediaSource);
-        this._eventManager.listen(this, AdEventType.AD_ERROR, this._attachMediaSource);
+        this._eventManager.listen(this, AdEventType.AD_BREAK_END, () => this._attachMediaSource());
+        this._eventManager.listen(this, AdEventType.AD_ERROR, () => this._attachMediaSource());
       }
       const rootElement = Utils.Dom.getElementBySelector(`#${this.config.targetId}`);
       if (rootElement) {


### PR DESCRIPTION
### Description of the Changes

IMA probably changed their adloaded timing which causes issues on our logic of playing ads with MSE.
issue: video detached 6-8 sec before midroll supposes to show up which causes an empty video tag.
Solution: detach the media when the ad break starts.

Solve FEC-10335.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
