### PR TITLE
feat(FEC-10656): set forceRedirectExternalStreams as true by default on IE11 and Chromecast

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -578,7 +578,7 @@ export default class Player extends FakeEventTarget {
     this._externalCaptionsHandler.reset(this._tracks.filter(track => track.external));
     this._posterManager.reset();
     this._stateManager.reset();
-    this._config.sources = {};
+    this._config.sources = {options: this.config.sources.options};
     this._activeTextCues = [];
     this._updateTextDisplay([]);
     this._tracks = [];

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2518,7 +2518,7 @@ describe('Player', function () {
       removeElement(targetId);
     });
 
-    it.only('should resets the player', function () {
+    it('should resets the player', function () {
       player = new Player(config);
       player._reset = false;
       let posterMgrSpy = sandbox.spy(player._posterManager, 'reset');

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -2518,7 +2518,7 @@ describe('Player', function () {
       removeElement(targetId);
     });
 
-    it('should resets the player', function () {
+    it.only('should resets the player', function () {
       player = new Player(config);
       player._reset = false;
       let posterMgrSpy = sandbox.spy(player._posterManager, 'reset');
@@ -2536,6 +2536,7 @@ describe('Player', function () {
       _updateTextDisplay.should.have.been.calledOnce;
       _updateTextDisplay.should.have.been.calledWith([]);
       player._config.should.not.be.empty;
+      player._config.sources.options.should.not.be.empty;
       player._tracks.should.be.empty;
       player._engineType.should.be.empty;
       player._streamType.should.be.empty;


### PR DESCRIPTION
### Description of the Changes

Keep the redirect config on change media

Related to https://github.com/kaltura/kaltura-player-js/pull/370

Solves FEC-10656, [KMS-22502](https://kaltura.atlassian.net/browse/KMS-22502)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
