### PR TITLE
feat(FEC-10486): Lock orientation according to screenLockOrientionMode config when switching to full screen

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -898,7 +898,7 @@ var config = {
 > > screenLockOrientionMode: string;
 > > ```
 > >
-> > > ##### Description: Gives the ability to lock the screen on fullscreen
+> > > ##### Description: Gives the ability to lock the screen orientation in fullscreen
 >
 > ##
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1403,4 +1403,53 @@ var config = {
 
 ##
 
+> ### config.dimensions
+>
+> ##### Type: `PKDimensionsConfig`
+>
+> ```js
+> {
+>   width?: string | number;
+>   height?: string | number;
+>   ratio?: string;
+> }
+> ```
+>
+> ##### Description: Dimensions configuration
+>
+> > ### config.dimensions.width
+> >
+> > ##### Type: `string | number`
+> >
+> > ##### Default: `''`
+> >
+> > ##### Description: The width of the player.
+> >
+> > If number was provided, the width will be calculated in pixels (`width: 640` equivalent to `width: '640px'`).
+> > If string was provided, any valid css syntax can be passed, for example: `width: '100%'`, `width: 'auto'`, etc.
+> >
+> > ### config.dimensions.height
+> >
+> > ##### Type: `string | number`
+> >
+> > ##### Default: `''`
+> >
+> > ##### Description: The height of the player.
+> >
+> > If number was provided, the height will be calculated in pixels (`height: 360` equivalent to `width: '360px'`).
+> > If string was provided, any valid css syntax can be passed, for example: `height: '100%'`, `height: 'auto'`, etc.
+> >
+> > ### config.dimensions.ratio
+> >
+> > ##### Type: `string`
+> >
+> > ##### Default: `''`
+> >
+> > ##### Description: Defines the aspect ratio of the player.
+> >
+> > The aspect ratio should be written in the form of `'width:height'`, for example: `'4:3'` (classic TV ratio).
+> > If one of the `height` or `width` parameters is additionally provided in the configuration, the value of the other parameter not provided will be calculated accordingly to match the aspect ratio. If both were provided, the `height` value would be overridden.
+
+##
+
 Now that we've learned about the different options available in the player configuration, let's see [how does the source selection logic works](./source-selection-logic.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -486,7 +486,8 @@ var config = {
 >  streamPriority: Array<PKStreamPriorityObject>,
 >  preferNative: PKPreferNativeConfigObject,
 >  inBrowserFullscreen: boolean,
->  playAdsWithMSE: boolean
+>  playAdsWithMSE: boolean,
+> screenLockOrientionMode: string
 > }
 > ```
 >
@@ -511,6 +512,7 @@ var config = {
 >  muted: false,
 >  pictureInPicture: true,
 >  playAdsWithMSE: false,
+> screenLockOrientionMode: '',
 >  options: {
 >    html5: {
 >      hls: {},
@@ -883,6 +885,20 @@ var config = {
 > > ```
 > >
 > > > ##### Description: Gives the ability to share same video tag to play ads and source with media source
+>
+> ##
+>
+> > ### config.playback.screenLockOrientionMode
+> >
+> > ##### Type: `string` - value list option in ScreenOrientationType
+> >
+> > ##### Default: ``
+> >
+> > ```js
+> > screenLockOrientionMode: string;
+> > ```
+> >
+> > > ##### Description: Gives the ability to lock the screen on fullscreen
 >
 > ##
 >
@@ -1384,55 +1400,6 @@ var config = {
 > > ##### Default: ``
 > >
 > > ##### Description: A specific DRM key system to use.
-
-##
-
-> ### config.dimensions
->
-> ##### Type: `PKDimensionsConfig`
->
-> ```js
-> {
->   width?: string | number;
->   height?: string | number;
->   ratio?: string;
-> }
-> ```
->
-> ##### Description: Dimensions configuration
->
-> > ### config.dimensions.width
-> >
-> > ##### Type: `string | number`
-> >
-> > ##### Default: `''`
-> >
-> > ##### Description: The width of the player.
-> >
-> > If number was provided, the width will be calculated in pixels (`width: 640` equivalent to `width: '640px'`).
-> > If string was provided, any valid css syntax can be passed, for example: `width: '100%'`, `width: 'auto'`, etc.
-> >
-> > ### config.dimensions.height
-> >
-> > ##### Type: `string | number`
-> >
-> > ##### Default: `''`
-> >
-> > ##### Description: The height of the player.
-> >
-> > If number was provided, the height will be calculated in pixels (`height: 360` equivalent to `width: '360px'`).
-> > If string was provided, any valid css syntax can be passed, for example: `height: '100%'`, `height: 'auto'`, etc.
-> >
-> > ### config.dimensions.ratio
-> >
-> > ##### Type: `string`
-> >
-> > ##### Default: `''`
-> >
-> > ##### Description: Defines the aspect ratio of the player.
-> >
-> > The aspect ratio should be written in the form of `'width:height'`, for example: `'4:3'` (classic TV ratio).
-> > If one of the `height` or `width` parameters is additionally provided in the configuration, the value of the other parameter not provided will be calculated accordingly to match the aspect ratio. If both were provided, the `height` value would be overridden.
 
 ##
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -512,7 +512,7 @@ var config = {
 >  muted: false,
 >  pictureInPicture: true,
 >  playAdsWithMSE: false,
->  screenLockOrientionMode: '',
+>  screenLockOrientionMode: ScreenOrientationType.NONE,
 >  options: {
 >    html5: {
 >      hls: {},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -892,7 +892,7 @@ var config = {
 > >
 > > ##### Type: `string` - value list option in ScreenOrientationType
 > >
-> > ##### Default: ``
+> > ##### Default: `none` - ScreenOrientationType.NONE
 > >
 > > ```js
 > > screenLockOrientionMode: string;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -487,7 +487,7 @@ var config = {
 >  preferNative: PKPreferNativeConfigObject,
 >  inBrowserFullscreen: boolean,
 >  playAdsWithMSE: boolean,
-> screenLockOrientionMode: string
+>  screenLockOrientionMode: string
 > }
 > ```
 >
@@ -512,7 +512,7 @@ var config = {
 >  muted: false,
 >  pictureInPicture: true,
 >  playAdsWithMSE: false,
-> screenLockOrientionMode: '',
+>  screenLockOrientionMode: '',
 >  options: {
 >    html5: {
 >      hls: {},

--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -15,5 +15,5 @@ declare type PKPlaybackConfigObject = {
   preferNative: PKPreferNativeConfigObject,
   inBrowserFullscreen: boolean,
   playAdsWithMSE: boolean,
-  disableFullScreenOrientation: boolean
+  screenLockOrientionMode: string
 };

--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -14,5 +14,6 @@ declare type PKPlaybackConfigObject = {
   streamPriority: Array<PKStreamPriorityObject>,
   preferNative: PKPreferNativeConfigObject,
   inBrowserFullscreen: boolean,
-  playAdsWithMSE: boolean
+  playAdsWithMSE: boolean,
+  disableFullScreenOrientation: boolean
 };

--- a/flow-typed/types/screen-orientation-type.js
+++ b/flow-typed/types/screen-orientation-type.js
@@ -1,0 +1,2 @@
+// @flow
+declare type PKOrientationType = {[type: string]: string};

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -178,7 +178,7 @@ class FullscreenController {
             // $FlowFixMe
             .lock(screenLockOrientionMode)
             .then(() => (this._isScreenLocked = true))
-            .catch(() => {});
+            .catch(() => (this._isScreenLocked = false));
         }
       },
       () => {}

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -22,6 +22,8 @@ class FullscreenController {
   // Flag to indicate that player is in fullscreen(when different element on fullscreen - api return correct state).
   _isInFullscreen: boolean = false;
   _isInBrowserFullscreen: boolean;
+  _isScreenOrientationSupport: boolean =
+    screen && screen.orientation && typeof screen.orientation.unlock === 'function' && typeof screen.orientation.lock === 'function';
   _eventManager: EventManager;
   // Flag to overcome browsers which supports more than one fullscreenchange event
   _isFullscreenEventDispatched: boolean = false;
@@ -166,10 +168,10 @@ class FullscreenController {
     Promise.resolve(this._nativeEnterFullScreen(fullScreenElement)).then(
       () => {
         this._isInFullscreen = true;
-        const screenOrientation = screen && screen.orientation && typeof screen.orientation.lock === 'function';
-        const playbackConfig = this._player.config.playback;
-        if (screenOrientation && !playbackConfig.disableFullScreenOrientation) {
-          screen.orientation.lock('landscape');
+        const screenLockOrientionMode = Utils.Object.getPropertyPath(this._player, 'config.playback.screenLockOrientionMode');
+        const validOrientation = Object.values(this._player.orientationTypes).includes(screenLockOrientionMode);
+        if (this._isScreenOrientationSupport && validOrientation) {
+          screen.orientation.lock(screenLockOrientionMode);
         }
       },
       () => {}
@@ -204,8 +206,7 @@ class FullscreenController {
     Promise.resolve(this._nativeExitFullScreen()).then(
       () => {
         this._isInFullscreen = false;
-        const screenOrientation = screen && screen.orientation && typeof screen.orientation.lock === 'function';
-        if (screenOrientation) {
+        if (this._isScreenOrientationSupport) {
           screen.orientation.unlock();
         }
       },

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -168,7 +168,7 @@ class FullscreenController {
         this._isInFullscreen = true;
         const screenOrientation = screen && screen.orientation && typeof screen.orientation.lock === 'function';
         const playbackConfig = this._player.config.playback;
-        if (screenOrientation && playbackConfig.disableFullScreenOrientation) {
+        if (screenOrientation && !playbackConfig.disableFullScreenOrientation) {
           screen.orientation.lock('landscape');
         }
       },

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -23,6 +23,7 @@ class FullscreenController {
   // Flag to indicate that player is in fullscreen(when different element on fullscreen - api return correct state).
   _isInFullscreen: boolean = false;
   _isInBrowserFullscreen: boolean;
+  _isScreenLocked: boolean = false;
   _isScreenOrientationSupport: boolean =
     // $FlowFixMe
     screen && screen.orientation && typeof screen.orientation.unlock === 'function' && typeof screen.orientation.lock === 'function';
@@ -174,7 +175,10 @@ class FullscreenController {
         const validOrientation = Object.values(ScreenOrientationType).includes(screenLockOrientionMode);
         if (this._isScreenOrientationSupport && validOrientation) {
           // $FlowFixMe
-          screen.orientation.lock(screenLockOrientionMode).catch(() => {});
+          screen.orientation
+            .lock(screenLockOrientionMode)
+            .then(() => (this._isScreenLocked = true))
+            .catch(() => {});
         }
       },
       () => {}
@@ -209,9 +213,10 @@ class FullscreenController {
     Promise.resolve(this._nativeExitFullScreen()).then(
       () => {
         this._isInFullscreen = false;
-        if (this._isScreenOrientationSupport) {
+        if (this._isScreenOrientationSupport && this._isScreenLocked) {
           // $FlowFixMe
           screen.orientation.unlock();
+          this._isScreenLocked = false;
         }
       },
       () => {}

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -3,6 +3,7 @@ import EventManager from '../event/event-manager';
 import Player from '../player';
 import FakeEvent from '../event/fake-event';
 import * as Utils from '../utils/util';
+import {ScreenOrientationType} from '../screen-orientation-type';
 
 /**
  * The IOS fullscreen class name.
@@ -23,6 +24,7 @@ class FullscreenController {
   _isInFullscreen: boolean = false;
   _isInBrowserFullscreen: boolean;
   _isScreenOrientationSupport: boolean =
+    // $FlowFixMe
     screen && screen.orientation && typeof screen.orientation.unlock === 'function' && typeof screen.orientation.lock === 'function';
   _eventManager: EventManager;
   // Flag to overcome browsers which supports more than one fullscreenchange event
@@ -169,9 +171,10 @@ class FullscreenController {
       () => {
         this._isInFullscreen = true;
         const screenLockOrientionMode = Utils.Object.getPropertyPath(this._player, 'config.playback.screenLockOrientionMode');
-        const validOrientation = Object.values(this._player.orientationTypes).includes(screenLockOrientionMode);
+        const validOrientation = Object.values(ScreenOrientationType).includes(screenLockOrientionMode);
         if (this._isScreenOrientationSupport && validOrientation) {
-          screen.orientation.lock(screenLockOrientionMode);
+          // $FlowFixMe
+          screen.orientation.lock(screenLockOrientionMode).catch(() => {});
         }
       },
       () => {}
@@ -207,6 +210,7 @@ class FullscreenController {
       () => {
         this._isInFullscreen = false;
         if (this._isScreenOrientationSupport) {
+          // $FlowFixMe
           screen.orientation.unlock();
         }
       },

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -174,8 +174,8 @@ class FullscreenController {
         const screenLockOrientionMode = Utils.Object.getPropertyPath(this._player, 'config.playback.screenLockOrientionMode');
         const validOrientation = Object.values(ScreenOrientationType).includes(screenLockOrientionMode);
         if (this._isScreenOrientationSupport && validOrientation) {
-          // $FlowFixMe
           screen.orientation
+            // $FlowFixMe
             .lock(screenLockOrientionMode)
             .then(() => (this._isScreenLocked = true))
             .catch(() => {});

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -26,7 +26,7 @@ class FullscreenController {
   _isScreenLocked: boolean = false;
   _isScreenOrientationSupport: boolean =
     // $FlowFixMe
-    screen && screen.orientation && typeof screen.orientation.unlock === 'function' && typeof screen.orientation.lock === 'function';
+    !!screen && !!screen.orientation && typeof screen.orientation.unlock === 'function' && typeof screen.orientation.lock === 'function';
   _eventManager: EventManager;
   // Flag to overcome browsers which supports more than one fullscreenchange event
   _isFullscreenEventDispatched: boolean = false;
@@ -172,7 +172,8 @@ class FullscreenController {
       () => {
         this._isInFullscreen = true;
         const screenLockOrientionMode = Utils.Object.getPropertyPath(this._player, 'config.playback.screenLockOrientionMode');
-        const validOrientation = Object.values(ScreenOrientationType).includes(screenLockOrientionMode);
+        const validOrientation =
+          screenLockOrientionMode !== ScreenOrientationType.NONE && Object.values(ScreenOrientationType).includes(screenLockOrientionMode);
         if (this._isScreenOrientationSupport && validOrientation) {
           screen.orientation
             // $FlowFixMe

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -164,7 +164,14 @@ class FullscreenController {
       this._player.exitPictureInPicture();
     }
     Promise.resolve(this._nativeEnterFullScreen(fullScreenElement)).then(
-      () => (this._isInFullscreen = true),
+      () => {
+        this._isInFullscreen = true;
+        const screenOrientation = screen && screen.orientation && typeof screen.orientation.lock === 'function';
+        const playbackConfig = this._player.config.playback;
+        if (screenOrientation && playbackConfig.disableFullScreenOrientation) {
+          screen.orientation.lock('landscape');
+        }
+      },
       () => {}
     );
   }
@@ -195,7 +202,13 @@ class FullscreenController {
    */
   _requestExitFullscreen(): void {
     Promise.resolve(this._nativeExitFullScreen()).then(
-      () => (this._isInFullscreen = false),
+      () => {
+        this._isInFullscreen = false;
+        const screenOrientation = screen && screen.orientation && typeof screen.orientation.lock === 'function';
+        if (screenOrientation) {
+          screen.orientation.unlock();
+        }
+      },
       () => {}
     );
   }

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -37,6 +37,7 @@ const DefaultConfig = {
       dash: false
     },
     inBrowserFullscreen: false,
+    disableFullScreenOrientation: false,
     playAdsWithMSE: false,
     streamPriority: [
       {

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -37,7 +37,7 @@ const DefaultConfig = {
       dash: false
     },
     inBrowserFullscreen: false,
-    disableFullScreenOrientation: false,
+    screenLockOrientionMode: '',
     playAdsWithMSE: false,
     streamPriority: [
       {

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -1,3 +1,5 @@
+import {ScreenOrientationType} from './screen-orientation-type';
+
 const DefaultConfig = {
   log: {
     level: 'ERROR'
@@ -37,7 +39,7 @@ const DefaultConfig = {
       dash: false
     },
     inBrowserFullscreen: false,
-    screenLockOrientionMode: '',
+    screenLockOrientionMode: ScreenOrientationType.NONE,
     playAdsWithMSE: false,
     streamPriority: [
       {

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -37,7 +37,7 @@ const DefaultConfig = {
       dash: false
     },
     inBrowserFullscreen: false,
-    screenLockOrientionMode: 'any',
+    screenLockOrientionMode: '',
     playAdsWithMSE: false,
     streamPriority: [
       {

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -37,7 +37,7 @@ const DefaultConfig = {
       dash: false
     },
     inBrowserFullscreen: false,
-    screenLockOrientionMode: '',
+    screenLockOrientionMode: 'any',
     playAdsWithMSE: false,
     streamPriority: [
       {

--- a/src/player.js
+++ b/src/player.js
@@ -35,7 +35,7 @@ import {ResizeWatcher} from './utils/resize-watcher';
 import {FullscreenController} from './fullscreen/fullscreen-controller';
 import {EngineDecorator} from './engines/engine-decorator';
 import {LabelOptions} from './track/label-options';
-
+import {ScreenOrientationType} from './screen-orientation-type';
 /**
  * The black cover class name.
  * @type {string}
@@ -2506,5 +2506,8 @@ export default class Player extends FakeEventTarget {
     return PKError;
   }
 
+  get orientationTypes(): PKOrientationType {
+    return ScreenOrientationType;
+  }
   // </editor-fold>
 }

--- a/src/player.js
+++ b/src/player.js
@@ -2505,9 +2505,5 @@ export default class Player extends FakeEventTarget {
   get Error(): typeof PKError {
     return PKError;
   }
-
-  get orientationTypes(): PKOrientationType {
-    return ScreenOrientationType;
-  }
   // </editor-fold>
 }

--- a/src/player.js
+++ b/src/player.js
@@ -35,7 +35,6 @@ import {ResizeWatcher} from './utils/resize-watcher';
 import {FullscreenController} from './fullscreen/fullscreen-controller';
 import {EngineDecorator} from './engines/engine-decorator';
 import {LabelOptions} from './track/label-options';
-import {ScreenOrientationType} from './screen-orientation-type';
 /**
  * The black cover class name.
  * @type {string}

--- a/src/playkit.js
+++ b/src/playkit.js
@@ -32,6 +32,7 @@ import {RequestType} from './request-type';
 import {AdBreakType} from './ads/ad-break-type';
 import {AdTagType} from './ads/ad-tag-type';
 import {AdEventType} from './ads/ad-event-type';
+import {ScreenOrientationType} from './screen-orientation-type';
 
 declare var __VERSION__: string;
 declare var __NAME__: string;
@@ -107,7 +108,8 @@ export {
   CorsType,
   DrmScheme,
   MimeType,
-  RequestType
+  RequestType,
+  ScreenOrientationType
 };
 
 // Export logger utils

--- a/src/screen-orientation-type.js
+++ b/src/screen-orientation-type.js
@@ -1,5 +1,6 @@
 // @flow
 const ScreenOrientationType: PKOrientationType = {
+  NONE: 'none',
   ANY: 'any',
   NATURAL: 'natural',
   LANDSCAPE: 'landscape',

--- a/src/screen-orientation-type.js
+++ b/src/screen-orientation-type.js
@@ -1,0 +1,13 @@
+// @flow
+const ScreenOrientationType: PKOrientationType = {
+  ANY: 'any',
+  NATURAL: 'natural',
+  LANDSCAPE: 'landscape',
+  PORTRAIT: 'portrait',
+  PORTRAIT_PRIMARY: 'portrait-primary',
+  PORTRAIT_SECONDARY: 'portrait-secondary',
+  LANDSCAPE_PRIMARY: 'landscape-primary',
+  LANDSCAPE_SECONDARY: 'landscape-secondary'
+};
+
+export {ScreenOrientationType};


### PR DESCRIPTION
### Description of the Changes

add screenLockOrientionMode config to be able to lock the screen mode in fullscreen.
new enum with possible values for this config:
`"none"
"any"
"natural"
"landscape"
"portrait"
"portrait-primary"
"portrait-secondary"
"landscape-primary"
"landscape-secondary"`

Solves FEC-10486

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
