### PR TITLE
fix(FEC-10510): iOS14 -  cannot exit from native PiP by the player's PiP button

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -530,12 +530,10 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   exitPictureInPicture(): void {
     try {
-      if (typeof this._el.webkitSetPresentationMode === 'function') {
-        this._el.webkitSetPresentationMode('inline');
-      } else if (document.pictureInPictureEnabled && typeof document.exitPictureInPicture === 'function') {
-        // Currently it's supported in chrome and in safari. So if we consider checking support before,
-        // we can use this flag to distinguish between the two. In the future we might need a different method.
-        // Second condition is because flow does not support this API yet
+      // Currently it's supported in chrome and in safari. So if we consider checking support before,
+      // we can use this flag to distinguish between the two. In the future we might need a different method.
+      // Second condition is because flow does not support this API yet
+      if (document.pictureInPictureEnabled && typeof document.exitPictureInPicture === 'function' && this._el === document.pictureInPictureElement) {
         document.exitPictureInPicture().catch(error => {
           this.dispatchEvent(
             new FakeEvent(
@@ -544,6 +542,8 @@ export default class Html5 extends FakeEventTarget implements IEngine {
             )
           );
         });
+      } else if (typeof this._el.webkitSetPresentationMode === 'function') {
+        this._el.webkitSetPresentationMode('inline');
       }
     } catch (error) {
       this.dispatchEvent(

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -529,10 +529,12 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   exitPictureInPicture(): void {
     try {
-      // Currently it's supported in chrome and in safari. So if we consider checking support before,
-      // we can use this flag to distinguish between the two. In the future we might need a different method.
-      // Second condition is because flow does not support this API yet
-      if (document.pictureInPictureEnabled && typeof document.exitPictureInPicture === 'function') {
+      if (typeof this._el.webkitSetPresentationMode === 'function') {
+        this._el.webkitSetPresentationMode('inline');
+      } else if (document.pictureInPictureEnabled && typeof document.exitPictureInPicture === 'function') {
+        // Currently it's supported in chrome and in safari. So if we consider checking support before,
+        // we can use this flag to distinguish between the two. In the future we might need a different method.
+        // Second condition is because flow does not support this API yet
         document.exitPictureInPicture().catch(error => {
           this.dispatchEvent(
             new FakeEvent(
@@ -541,10 +543,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
             )
           );
         });
-      } else if (typeof this._el.webkitSetPresentationMode === 'function') {
-        this._el.webkitSetPresentationMode('inline');
-        // Safari does not fire this event but Chrome does, normalizing the behaviour
-        setTimeout(() => this.dispatchEvent(new FakeEvent(Html5EventType.LEAVE_PICTURE_IN_PICTURE)), 0);
       }
     } catch (error) {
       this.dispatchEvent(

--- a/src/player.js
+++ b/src/player.js
@@ -1359,6 +1359,7 @@ export default class Player extends FakeEventTarget {
    */
   exitPictureInPicture(): void {
     if (this._engine.isInPictureInPicture) {
+      this.exitFullscreen();
       this._engine.exitPictureInPicture();
     }
   }

--- a/src/player.js
+++ b/src/player.js
@@ -1359,7 +1359,6 @@ export default class Player extends FakeEventTarget {
    */
   exitPictureInPicture(): void {
     if (this._engine.isInPictureInPicture) {
-      this.exitFullscreen();
       this._engine.exitPictureInPicture();
     }
   }


### PR DESCRIPTION
### Description of the Changes

* Don't use `exitPictureInPicture` when it's native PiP but use `webkitSetPresentationMode('inline')`
* Remove the redundant `LEAVE_PICTURE_IN_PICTURE` firing. it's already fired natively. 

Solves FEC-10510

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
