### PR TITLE
fix: CEA708 subtitle doesn't get correct index on native 

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1132,6 +1132,8 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._eventManager.listen(this._el.textTracks, 'addtrack', (event: any) => {
         if (event.track.kind === 'metadata') {
           listenToCueChange(event.track);
+        } else if (event.track.kind === 'captions' || event.track.kind === 'subtitles') {
+          this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_ADDED, {track: event.track}));
         }
       });
     }

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -299,6 +299,11 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._handleVideoError();
     });
     this._handleMetadataTrackEvents();
+    this._eventManager.listen(this._el.textTracks, 'addtrack', (event: any) => {
+      if (event.track.kind === 'captions' || event.track.kind === 'subtitles') {
+        this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_ADDED, {track: event.track}));
+      }
+    });
     let mediaSourceAdapter = this._mediaSourceAdapter;
     if (mediaSourceAdapter) {
       this._eventManager.listen(mediaSourceAdapter, CustomEventType.VIDEO_TRACK_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
@@ -1132,8 +1137,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._eventManager.listen(this._el.textTracks, 'addtrack', (event: any) => {
         if (event.track.kind === 'metadata') {
           listenToCueChange(event.track);
-        } else if (event.track.kind === 'captions' || event.track.kind === 'subtitles') {
-          this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_ADDED, {track: event.track}));
         }
       });
     }

--- a/src/event/event-type.js
+++ b/src/event/event-type.js
@@ -163,6 +163,10 @@ const CustomEventType: PKEventTypes = {
    */
   TEXT_TRACK_CHANGED: 'texttrackchanged',
   /**
+   * Fires when the text track added to native
+   */
+  TEXT_TRACK_ADDED: 'texttrackadded',
+  /**
    * Fires when the active text track cue has changed.
    */
   TEXT_CUE_CHANGED: 'textcuechanged',

--- a/src/player.js
+++ b/src/player.js
@@ -1747,8 +1747,8 @@ export default class Player extends FakeEventTarget {
     const trackIndex = videoElement
       ? Array.from(videoElement.textTracks).findIndex(track => track && track.language === event.payload.track.language)
       : -1;
-    const textTracks = this._getTextTracks();
     if (trackIndex === 0) {
+      const textTracks = this._getTextTracks();
       // new native track added to start or end of text track list so if it added to start we should fix our indexes
       // by increasing the index by 1
       textTracks.forEach(track => {

--- a/src/player.js
+++ b/src/player.js
@@ -2134,7 +2134,9 @@ export default class Player extends FakeEventTarget {
    */
   _updateTracks(tracks: Array<Track>): void {
     Player._logger.debug('Tracks changed', tracks);
-    this._eventManager.listen(this._engine, CustomEventType.TEXT_TRACK_ADDED, (event: FakeEvent) => this._onTextTrackAdded(event));
+    if (this.config.playback.useNativeTextTrack) {
+      this._eventManager.listen(this._engine, CustomEventType.TEXT_TRACK_ADDED, (event: FakeEvent) => this._onTextTrackAdded(event));
+    }
     this._tracks = tracks.concat(this._externalCaptionsHandler.getExternalTracks(tracks));
     this._addTextTrackOffOption();
     this._maybeSetTracksLabels();

--- a/src/player.js
+++ b/src/player.js
@@ -28,7 +28,7 @@ import {DefaultConfig} from './player-config.js';
 import './assets/style.css';
 import PKError from './error/error';
 import {EngineProvider} from './engines/engine-provider';
-import {ExternalCaptionsHandler} from './track/external-captions-handler';
+import {EXTERNAL_TRACK_ID, ExternalCaptionsHandler} from './track/external-captions-handler';
 import {AdBreakType} from './ads/ad-break-type';
 import {AdTagType} from './ads/ad-tag-type';
 import {ResizeWatcher} from './utils/resize-watcher';
@@ -2128,14 +2128,16 @@ export default class Player extends FakeEventTarget {
    */
   _maybeAdjustTextTracksIndexes(): void {
     if (this._config.playback.useNativeTextTrack) {
-      const getNativeLanguageTrackIndex = (textTrack: TextTrack): number => {
-        const videoElement = this.getVideoElement();
-        return videoElement ? Array.from(videoElement.textTracks).findIndex(track => (track ? track.language === textTrack.language : false)) : -1;
-      };
+      const videoElement = this.getVideoElement();
+      const externalIndex = videoElement
+        ? Array.from(videoElement.textTracks).findIndex(track => (track ? track.language === EXTERNAL_TRACK_ID : false))
+        : false;
       const textTracks = this._getTextTracks();
       let externalTrackIndex = textTracks.length;
+      // if external track added to start of text tracks should fix the indexes by set to next index cause there
+      // is only one text track for external tracks.
       textTracks.forEach(track => {
-        track.index = track.external ? externalTrackIndex++ : getNativeLanguageTrackIndex(track);
+        track.index = track.external ? ++externalTrackIndex : externalIndex === 0 ? ++track.index : track.index;
       });
     }
   }

--- a/src/player.js
+++ b/src/player.js
@@ -2134,8 +2134,8 @@ export default class Player extends FakeEventTarget {
         : false;
       const textTracks = this._getTextTracks();
       let externalTrackIndex = textTracks.length;
-      // if external track added to start of text tracks should fix the indexes by set to next index cause there
-      // is only one text track for external tracks.
+      // for external we make unique index to be able to select on API, external track added to start or end of native
+      // text tracks then we should fix the indexes by set to next index(only one native text track for external tracks)
       textTracks.forEach(track => {
         track.index = track.external ? ++externalTrackIndex : externalIndex === 0 ? ++track.index : track.index;
       });

--- a/src/player.js
+++ b/src/player.js
@@ -1746,7 +1746,7 @@ export default class Player extends FakeEventTarget {
     const videoElement = this.getVideoElement();
     const trackIndex = videoElement
       ? Array.from(videoElement.textTracks).findIndex(track => track && track.language === event.payload.track.language)
-      : false;
+      : -1;
     const textTracks = this._getTextTracks();
     if (trackIndex === 0) {
       // new native track added to start or end of text track list so if it added to start we should fix our indexes


### PR DESCRIPTION
### Description of the Changes

Issue: addTrack on safari add the track to the first position on TextTrackList.
Solution: register after native tracks loaded to addtexttrack to make sure if new tracks adding on index 0 it'll change the indexes for all tracks otherwise it won't change it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
