### PR TITLE
fix(FEC-10679): external native text track still existing on API for next media

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -14,6 +14,7 @@ import Error from '../../../../error/error';
 import defaultConfig from './native-adapter-default-config';
 import type {FairPlayDrmConfigType} from './fairplay-drm-handler';
 import {FairPlayDrmHandler} from './fairplay-drm-handler';
+import {EXTERNAL_TRACK_ID} from '../../../../track/external-captions-handler';
 
 const BACK_TO_FOCUS_TIMEOUT: number = 1000;
 const MAX_MEDIA_RECOVERY_ATTEMPTS: number = 3;
@@ -654,19 +655,21 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const parsedTracks = [];
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
-        const settings = {
-          kind: textTracks[i].kind,
-          active: textTracks[i].mode === 'showing',
-          label: textTracks[i].label,
-          language: textTracks[i].language,
-          index: i
-        };
-        if (settings.kind === 'subtitles') {
-          parsedTracks.push(new PKTextTrack(settings));
-        } else if (settings.kind === 'captions' && this._config.enableCEA708Captions) {
-          settings.label = settings.label || captionsTextTrackLabels.shift();
-          settings.language = settings.language || captionsTextTrackLanguageCodes.shift();
-          parsedTracks.push(new PKTextTrack(settings));
+        if (textTracks[i].language !== EXTERNAL_TRACK_ID && textTracks[i].label !== EXTERNAL_TRACK_ID) {
+          const settings = {
+            kind: textTracks[i].kind,
+            active: textTracks[i].mode === 'showing',
+            label: textTracks[i].label,
+            language: textTracks[i].language,
+            index: i
+          };
+          if (settings.kind === 'subtitles') {
+            parsedTracks.push(new PKTextTrack(settings));
+          } else if (settings.kind === 'captions' && this._config.enableCEA708Captions) {
+            settings.label = settings.label || captionsTextTrackLabels.shift();
+            settings.language = settings.language || captionsTextTrackLanguageCodes.shift();
+            parsedTracks.push(new PKTextTrack(settings));
+          }
         }
       }
     }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -655,7 +655,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const parsedTracks = [];
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
-        if (textTracks[i].language !== EXTERNAL_TRACK_ID && textTracks[i].label !== EXTERNAL_TRACK_ID) {
+        if (textTracks[i].language !== EXTERNAL_TRACK_ID || textTracks[i].label !== EXTERNAL_TRACK_ID) {
           const settings = {
             kind: textTracks[i].kind,
             active: textTracks[i].mode === 'showing',

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -1025,7 +1025,9 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     let textTracks = this._videoElement.textTracks;
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
-        (textTracks[i].kind === 'subtitles' || textTracks[i].kind === 'captions') && (textTracks[i].mode = 'disabled');
+        (textTracks[i].kind === 'subtitles' || textTracks[i].kind === 'captions') &&
+          (textTracks[i].language !== EXTERNAL_TRACK_ID || textTracks[i].label !== EXTERNAL_TRACK_ID) &&
+          (textTracks[i].mode = 'disabled');
       }
     }
   }

--- a/src/player.js
+++ b/src/player.js
@@ -2070,7 +2070,7 @@ export default class Player extends FakeEventTarget {
         const videoElement = this.getVideoElement();
         return videoElement
           ? Array.from(videoElement.textTracks).findIndex(track =>
-              track ? track.language === textTrack.language || (!!textTrack.external && track.language === EXTERNAL_TRACK_ID) : false
+              track ? track.language === textTrack.language || track.language === EXTERNAL_TRACK_ID : false
             )
           : -1;
       };

