### PR TITLE
feat(FEC-10682): signal seek in different way from buffering.

### DIFF
--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -7,7 +7,6 @@ import {CustomEventType, Html5EventType} from '../event/event-type';
 import FakeEvent from '../event/fake-event';
 import getLogger from '../utils/logger';
 
-const SEEKING_THRESHOLD: number = 500;
 /**
  * This class responsible to manage all the state machine of the player.
  * @classdesc
@@ -115,14 +114,10 @@ export default class StateManager {
         if (this._player.seeking) {
           this._updateState(StateType.SEEKING);
           this._dispatchEvent();
-          //if waiting and seeking took more than threshold, it's buffering
-          setTimeout(() => {
-            if (StateType.SEEKING === this._curState.type) {
-              this._waiting();
-            }
-          }, SEEKING_THRESHOLD);
         } else {
-          this._waiting();
+          this._updateState(StateType.BUFFERING);
+          this._lastWaitingTime = this._player.currentTime;
+          this._dispatchEvent();
         }
       },
       [Html5EventType.ENDED]: () => {
@@ -237,16 +232,6 @@ export default class StateManager {
       }: StateChanged)
     );
     this._player.dispatchEvent(event);
-  }
-  /**
-   * waiting handler on state manager
-   * @private
-   * @returns {void}
-   */
-  _waiting(): void {
-    this._updateState(StateType.BUFFERING);
-    this._lastWaitingTime = this._player.currentTime;
-    this._dispatchEvent();
   }
   /**
    * Destroys the state manager.

--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -89,6 +89,12 @@ export default class StateManager {
       [Html5EventType.ERROR]: () => {
         this._updateState(StateType.IDLE);
         this._dispatchEvent();
+      },
+      [Html5EventType.SEEKED]: () => {
+        if (this._prevState && this._prevState.type === StateType.PLAYING) {
+          this._updateState(StateType.PLAYING);
+          this._dispatchEvent();
+        }
       }
     },
     [StateType.PAUSED]: {
@@ -112,7 +118,7 @@ export default class StateManager {
       },
       [Html5EventType.WAITING]: () => {
         if (this._player.seeking) {
-          this._updateState(StateType.SEEKING);
+          this._updateState(StateType.LOADING);
           this._dispatchEvent();
         } else {
           this._updateState(StateType.BUFFERING);
@@ -144,12 +150,6 @@ export default class StateManager {
           this._updateState(StateType.PLAYING);
           this._dispatchEvent();
         }
-      }
-    },
-    [StateType.SEEKING]: {
-      [Html5EventType.SEEKED]: () => {
-        this._updateState(this._prevState.type);
-        this._dispatchEvent();
       }
     }
   };

--- a/src/state/state-type.js
+++ b/src/state/state-type.js
@@ -4,7 +4,8 @@ const StateType: PKStateTypes = {
   LOADING: 'loading',
   PLAYING: 'playing',
   PAUSED: 'paused',
-  BUFFERING: 'buffering'
+  BUFFERING: 'buffering',
+  SEEKING: 'seeking'
 };
 
 export {StateType};

--- a/src/state/state-type.js
+++ b/src/state/state-type.js
@@ -4,8 +4,7 @@ const StateType: PKStateTypes = {
   LOADING: 'loading',
   PLAYING: 'playing',
   PAUSED: 'paused',
-  BUFFERING: 'buffering',
-  SEEKING: 'seeking'
+  BUFFERING: 'buffering'
 };
 
 export {StateType};


### PR DESCRIPTION
### Description of the Changes

Issue: seek and the buffer was signaled as the same state in the player - couldn't be able to find the difference between the real buffer and seeking.
Solution: add a new state for seeking to make sure it won't signal as a buffer.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
