### PR TITLE
fix(FEC-10643): seek to live edge on first play redundant

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1926,7 +1926,8 @@ export default class Player extends FakeEventTarget {
     }
     this.ready()
       .then(() => {
-        if (this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0))) {
+        const liveOrDvrOutOfWindow = this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0));
+        if (!this._firstPlay && liveOrDvrOutOfWindow) {
           this.seekToLiveEdge();
         }
         this._engine.play();


### PR DESCRIPTION
### Description of the Changes

Issue: seek on low-level device could take a few seconds, remove it when it's not needed.
Solution: on the first play we're already on edge so it's redundant.

Solves FEC-10643

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
