### PR TITLE
fix(FEC-10681): pre roll stuck half way or doesn't allow the content to start playing on iphone and chrome

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1871,7 +1871,6 @@ export default class Player extends FakeEventTarget {
       Player._logger.warn('Autoplay failed, pause player');
       this._posterManager.show();
       this.load();
-      this.ready().then(() => this.pause());
       this.dispatchEvent(new FakeEvent(CustomEventType.AUTOPLAY_FAILED));
     };
   }


### PR DESCRIPTION
### Description of the Changes

Don't pause once ready. 
This was right before the load was middleware. 
Also, it's redundant because the player it's already paused and moved to the `PAUSED` state by `METADATA_LOADED` 

Solves FEC-10681

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
