### PR TITLE
fix(FEC-10451): captions misaligned in V7 VTT

### DIFF
--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -659,15 +659,21 @@ class CueStyleBox extends StyleBox {
     // position of the cue box. The reference edge will be resolved later when
     // the box orientation styles are applied.
     let textPos = 0;
-    switch (cue.positionAlign) {
+    let textSize = cue.size;
+    let align = cue.positionAlign || cue.align;
+    switch (align) {
       case 'start':
+      case 'left':
         textPos = cue.position;
+        textSize = 100 - textPos;
         break;
       case 'center':
-        textPos = cue.position - cue.size / 2;
+        textSize = 2 * cue.position;
+        textPos = (100 - textSize) / 2;
         break;
       case 'end':
-        textPos = cue.position - cue.size;
+      case 'right':
+        textSize = 100 - cue.position;
         break;
     }
 
@@ -677,7 +683,7 @@ class CueStyleBox extends StyleBox {
     if (cue.vertical === '') {
       this.applyStyles({
         left: this.formatStyle(textPos, '%'),
-        width: this.formatStyle(cue.size, '%')
+        width: this.formatStyle(textSize || cue.size, '%')
       });
       // Vertical box orientation; textPos is the distance from the top edge of the
       // area to the top edge of the box and cue.size is the height extending
@@ -685,7 +691,7 @@ class CueStyleBox extends StyleBox {
     } else {
       this.applyStyles({
         top: this.formatStyle(textPos, '%'),
-        height: this.formatStyle(cue.size, '%')
+        height: this.formatStyle(textSize || cue.size, '%')
       });
     }
 

--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -659,21 +659,18 @@ class CueStyleBox extends StyleBox {
     // position of the cue box. The reference edge will be resolved later when
     // the box orientation styles are applied.
     let textPos = 0;
-    let textSize = cue.size;
     let align = cue.positionAlign || cue.align;
     switch (align) {
       case 'start':
       case 'left':
         textPos = cue.position;
-        textSize = 100 - textPos;
         break;
       case 'center':
-        textSize = 2 * cue.position;
-        textPos = (100 - textSize) / 2;
+        textPos = cue.position - cue.size / 2;
         break;
       case 'end':
       case 'right':
-        textSize = 100 - cue.position;
+        textPos = cue.position - cue.size;
         break;
     }
 
@@ -683,7 +680,7 @@ class CueStyleBox extends StyleBox {
     if (cue.vertical === '') {
       this.applyStyles({
         left: this.formatStyle(textPos, '%'),
-        width: this.formatStyle(textSize || cue.size, '%')
+        width: this.formatStyle(Math.min(cue.size, 100 - textPos) || cue.size, '%')
       });
       // Vertical box orientation; textPos is the distance from the top edge of the
       // area to the top edge of the box and cue.size is the height extending
@@ -691,7 +688,7 @@ class CueStyleBox extends StyleBox {
     } else {
       this.applyStyles({
         top: this.formatStyle(textPos, '%'),
-        height: this.formatStyle(textSize || cue.size, '%')
+        height: this.formatStyle(Math.min(cue.size, 100 - textPos) || cue.size, '%')
       });
     }
 


### PR DESCRIPTION
### Description of the Changes

* Handle the VTT property `align: left/right` (like `positionAlign: start/end`)
* Protect the cue width and height to not exceed the caption area

Solves FEC-10451

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
