### PR TITLE
fix: safari doesn't enter to buffering on seek.

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -454,7 +454,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   _onTimeUpdate(): void {
     if (!this._videoElement.paused) {
       if (this._videoElement.currentTime > this._lastTimeUpdate) {
-        if (this._waitingEventTriggered) {
+        if (this._waitingEventTriggered && !this._videoElement.seeking) {
           this._waitingEventTriggered = false;
           this._trigger(Html5EventType.PLAYING);
         }

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -134,10 +134,8 @@ export default class StateManager {
         this._dispatchEvent();
       },
       [Html5EventType.SEEKED]: () => {
-        if (this._prevState && this._prevState.type === StateType.PLAYING) {
-          this._updateState(StateType.PLAYING);
-          this._dispatchEvent();
-        }
+        this._updateState(StateType.BUFFERING);
+        this._dispatchEvent();
       },
       [Html5EventType.TIME_UPDATE]: () => {
         if (this._player.currentTime !== this._lastWaitingTime && this._prevState && this._prevState.type === StateType.PLAYING) {


### PR DESCRIPTION
### Description of the Changes

Issue: the player doesn't enter to buffering state on safari on seeking.
Solution: keep the state after seeked on buffering which will change on playing only.
don't fire playing on seeking, only after video already seeked.
verified there isn't a regression of -https://github.com/kaltura/playkit-js/pull/100.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
