### PR TITLE
fix: repositioning cues by config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.64.5](https://github.com/kaltura/playkit-js/compare/v0.64.4...v0.64.5) (2020-12-03)
+
+
+
 ### [0.64.4](https://github.com/kaltura/playkit-js/compare/v0.64.3...v0.64.4) (2020-11-29)
 
 

--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -17,5 +17,5 @@ declare type PKPlaybackConfigObject = {
   preferNative: PKPreferNativeConfigObject,
   inBrowserFullscreen: boolean,
   playAdsWithMSE: boolean,
-  textTrackDisplaySetting: Cue
+  textTrackDisplaySetting: object
 };

--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -1,4 +1,6 @@
 // @flow
+import {Cue} from '../../src/track/vtt-cue';
+
 declare type PKPlaybackConfigObject = {
   audioLanguage: string,
   textLanguage: string,
@@ -14,5 +16,6 @@ declare type PKPlaybackConfigObject = {
   streamPriority: Array<PKStreamPriorityObject>,
   preferNative: PKPreferNativeConfigObject,
   inBrowserFullscreen: boolean,
-  playAdsWithMSE: boolean
+  playAdsWithMSE: boolean,
+  TextTrackDisplaySetting: Cue
 };

--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -17,5 +17,5 @@ declare type PKPlaybackConfigObject = {
   preferNative: PKPreferNativeConfigObject,
   inBrowserFullscreen: boolean,
   playAdsWithMSE: boolean,
-  textTrackDisplaySetting: object
+  textTrackDisplaySetting: Object
 };

--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -17,5 +17,5 @@ declare type PKPlaybackConfigObject = {
   preferNative: PKPreferNativeConfigObject,
   inBrowserFullscreen: boolean,
   playAdsWithMSE: boolean,
-  TextTrackDisplaySetting: Cue
+  textTrackDisplaySetting: Cue
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@playkit-js/playkit-js",
-  "version": "0.64.4",
+  "version": "0.64.5",
   "main": "dist/playkit.js",
   "scripts": {
     "clean": "rm -rf ./dist",

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -1,5 +1,3 @@
-import {Cue} from './track/vtt-cue';
-
 const DefaultConfig = {
   log: {
     level: 'ERROR'
@@ -40,7 +38,7 @@ const DefaultConfig = {
     },
     inBrowserFullscreen: false,
     playAdsWithMSE: false,
-    TextTrackDisplaySetting: Cue,
+    TextTrackDisplaySetting: {},
     streamPriority: [
       {
         engine: 'html5',

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -38,7 +38,7 @@ const DefaultConfig = {
     },
     inBrowserFullscreen: false,
     playAdsWithMSE: false,
-    TextTrackDisplaySetting: {},
+    textTrackDisplaySetting: {},
     streamPriority: [
       {
         engine: 'html5',

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -1,3 +1,5 @@
+import {Cue} from './track/vtt-cue';
+
 const DefaultConfig = {
   log: {
     level: 'ERROR'
@@ -38,6 +40,7 @@ const DefaultConfig = {
     },
     inBrowserFullscreen: false,
     playAdsWithMSE: false,
+    TextTrackDisplaySetting: Cue,
     streamPriority: [
       {
         engine: 'html5',

--- a/src/player.js
+++ b/src/player.js
@@ -475,6 +475,7 @@ export default class Player extends FakeEventTarget {
     } else {
       Utils.Object.mergeDeep(this._config, config);
     }
+    this.setTextDisplaySettings(this._config.playback.TextTrackDisplaySetting);
   }
 
   /**
@@ -1225,11 +1226,11 @@ export default class Player extends FakeEventTarget {
 
   /**
    * update the text display settings
-   * @param {Object} settings - text cue display settings
+   * @param {Cue} settings - text cue display settings
    * @public
    * @returns {void}
    */
-  setTextDisplaySettings(settings: Object): void {
+  setTextDisplaySettings(settings: Cue): void {
     this._textDisplaySettings = settings;
     this._updateCueDisplaySettings();
     for (let i = 0; i < this._activeTextCues.length; i++) {

--- a/src/player.js
+++ b/src/player.js
@@ -475,7 +475,7 @@ export default class Player extends FakeEventTarget {
     } else {
       Utils.Object.mergeDeep(this._config, config);
     }
-    this.setTextDisplaySettings(this._config.playback.TextTrackDisplaySetting);
+    this.setTextDisplaySettings(this._config.playback.textTrackDisplaySetting);
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -1226,11 +1226,11 @@ export default class Player extends FakeEventTarget {
 
   /**
    * update the text display settings
-   * @param {object} settings - text cue display settings
+   * @param {Object} settings - text cue display settings
    * @public
    * @returns {void}
    */
-  setTextDisplaySettings(settings: object): void {
+  setTextDisplaySettings(settings: Object): void {
     this._textDisplaySettings = settings;
     this._updateCueDisplaySettings();
     for (let i = 0; i < this._activeTextCues.length; i++) {

--- a/src/player.js
+++ b/src/player.js
@@ -1226,11 +1226,11 @@ export default class Player extends FakeEventTarget {
 
   /**
    * update the text display settings
-   * @param {Cue} settings - text cue display settings
+   * @param {object} settings - text cue display settings
    * @public
    * @returns {void}
    */
-  setTextDisplaySettings(settings: Cue): void {
+  setTextDisplaySettings(settings: object): void {
     this._textDisplaySettings = settings;
     this._updateCueDisplaySettings();
     for (let i = 0; i < this._activeTextCues.length; i++) {


### PR DESCRIPTION
### Description of the Changes

Issue: can't change cue visibility by config.
Solution: add config and use our API.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
