### PR TITLE
fix(FEC-10512): handle memory leaks in smart TV

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,12 @@
     "@babel/plugin-transform-property-mutators",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-transform-classes"
+    [
+      "@babel/plugin-transform-classes",
+      {
+        "loose": true
+      }
+    ]
   ],
   "presets": ["@babel/preset-env", "@babel/preset-flow"]
 }

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -282,13 +282,14 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   attach(): void {
     Object.keys(Html5EventType).forEach(html5Event => {
-      this._eventManager.listen(this._el, Html5EventType[html5Event], () => {
-        if (Html5EventType[html5Event] === Html5EventType.ERROR) {
-          this._handleVideoError();
-        } else {
-          this.dispatchEvent(new FakeEvent(Html5EventType[html5Event]));
-        }
-      });
+      if (Html5EventType[html5Event] !== Html5EventType.ERROR) {
+        this._eventManager.listen(this._el, Html5EventType[html5Event], () => {
+          return this.dispatchEvent(new FakeEvent(Html5EventType[html5Event]));
+        });
+      }
+    });
+    this._eventManager.listen(this._el, Html5EventType.ERROR, () => {
+      this._handleVideoError();
     });
     this._handleMetadataTrackEvents();
     let mediaSourceAdapter = this._mediaSourceAdapter;


### PR DESCRIPTION
### Description of the Changes

issue: HTML5 event handler is too complex and took too long and the babel config causes memory issue on a smart TV.
Solution: simplify the handler and fix the babel plugin config which causes the memory issue.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
