### PR TITLE
fix(FEC-10760): Youbora - bufferUnderrun event fired when buffering started and no bufferDuration in Ping events

### DIFF
--- a/src/state/state-manager.js
+++ b/src/state/state-manager.js
@@ -6,6 +6,7 @@ import {StateType} from './state-type';
 import {CustomEventType, Html5EventType} from '../event/event-type';
 import FakeEvent from '../event/fake-event';
 import getLogger from '../utils/logger';
+import Env from '../utils/env';
 
 /**
  * This class responsible to manage all the state machine of the player.
@@ -68,87 +69,49 @@ export default class StateManager {
    */
   _transitions: Transition = {
     [StateType.IDLE]: {
-      [Html5EventType.LOAD_START]: () => {
-        this._updateState(StateType.LOADING);
-        this._dispatchEvent();
-      },
-      [Html5EventType.PLAY]: () => {
-        this._updateState(StateType.BUFFERING);
-        this._dispatchEvent();
-      },
-      [Html5EventType.SEEKED]: () => {
-        this._updateState(StateType.PAUSED);
-        this._dispatchEvent();
-      }
+      [Html5EventType.LOAD_START]: () => this._updateState(StateType.LOADING),
+      [Html5EventType.PLAY]: () => this._updateState(StateType.BUFFERING),
+      [Html5EventType.SEEKED]: () => this._updateState(StateType.PAUSED)
     },
     [StateType.LOADING]: {
-      [Html5EventType.LOADED_METADATA]: () => {
-        this._updateState(StateType.PAUSED);
-        this._dispatchEvent();
-      },
-      [Html5EventType.ERROR]: () => {
-        this._updateState(StateType.IDLE);
-        this._dispatchEvent();
-      },
+      [Html5EventType.LOADED_METADATA]: () => this._updateState(StateType.PAUSED),
+      [Html5EventType.ERROR]: () => this._updateState(StateType.IDLE),
       [Html5EventType.SEEKED]: () => {
         if (this._prevState && this._prevState.type === StateType.PLAYING) {
           this._updateState(StateType.PLAYING);
-          this._dispatchEvent();
         }
       }
     },
     [StateType.PAUSED]: {
-      [Html5EventType.PLAY]: () => {
-        this._updateState(StateType.PLAYING);
-        this._dispatchEvent();
-      },
-      [Html5EventType.PLAYING]: () => {
-        this._updateState(StateType.PLAYING);
-        this._dispatchEvent();
-      },
-      [Html5EventType.ENDED]: () => {
-        this._updateState(StateType.IDLE);
-        this._dispatchEvent();
-      }
+      [Html5EventType.PLAY]: () => this._updateState(StateType.PLAYING),
+      [Html5EventType.PLAYING]: () => this._updateState(StateType.PLAYING),
+      [Html5EventType.ENDED]: () => this._updateState(StateType.IDLE)
     },
     [StateType.PLAYING]: {
-      [Html5EventType.PAUSE]: () => {
-        this._updateState(StateType.PAUSED);
-        this._dispatchEvent();
-      },
+      [Html5EventType.PAUSE]: () => this._updateState(StateType.PAUSED),
       [Html5EventType.WAITING]: () => {
         if (this._player.seeking) {
           this._updateState(StateType.LOADING);
-          this._dispatchEvent();
         } else {
           this._updateState(StateType.BUFFERING);
           this._lastWaitingTime = this._player.currentTime;
-          this._dispatchEvent();
         }
       },
-      [Html5EventType.ENDED]: () => {
-        this._updateState(StateType.IDLE);
-        this._dispatchEvent();
-      },
-      [Html5EventType.ERROR]: () => {
-        this._updateState(StateType.IDLE);
-        this._dispatchEvent();
-      }
+      [Html5EventType.ENDED]: () => this._updateState(StateType.IDLE),
+      [Html5EventType.ERROR]: () => this._updateState(StateType.IDLE)
     },
     [StateType.BUFFERING]: {
-      [Html5EventType.PLAYING]: () => {
-        this._updateState(StateType.PLAYING);
-        this._dispatchEvent();
-      },
-      [Html5EventType.PAUSE]: () => {
-        this._updateState(StateType.PAUSED);
-        this._dispatchEvent();
-      },
+      [Html5EventType.PLAYING]: () => this._updateState(StateType.PLAYING),
+      [Html5EventType.PAUSE]: () => this._updateState(StateType.PAUSED),
       [Html5EventType.TIME_UPDATE]: () => {
-        if (this._player.currentTime !== this._lastWaitingTime && this._prevState && this._prevState.type === StateType.PLAYING) {
+        if (
+          Env.browser.name === 'IE' &&
+          this._player.currentTime !== this._lastWaitingTime &&
+          this._prevState &&
+          this._prevState.type === StateType.PLAYING
+        ) {
           this._lastWaitingTime = null;
           this._updateState(StateType.PLAYING);
-          this._dispatchEvent();
         }
       }
     }
@@ -215,6 +178,7 @@ export default class StateManager {
       this._prevState = this._curState;
       this._curState = new State(type);
       this._logger.debug(`Switch player state: from ${this._prevState.type} to ${this._curState.type}`);
+      this._dispatchEvent();
     }
   }
 

--- a/test/src/configs/external-captions.json
+++ b/test/src/configs/external-captions.json
@@ -1,16 +1,16 @@
 {
   "He": {
-        "url": "http://externaltests.dev.kaltura.com/player/library_Player_V3/Captions/Caption_files_VTT/hebrew.vtt",
-        "label": "Heb",
-        "language": "he",
-        "type": "vtt",
-        "default": false
+    "url": "http://externaltests.dev.kaltura.com/player/library_Player_V3/Captions/Caption_files_VTT/hebrew.vtt",
+    "label": "Heb",
+    "language": "he",
+    "type": "vtt",
+    "default": false
   },
   "Ru": {
-        "url": "http://externaltests.dev.kaltura.com/player/library_Player_V3/Captions/Caption_files_VTT/hebrew.vtt",
-        "label": "Rus",
-        "language": "ru",
-        "type": "vtt",
-        "default": false
+    "url": "http://externaltests.dev.kaltura.com/player/library_Player_V3/Captions/Caption_files_VTT/hebrew.vtt",
+    "label": "Rus",
+    "language": "ru",
+    "type": "vtt",
+    "default": false
   }
 }


### PR DESCRIPTION
### Description of the Changes

When buffering on live content, the order of events that triggered from the video element is: 
1. `playing`
2. `waiting`
3. `timeupdate`
(this is true for all browsers except IE)
Because we're triggering `playing` on `timeupdate` event we're causing Youbora to report end of buffer when the player is actually still buffering.

The solution is to exclude this logic only to IE.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
