### PR TITLE
fix(FEC-10266): Ima dai doesn't show ad preset

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -14,8 +14,6 @@ import Error from '../../error/error';
 import getLogger from '../../utils/logger';
 import {DroppedFramesWatcher} from '../dropped-frames-watcher';
 
-const HIDE_METADATA_TRACK_TIMEOUT: number = 100;
-
 /**
  * Html5 engine for playback.
  * @classdesc
@@ -1127,16 +1125,15 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._eventManager.listen(this._el.textTracks, 'addtrack', (event: any) => {
         if (event.track.kind === 'metadata') {
           listenToCueChange(event.track);
-        } else {
-          // When a non metadata track has added it could change the metadata track mode to disabled. Need to return it to hidden.
-          Array.from(this._el.textTracks).forEach((track: TextTrack) => {
-            if (track.kind === 'metadata') {
-              setTimeout(() => (track.mode = 'hidden'), HIDE_METADATA_TRACK_TIMEOUT);
-            }
-          });
         }
       });
     }
+    this._eventManager.listen(this._el.textTracks, 'change', () => {
+      const metadataTrack = Array.from(this._el.textTracks).find((track: TextTrack) => track.kind === 'metadata');
+      if (metadataTrack && metadataTrack.mode !== 'hidden') {
+        metadataTrack.mode = 'hidden';
+      }
+    });
   }
 
   get targetBuffer(): number {


### PR DESCRIPTION
### Description of the Changes

issue: iPhone 7 ios 13.5.1, iPhone 7 change metadata track to disable after our timeout for that issue called.
solution: change the timeout to listener to change event to avoid this scenario of incorrect timing.

Solve: FEC-10266.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