--- a/src/player.js
+++ b/src/player.js
@@ -574,8 +574,7 @@ export default class Player extends FakeEventTarget {
     if (this._reset) return;
     this.pause();
     //make sure all services are reset before engine and engine attributes are reset
-    // $FlowFixMe
-    this._externalCaptionsHandler.reset(this._tracks.filter(track => track.external));
+    this._externalCaptionsHandler.reset();
     this._posterManager.reset();
     this._stateManager.reset();
     this._config.sources = {};

--- a/src/player.js
+++ b/src/player.js
@@ -28,7 +28,7 @@ import {DefaultConfig} from './player-config.js';
 import './assets/style.css';
 import PKError from './error/error';
 import {EngineProvider} from './engines/engine-provider';
-import {EXTERNAL_TRACK_ID, ExternalCaptionsHandler} from './track/external-captions-handler';
+import {ExternalCaptionsHandler} from './track/external-captions-handler';
 import {AdBreakType} from './ads/ad-break-type';
 import {AdTagType} from './ads/ad-tag-type';
 import {ResizeWatcher} from './utils/resize-watcher';
@@ -2068,13 +2068,13 @@ export default class Player extends FakeEventTarget {
     if (this._config.playback.useNativeTextTrack) {
       const getNativeLanguageTrackIndex = (textTrack: TextTrack): number => {
         const videoElement = this.getVideoElement();
-        return videoElement
-          ? Array.from(videoElement.textTracks).findIndex(track =>
-              track ? track.language === textTrack.language || (!!textTrack.external && track.language === EXTERNAL_TRACK_ID) : false
-            )
-          : -1;
+        return videoElement ? Array.from(videoElement.textTracks).findIndex(track => (track ? track.language === textTrack.language : false)) : -1;
       };
-      this._getTextTracks().forEach(track => (track.index = getNativeLanguageTrackIndex(track)));
+      const textTracks = this._getTextTracks();
+      let externalTrackIndex = textTracks.length;
+      textTracks.forEach(track => {
+        track.index = track.external ? externalTrackIndex++ : getNativeLanguageTrackIndex(track);
+      });
     }
   }
 

--- a/src/player.js
+++ b/src/player.js
@@ -2066,11 +2066,11 @@ export default class Player extends FakeEventTarget {
    */
   _maybeAdjustTextTracksIndexes(): void {
     if (this._config.playback.useNativeTextTrack) {
-      const getNativeLanguageTrackIndex = (textTrack: Track): number => {
+      const getNativeLanguageTrackIndex = (textTrack: TextTrack): number => {
         const videoElement = this.getVideoElement();
         return videoElement
           ? Array.from(videoElement.textTracks).findIndex(track =>
-              track ? track.language === textTrack.language || track.language === EXTERNAL_TRACK_ID : false
+              track ? track.language === textTrack.language || (!!textTrack.external && track.language === EXTERNAL_TRACK_ID) : false
             )
           : -1;
       };

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -121,6 +121,9 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     if (!captions) {
       return [];
     }
+    if (this._player.config.playback.useNativeTextTrack) {
+      this._addNativeTextTrack();
+    }
     const playerTextTracks = tracks.filter(track => track instanceof TextTrack);
     let textTracksLength = playerTextTracks.length || 0;
     const newTextTracks = [];
@@ -148,9 +151,6 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   _maybeAddTrack(track: TextTrack, caption: PKExternalCaptionObject, playerTextTracks: Array<Track>, newTextTracks: Array<TextTrack>): void {
     const sameLangTrack = playerTextTracks.find(textTrack => Track.langComparer(caption.language, textTrack.language));
     if (!sameLangTrack) {
-      if (this._player.config.playback.useNativeTextTrack) {
-        this._addNativeTextTrack();
-      }
       newTextTracks.push(track);
       this._updateTextTracksModel(caption);
     } else {

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -467,10 +467,10 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   _resetExternalNativeTextTrack(): void {
     const videoElement = this._player.getVideoElement();
     if (videoElement) {
-      const track = Array.from(videoElement.textTracks).find(track => track && track.language === EXTERNAL_TRACK_ID);
+      const track = Array.from(videoElement.textTracks).find(track => (track ? track.language === EXTERNAL_TRACK_ID : false));
       if (track) {
-        track.mode = 'disabled';
         track.cues && Object.values(track.cues).forEach(cue => track.removeCue(cue));
+        track.mode = 'disabled';
       }
     }
   }

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -216,7 +216,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   _selectTextTrack(textTrack: TextTrack) {
     this.hideTextTrack();
     if (this._player.config.playback.useNativeTextTrack) {
-      this._addCuesToNativeTextTrack(textTrack, this._textTrackModel[textTrack.language].cues);
+      this._addCuesToNativeTextTrack(this._textTrackModel[textTrack.language].cues);
     } else {
       this._setTextTrack(textTrack);
     }
@@ -477,11 +477,10 @@ class ExternalCaptionsHandler extends FakeEventTarget {
 
   /**
    * adding cues to an existing text element in a video tag
-   * @param {TextTrack} textTrack - adding cues to an exiting text track element
    * @param {Array<Cue>} cues - the cues to be added
    * @return {void}
    */
-  _addCuesToNativeTextTrack(textTrack: TextTrack, cues: Array<Cue>): void {
+  _addCuesToNativeTextTrack(cues: Array<Cue>): void {
     const videoElement = this._player.getVideoElement();
     if (videoElement) {
       const track = Array.from(videoElement.textTracks).find(track => (track ? track.language === EXTERNAL_TRACK_ID : false));

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -29,6 +29,8 @@ const SRT_POSTFIX: string = 'srt';
 
 const VTT_POSTFIX: string = 'vtt';
 
+const EXTERNAL_TRACK_ID: string = 'playkit-external-track';
+
 class ExternalCaptionsHandler extends FakeEventTarget {
   /**
    * The external captions handler class logger.
@@ -96,11 +98,15 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @public
    */
   hideTextTrack(): void {
-    // only if external text track was active we need to hide it.
-    if (this._isTextTrackActive) {
-      this._eventManager.unlisten(this._player, Html5EventType.TIME_UPDATE);
-      this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_CUE_CHANGED, {cues: []}));
-      this._resetCurrentTrack();
+    if (this._player.config.playback.useNativeTextTrack) {
+      this._resetExternalNativeTextTrack();
+    } else {
+      // only if external text track was active we need to hide it.
+      if (this._isTextTrackActive) {
+        this._eventManager.unlisten(this._player, Html5EventType.TIME_UPDATE);
+        this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_CUE_CHANGED, {cues: []}));
+        this._resetCurrentTrack();
+      }
     }
   }
 
@@ -143,7 +149,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     const sameLangTrack = playerTextTracks.find(textTrack => Track.langComparer(caption.language, textTrack.language));
     if (!sameLangTrack) {
       if (this._player.config.playback.useNativeTextTrack) {
-        this._addNativeTextTrack(track);
+        this._addNativeTextTrack();
       }
       newTextTracks.push(track);
       this._updateTextTracksModel(caption);
@@ -193,31 +199,28 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    */
   selectTextTrack(textTrack: TextTrack): void {
     if (this._textTrackModel[textTrack.language]) {
-      if (this._textTrackModel[textTrack.language].cuesStatus === CuesStatus.DOWNLOADED && !this._player.config.playback.useNativeTextTrack) {
-        textTrack.active = true;
-        this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}));
-        this.hideTextTrack();
-        this._setTextTrack(textTrack);
+      textTrack.active = true;
+      this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}));
+      if (this._textTrackModel[textTrack.language].cuesStatus === CuesStatus.DOWNLOADED) {
+        this._selectTextTrack(textTrack);
       } else if (this._textTrackModel[textTrack.language].cuesStatus === CuesStatus.NOT_DOWNLOADED) {
-        textTrack.active = true;
-        if (!this._player.config.playback.useNativeTextTrack) {
-          this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}));
-        }
         this._downloadAndParseCues(textTrack)
           .then(() => {
             this._textTrackModel[textTrack.language].cuesStatus = CuesStatus.DOWNLOADED;
-            if (this._player.config.playback.useNativeTextTrack) {
-              this._addCuesToNativeTextTrack(textTrack, this._textTrackModel[textTrack.language].cues);
-            } else {
-              this.hideTextTrack();
-              this._setTextTrack(textTrack);
-            }
+            this._selectTextTrack(textTrack);
           })
           .catch(error => this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error)));
       }
     }
   }
-
+  _selectTextTrack(textTrack: TextTrack) {
+    this.hideTextTrack();
+    if (this._player.config.playback.useNativeTextTrack) {
+      this._addCuesToNativeTextTrack(textTrack, this._textTrackModel[textTrack.language].cues);
+    } else {
+      this._setTextTrack(textTrack);
+    }
+  }
   /**
    * set hasBeenReset to true for all the cues.
    * @returns {void}
@@ -232,13 +235,12 @@ class ExternalCaptionsHandler extends FakeEventTarget {
 
   /**
    * resets the handler
-   * @param {Array<TextTrack>} externalTracks - external tracks
    * @returns {void}
    */
-  reset(externalTracks: Array<TextTrack>): void {
+  reset(): void {
     this._resetCurrentTrack();
     this._textTrackModel = {};
-    this._resetExternalNativeTextTrack(externalTracks);
+    this._resetExternalNativeTextTrack();
     this._eventManager.removeAll();
   }
 
@@ -460,18 +462,16 @@ class ExternalCaptionsHandler extends FakeEventTarget {
 
   /**
    * delete cues on reset to avoid usage of the text track on the next media
-   * @param {Array<TextTrack>} externalTracks - external tracks
    * @return {void}
    */
-  _resetExternalNativeTextTrack(externalTracks: Array<TextTrack>): void {
+  _resetExternalNativeTextTrack(): void {
     const videoElement = this._player.getVideoElement();
     if (videoElement) {
-      externalTracks.forEach(externalTrack => {
-        const track = Array.from(videoElement.textTracks).find(track => track && track.language === externalTrack.language);
-        if (track && track.cues) {
-          Object.values(track.cues).forEach(cue => track.removeCue(cue));
-        }
-      });
+      const track = Array.from(videoElement.textTracks).find(track => track && track.language === EXTERNAL_TRACK_ID);
+      if (track) {
+        track.mode = 'disabled';
+        track.cues && Object.values(track.cues).forEach(cue => track.removeCue(cue));
+      }
     }
   }
 
@@ -484,8 +484,9 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   _addCuesToNativeTextTrack(textTrack: TextTrack, cues: Array<Cue>): void {
     const videoElement = this._player.getVideoElement();
     if (videoElement) {
-      const track = Array.from(videoElement.textTracks).find(track => (track ? track.language === textTrack.language : false));
+      const track = Array.from(videoElement.textTracks).find(track => (track ? track.language === EXTERNAL_TRACK_ID : false));
       if (track) {
+        track.mode = 'showing';
         cues.forEach(cue => track.addCue(cue));
       }
     }
@@ -494,20 +495,16 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   /**
    * adds a new text track element to the video element or set an existing one
    * (when adding a text track with existing language to the video element it will remove all its cues)
-   * @param {TextTrack} textTrack - the playkit text track object to be added
    * @returns {void}
    */
-  _addNativeTextTrack(textTrack: TextTrack): void {
+  _addNativeTextTrack(): void {
     const videoElement = this._player.getVideoElement();
     if (videoElement) {
-      const sameLanguageTrackIndex = Array.from(videoElement.textTracks).findIndex(track => (track ? track.language === textTrack.language : false));
+      const sameLanguageTrackIndex = Array.from(videoElement.textTracks).findIndex(track => (track ? track.language === EXTERNAL_TRACK_ID : false));
       if (sameLanguageTrackIndex > -1) {
-        const domTrack = videoElement.textTracks[sameLanguageTrackIndex];
-        if (domTrack.cues) {
-          Object.values(domTrack.cues).forEach(cue => domTrack.removeCue(cue));
-        }
+        this._resetExternalNativeTextTrack();
       } else {
-        videoElement.addTextTrack('subtitles', textTrack.label || textTrack.language, textTrack.language);
+        videoElement.addTextTrack('subtitles', EXTERNAL_TRACK_ID, EXTERNAL_TRACK_ID);
       }
     }
   }
@@ -529,4 +526,4 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   }
 }
 
-export {ExternalCaptionsHandler};
+export {ExternalCaptionsHandler, EXTERNAL_TRACK_ID};

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -199,8 +199,6 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    */
   selectTextTrack(textTrack: TextTrack): void {
     if (this._textTrackModel[textTrack.language]) {
-      textTrack.active = true;
-      this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}));
       if (this._textTrackModel[textTrack.language].cuesStatus === CuesStatus.DOWNLOADED) {
         this._selectTextTrack(textTrack);
       } else if (this._textTrackModel[textTrack.language].cuesStatus === CuesStatus.NOT_DOWNLOADED) {
@@ -220,6 +218,8 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     } else {
       this._setTextTrack(textTrack);
     }
+    textTrack.active = true;
+    this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}));
   }
   /**
    * set hasBeenReset to true for all the cues.

--- a/test/src/configs/external-captions.json
+++ b/test/src/configs/external-captions.json
@@ -1,0 +1,16 @@
+{
+  "He": {
+        "url": "http://externaltests.dev.kaltura.com/player/library_Player_V3/Captions/Caption_files_VTT/hebrew.vtt",
+        "label": "Heb",
+        "language": "he",
+        "type": "vtt",
+        "default": false
+  },
+  "Ru": {
+        "url": "http://externaltests.dev.kaltura.com/player/library_Player_V3/Captions/Caption_files_VTT/hebrew.vtt",
+        "label": "Rus",
+        "language": "ru",
+        "type": "vtt",
+        "default": false
+  }
+}

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -3,6 +3,7 @@ import Player from '../../src/player';
 import {StateType} from '../../src/state/state-type';
 import {CustomEventType, Html5EventType} from '../../src/event/event-type';
 import SourcesConfig from './configs/sources.json';
+import ExternalCaption from './configs/external-captions.json';
 import Track from '../../src/track/track';
 import VideoTrack from '../../src/track/video-track';
 import AudioTrack from '../../src/track/audio-track';
@@ -16,6 +17,8 @@ import {LabelOptions} from '../../src/track/label-options';
 import {EngineProvider} from '../../src/engines/engine-provider';
 import FakeEvent from '../../src/event/fake-event';
 import Html5AutoPlayCapability from '../../src/engines/html5/capabilities/html5-autoplay';
+import {EXTERNAL_TRACK_ID} from '../../src/track/external-captions-handler';
+import * as Utils from '../../src/utils/util';
 
 const targetId = 'player-placeholder_player.spec';
 let sourcesConfig = PKObject.copyDeep(SourcesConfig);
@@ -1229,6 +1232,239 @@ describe('Player', function () {
         const settings = {line: -4};
         player.setTextDisplaySettings(settings);
         player._textDisplaySettings.should.be.equal(settings);
+      });
+    });
+  });
+
+  describe.only('Text Track', () => {
+    let config, player, video, playerContainer;
+
+    before(() => {
+      playerContainer = createElement('div', targetId);
+    });
+
+    afterEach(() => {
+      player.destroy();
+    });
+
+    after(() => {
+      removeVideoElementsFromTestPage();
+      removeElement(targetId);
+    });
+
+    let getActiveNativeTracks = () => {};
+    let checkTrack = () => {};
+
+    const switchTextTrack = (track1, track2, done) => {
+      const tracksChangeToTrack1 = event => {
+        try {
+          player.removeEventListener(CustomEventType.TEXT_TRACK_CHANGED, tracksChangeToTrack1);
+          player.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, tracksChangeToTrack2);
+          checkTrack(track1, event.payload.selectedTextTrack);
+          player.selectTrack(track2);
+        } catch (e) {
+          done(e);
+        }
+      };
+      const tracksChangeToTrack2 = event => {
+        try {
+          player.removeEventListener(CustomEventType.TEXT_TRACK_CHANGED, tracksChangeToTrack2);
+          checkTrack(track2, event.payload.selectedTextTrack);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      };
+      player.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, tracksChangeToTrack1);
+      player.selectTrack(track1);
+    };
+
+    describe('useNativeTextTrack = true', () => {
+      before(() => {
+        getActiveNativeTracks = () => {
+          return Array.from(video.textTracks).filter(track => {
+            return track.mode === 'showing';
+          });
+        };
+
+        checkTrack = (textTrack, selectedTrack) => {
+          const activeNativeTracks = getActiveNativeTracks();
+          activeNativeTracks.length.should.equal(1);
+          selectedTrack.language.should.equal(textTrack.language);
+          textTrack.external
+            ? activeNativeTracks[0].language.should.equal(EXTERNAL_TRACK_ID)
+            : activeNativeTracks[0].language.should.equal(textTrack.language);
+        };
+      });
+
+      beforeEach(() => {
+        config = Utils.Object.mergeDeep(getConfigStructure(), {
+          sources: Utils.Object.mergeDeep({captions: [ExternalCaption.He, ExternalCaption.Ru]}, sourcesConfig.Mp4),
+          playback: {useNativeTextTrack: true}
+        });
+        player = new Player(config);
+        playerContainer.appendChild(player.getView());
+        video = player._engine.getVideoElement();
+        video.addTextTrack('subtitles', 'English', 'en');
+        video.addTextTrack('subtitles', 'French', 'fr');
+      });
+
+      it('should switch between internal and external', done => {
+        player.ready().then(() => {
+          let externalTracks = player.getTracks().filter(track => {
+            return track instanceof TextTrack && track.external;
+          });
+          let internalTracks = player.getTracks().filter(track => {
+            return track instanceof TextTrack && !track.external;
+          });
+          switchTextTrack(externalTracks[0], internalTracks[0], done);
+        });
+        player.load();
+      });
+
+      it('should switch between internal and internal', done => {
+        player.ready().then(() => {
+          let internalTracks = player.getTracks().filter(track => {
+            return track instanceof TextTrack && !track.external;
+          });
+          switchTextTrack(internalTracks[0], internalTracks[1], done);
+        });
+        player.load();
+      });
+
+      it('should switch between external and external', done => {
+        player.ready().then(() => {
+          let externalTracks = player.getTracks().filter(track => {
+            return track instanceof TextTrack && track.external;
+          });
+          switchTextTrack(externalTracks[0], externalTracks[1], done);
+        });
+        player.load();
+      });
+
+      it('should getTracks return external and internal caption', done => {
+        player.ready().then(() => {
+          try {
+            let tracks = player.getTracks().filter(track => {
+              return track instanceof TextTrack;
+            });
+            tracks.length.should.equal(5);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+        player.load();
+      });
+
+      it('should create only one track for external', done => {
+        player.ready().then(() => {
+          try {
+            Array.from(video.textTracks).length.should.equal(3);
+            const externalTrack = Array.from(video.textTracks).filter(track => track.language === EXTERNAL_TRACK_ID);
+            externalTrack.length.should.equal(1);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+        player.load();
+      });
+    });
+
+    describe('useNativeTextTrack = false', () => {
+      before(() => {
+        getActiveNativeTracks = () => {
+          return Array.from(video.textTracks).filter(track => {
+            return track.mode === 'hidden';
+          });
+        };
+        checkTrack = (textTrack, selectedTrack) => {
+          const activeNativeTracks = getActiveNativeTracks();
+          if (!textTrack.external) {
+            activeNativeTracks.length.should.equal(1);
+            activeNativeTracks[0].language.should.equal(textTrack.language);
+            player._externalCaptionsHandler._isTextTrackActive = false;
+          } else {
+            activeNativeTracks.length.should.equal(0);
+            player._externalCaptionsHandler._isTextTrackActive = true;
+          }
+          selectedTrack.language.should.equal(textTrack.language);
+        };
+      });
+
+      beforeEach(() => {
+        config = Utils.Object.mergeDeep(getConfigStructure(), {
+          sources: Utils.Object.mergeDeep({captions: [ExternalCaption.He, ExternalCaption.Ru]}, sourcesConfig.Mp4),
+          playback: {useNativeTextTrack: false}
+        });
+        player = new Player(config);
+        playerContainer.appendChild(player.getView());
+        video = player._engine.getVideoElement();
+        video.addTextTrack('subtitles', 'English', 'en');
+        video.addTextTrack('subtitles', 'French', 'fr');
+      });
+
+      it('should switch between internal and external', done => {
+        player.ready().then(() => {
+          let externalTracks = player.getTracks().filter(track => {
+            return track instanceof TextTrack && track.external;
+          });
+          let internalTracks = player.getTracks().filter(track => {
+            return track instanceof TextTrack && !track.external;
+          });
+          switchTextTrack(externalTracks[0], internalTracks[0], done);
+        });
+        player.load();
+      });
+
+      it('should switch between internal and internal', done => {
+        player.ready().then(() => {
+          let internalTracks = player.getTracks().filter(track => {
+            return track instanceof TextTrack && !track.external;
+          });
+          switchTextTrack(internalTracks[0], internalTracks[1], done);
+        });
+        player.load();
+      });
+
+      it('should switch between external and external', done => {
+        player.ready().then(() => {
+          let externalTracks = player.getTracks().filter(track => {
+            return track instanceof TextTrack && track.external;
+          });
+          switchTextTrack(externalTracks[0], externalTracks[1], done);
+        });
+        player.load();
+      });
+
+      it('should getTracks return external and internal caption', done => {
+        player.ready().then(() => {
+          try {
+            let tracks = player.getTracks().filter(track => {
+              return track instanceof TextTrack;
+            });
+            tracks.length.should.equal(5);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+        player.load();
+      });
+
+      it('should not create native track for external', done => {
+        player.ready().then(() => {
+          try {
+            Array.from(video.textTracks).length.should.equal(2);
+            const externalTrack = Array.from(video.textTracks).filter(track => track.language === EXTERNAL_TRACK_ID);
+            externalTrack.length.should.equal(0);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+        player.load();
       });
     });
   });

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1236,7 +1236,7 @@ describe('Player', function () {
     });
   });
 
-  describe.only('Text Track', () => {
+  describe('Text Track', () => {
     let config, player, video, playerContainer;
 
     before(() => {


### PR DESCRIPTION
### Description of the Changes

Issue: external tracks on native still exist on player tracks API and for next media.
Solution: add a track called playkit-external-track for external tracks and don't expose it on API.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
