### PR TITLE
fix(FEC-10590): DOM play error on SmartTV on when stall happen on the beginning

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1652,7 +1652,6 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEventType.ABR_MODE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.TIMED_METADATA, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.PLAY_FAILED, (event: FakeEvent) => {
-        this.pause();
         this._onPlayFailed(event);
         this.dispatchEvent(event);
       });


### PR DESCRIPTION
### Description of the Changes

Issue: shaka added a play() pause() on the stall detector which causes the play promise to fail.
Solution: don't pause for smart tv (user gesture doesn't exist for smart TV autoplay), set this login on Kaltura player instead.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
