### PR TITLE
fix(FEC-10468): PLAYBACK_START not fired on autoplay

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -514,6 +514,7 @@ export default class Player extends FakeEventTarget {
   play(): void {
     if (!this._playbackStart) {
       this._playbackStart = true;
+      this.dispatchEvent(new FakeEvent(CustomEventType.PLAYBACK_START));
       if (!this.src) {
         this._prepareVideoElement();
       }

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1334,6 +1334,68 @@ describe('Player', function () {
       });
     });
 
+    describe('playback start', function () {
+      let config;
+      let player;
+      let playerContainer;
+
+      before(() => {
+        playerContainer = createElement('DIV', targetId);
+      });
+
+      beforeEach(() => {
+        config = getConfigStructure();
+        player = new Player(config);
+        playerContainer.appendChild(player.getView());
+      });
+
+      afterEach(() => {
+        player.destroy();
+      });
+
+      after(() => {
+        removeVideoElementsFromTestPage();
+        removeElement(targetId);
+      });
+
+      it('should fire playback start only once', done => {
+        let counter = 0;
+        let onPlaying = () => {
+          player.removeEventListener(Html5EventType.PLAYING, onPlaying);
+          player.pause();
+          player.play();
+          setTimeout(() => {
+            try {
+              counter.should.equal(1);
+              done();
+            } catch (e) {
+              done(e);
+            }
+          }, 0);
+        };
+        player.addEventListener(CustomEventType.PLAYBACK_START, () => {
+          counter++;
+        });
+        player.addEventListener(Html5EventType.PLAYING, onPlaying);
+        player.configure({
+          sources: sourcesConfig.Mp4
+        });
+        player.play();
+      });
+
+      it('should fire playback start - autoplay', done => {
+        player.addEventListener(CustomEventType.PLAYBACK_START, () => {
+          done();
+        });
+        player.configure({
+          sources: sourcesConfig.Mp4,
+          playback: {
+            autoplay: true
+          }
+        });
+      });
+    });
+
     describe('first play', function () {
       let config;
       let player;


### PR DESCRIPTION
### Description of the Changes

Move `PLAYBACK_START` back to playkit for autoplay flow
(The only reason we moved it to kaltura player is to be aligned with PLAYBACK_ENDED)

Revert part of commit 9b5ed58

Solves FEC-10468

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
