### PR TITLE
feat(FEC-10766): create text config section and option for styling

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -469,6 +469,7 @@ var config = {
 > {
 >  useNativeTextTrack: boolean,
 >  enableCEA708Captions: boolean,
+>  forceCenter: boolean,
 >  textTrackDisplaySetting: Object,
 >  textStyle: TextStyle,
 >  captionsTextTrack1Label: string,
@@ -484,6 +485,7 @@ var config = {
 > {
 >  useNativeTextTrack: false,
 >  enableCEA708Captions: false,
+>  forceCenter: false,
 >  captionsTextTrack1Label: "English",
 >  captionsTextTrack1LanguageCode: "en",
 >  captionsTextTrack2Label: "Spanish",
@@ -512,6 +514,16 @@ var config = {
 > > ##### Default: `false`
 > >
 > > ##### Description: Whether or not to enable CEA-708 captions.
+>
+> ##
+>
+> > ### config.text.forceCenter
+> >
+> > ##### Type: `Object`
+> >
+> > ##### Default: `false`
+> >
+> > ##### Description: set the forceCenter to true will override the position, align and size in textTrackDisplaySetting
 >
 > ##
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -595,7 +595,8 @@ var config = {
 >  streamPriority: Array<PKStreamPriorityObject>,
 >  preferNative: PKPreferNativeConfigObject,
 >  inBrowserFullscreen: boolean,
->  playAdsWithMSE: boolean
+>  playAdsWithMSE: boolean,
+>  screenLockOrientionMode: string
 > }
 > ```
 >
@@ -614,6 +615,7 @@ var config = {
 >  muted: false,
 >  pictureInPicture: true,
 >  playAdsWithMSE: false,
+>  screenLockOrientionMode: ScreenOrientationType.NONE,
 >  options: {
 >    html5: {
 >      hls: {},
@@ -924,6 +926,20 @@ var config = {
 > > ```
 > >
 > > > ##### Description: Gives the ability to share same video tag to play ads and source with media source
+>
+> ##
+>
+> > ### config.playback.screenLockOrientionMode
+> >
+> > ##### Type: `string` - value list option in ScreenOrientationType
+> >
+> > ##### Default: `none` - ScreenOrientationType.NONE
+> >
+> > ```js
+> > screenLockOrientionMode: string;
+> > ```
+> >
+> > > ##### Description: Gives the ability to lock the screen orientation in fullscreen
 >
 > ##
 >
@@ -1425,6 +1441,55 @@ var config = {
 > > ##### Default: ``
 > >
 > > ##### Description: A specific DRM key system to use.
+
+##
+
+> ### config.dimensions
+>
+> ##### Type: `PKDimensionsConfig`
+>
+> ```js
+> {
+>   width?: string | number;
+>   height?: string | number;
+>   ratio?: string;
+> }
+> ```
+>
+> ##### Description: Dimensions configuration
+>
+> > ### config.dimensions.width
+> >
+> > ##### Type: `string | number`
+> >
+> > ##### Default: `''`
+> >
+> > ##### Description: The width of the player.
+> >
+> > If number was provided, the width will be calculated in pixels (`width: 640` equivalent to `width: '640px'`).
+> > If string was provided, any valid css syntax can be passed, for example: `width: '100%'`, `width: 'auto'`, etc.
+> >
+> > ### config.dimensions.height
+> >
+> > ##### Type: `string | number`
+> >
+> > ##### Default: `''`
+> >
+> > ##### Description: The height of the player.
+> >
+> > If number was provided, the height will be calculated in pixels (`height: 360` equivalent to `width: '360px'`).
+> > If string was provided, any valid css syntax can be passed, for example: `height: '100%'`, `height: 'auto'`, etc.
+> >
+> > ### config.dimensions.ratio
+> >
+> > ##### Type: `string`
+> >
+> > ##### Default: `''`
+> >
+> > ##### Description: Defines the aspect ratio of the player.
+> >
+> > The aspect ratio should be written in the form of `'width:height'`, for example: `'4:3'` (classic TV ratio).
+> > If one of the `height` or `width` parameters is additionally provided in the configuration, the value of the other parameter not provided will be calculated accordingly to match the aspect ratio. If both were provided, the `height` value would be overridden.
 
 ##
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,8 @@ var player = playkit.core.loadPlayer(config);
   network: PKNetworkConfigObject,
   customLabels: PKCustomLabelsConfigObject,
   abr: PKAbrConfigObject,
-  drm: PKDrmConfigObject
+  drm: PKDrmConfigObject,
+  dimensions: PKDimensionsConfig
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,8 +20,7 @@ var player = playkit.core.loadPlayer(config);
   network: PKNetworkConfigObject,
   customLabels: PKCustomLabelsConfigObject,
   abr: PKAbrConfigObject,
-  drm: PKDrmConfigObject,
-  dimensions: PKDimensionsConfig
+  drm: PKDrmConfigObject
 }
 ```
 
@@ -38,15 +37,18 @@ var config = {
     },
     metadata: {}
   },
-  playback: {
-    audioLanguage: '',
-    textLanguage: '',
-    useNativeTextTrack: false,
+  text: {
     enableCEA708Captions: false,
+    useNativeTextTrack: false,
+    forceCenterCaptions: false,
     captionsTextTrack1Label: 'English',
     captionsTextTrack1LanguageCode: 'en',
     captionsTextTrack2Label: 'Spanish',
-    captionsTextTrack2LanguageCode: 'es',
+    captionsTextTrack2LanguageCode: 'es'
+  },
+  playback: {
+    audioLanguage: '',
+    textLanguage: '',
     volume: 1,
     startTime: -1,
     playsinline: true,
@@ -457,8 +459,120 @@ var config = {
 > > };
 > > ```
 
-##
-
+> ##
+> ### config.text
+>
+> ##### Type: `PKTextConfigObject`
+>
+> ```js
+> {
+>  useNativeTextTrack: boolean,
+>  enableCEA708Captions: boolean,
+>  textTrackDisplaySetting: Object,
+>  textStyle: TextStyle,
+>  captionsTextTrack1Label: string,
+>  captionsTextTrack1LanguageCode: string,
+>  captionsTextTrack2Label: string,
+>  captionsTextTrack2LanguageCode: string
+> }
+> ```
+>
+> ##### Default:
+>
+> ```js
+> {
+>  useNativeTextTrack: false,
+>  enableCEA708Captions: false,
+>  captionsTextTrack1Label: "English",
+>  captionsTextTrack1LanguageCode: "en",
+>  captionsTextTrack2Label: "Spanish",
+>  captionsTextTrack2LanguageCode: "es"
+> }
+> ```
+>
+> ##
+>
+> > ### config.text.useNativeTextTrack
+> >
+> > ##### Type: `boolean`
+> >
+> > ##### Default: `false`
+> >
+> > ##### Description: Determines whether to use native browser text tracks or not.
+> >
+> > If set to True, the native browser captions will be displayed.
+>
+> ##
+>
+> > ### config.text.enableCEA708Captions
+> >
+> > ##### Type: `boolean`
+> >
+> > ##### Default: `false`
+> >
+> > ##### Description: Whether or not to enable CEA-708 captions.
+>
+> ##
+>
+> > ### config.text.textTrackDisplaySetting
+> >
+> > ##### Type: `Object`
+> >
+> > ##### Default: `null`
+> >
+> > ##### Description: set the textTrackDisplaySetting to override the cues position
+>
+> ##
+>
+> > ### config.text.textStyle
+> >
+> > ##### Type: `TextStyle`
+> >
+> > ##### Default: `null`
+> >
+> > ##### Description: set the styling for text tracks
+>
+> ##
+>
+> > ### config.text.captionsTextTrack1Label
+> >
+> > ##### Type: `string`
+> >
+> > ##### Default: `English`
+> >
+> > ##### Description: Label for the CEA-708 captions track 1.
+>
+> ##
+>
+> > ### config.text.captionsTextTrack1LanguageCode
+> >
+> > ##### Type: `string`
+> >
+> > ##### Default: `en`
+> >
+> > ##### Description: RFC 3066 language code for the CEA-708 captions track 1.
+>
+> ##
+>
+> > ### config.text.captionsTextTrack2Label
+> >
+> > ##### Type: `string`
+> >
+> > ##### Default: `Spanish`
+> >
+> > ##### Description: Label for the CEA-708 captions track 2.
+>
+> ##
+>
+> > ### config.text.captionsTextTrack2LanguageCode
+> >
+> > ##### Type: `string`
+> >
+> > ##### Default: `es`
+> >
+> > ##### Description: RFC 3066 language code for the CEA-708 captions track 2.
+>
+> ##
 > ### config.playback
 >
 > ##### Type: `PKPlaybackConfigObject`
@@ -467,12 +581,6 @@ var config = {
 > {
 >  audioLanguage: string,
 >  textLanguage: string,
->  useNativeTextTrack: boolean,
->  enableCEA708Captions: boolean,
->  captionsTextTrack1Label: string,
->  captionsTextTrack1LanguageCode: string,
->  captionsTextTrack2Label: string,
->  captionsTextTrack2LanguageCode: string,
 >  volume: number,
 >  startTime: number,
 >  playsinline: boolean,
@@ -486,8 +594,7 @@ var config = {
 >  streamPriority: Array<PKStreamPriorityObject>,
 >  preferNative: PKPreferNativeConfigObject,
 >  inBrowserFullscreen: boolean,
->  playAdsWithMSE: boolean,
->  screenLockOrientionMode: string
+>  playAdsWithMSE: boolean
 > }
 > ```
 >
@@ -497,12 +604,6 @@ var config = {
 > {
 >  audioLanguage: "",
 >  textLanguage: "",
->  useNativeTextTrack: false,
->  enableCEA708Captions: false,
->  captionsTextTrack1Label: "English",
->  captionsTextTrack1LanguageCode: "en",
->  captionsTextTrack2Label: "Spanish",
->  captionsTextTrack2LanguageCode: "es",
 >  volume: 1,
 >  startTime: -1,
 >  playsinline: true,
@@ -512,7 +613,6 @@ var config = {
 >  muted: false,
 >  pictureInPicture: true,
 >  playAdsWithMSE: false,
->  screenLockOrientionMode: ScreenOrientationType.NONE,
 >  options: {
 >    html5: {
 >      hls: {},
@@ -600,68 +700,6 @@ var config = {
 > > 2.  **Manifest default language** - If a default language is specified in the manifest file then this language will be selected.
 > > 3.  **First language in manifest** - The first language specified in the manifest file will be selected.
 > > 4.  If none of the above conditions have taken place, do not display captions.
->
-> ##
->
-> > ### config.playback.useNativeTextTrack
-> >
-> > ##### Type: `boolean`
-> >
-> > ##### Default: `false`
-> >
-> > ##### Description: Determines whether to use native browser text tracks or not.
-> >
-> > If set to True, the native browser captions will be displayed.
->
-> ##
->
-> > ### config.playback.enableCEA708Captions
-> >
-> > ##### Type: `boolean`
-> >
-> > ##### Default: `false`
-> >
-> > ##### Description: Whether or not to enable CEA-708 captions.
->
-> ##
->
-> > ### config.playback.captionsTextTrack1Label
-> >
-> > ##### Type: `string`
-> >
-> > ##### Default: `English`
-> >
-> > ##### Description: Label for the CEA-708 captions track 1.
->
-> ##
->
-> > ### config.playback.captionsTextTrack1LanguageCode
-> >
-> > ##### Type: `string`
-> >
-> > ##### Default: `en`
-> >
-> > ##### Description: RFC 3066 language code for the CEA-708 captions track 1.
->
-> ##
->
-> > ### config.playback.captionsTextTrack2Label
-> >
-> > ##### Type: `string`
-> >
-> > ##### Default: `Spanish`
-> >
-> > ##### Description: Label for the CEA-708 captions track 2.
->
-> ##
->
-> > ### config.playback.captionsTextTrack2LanguageCode
-> >
-> > ##### Type: `string`
-> >
-> > ##### Default: `es`
-> >
-> > ##### Description: RFC 3066 language code for the CEA-708 captions track 2.
 >
 > ##
 >
@@ -885,20 +923,6 @@ var config = {
 > > ```
 > >
 > > > ##### Description: Gives the ability to share same video tag to play ads and source with media source
->
-> ##
->
-> > ### config.playback.screenLockOrientionMode
-> >
-> > ##### Type: `string` - value list option in ScreenOrientationType
-> >
-> > ##### Default: `none` - ScreenOrientationType.NONE
-> >
-> > ```js
-> > screenLockOrientionMode: string;
-> > ```
-> >
-> > > ##### Description: Gives the ability to lock the screen orientation in fullscreen
 >
 > ##
 >
@@ -1400,55 +1424,6 @@ var config = {
 > > ##### Default: ``
 > >
 > > ##### Description: A specific DRM key system to use.
-
-##
-
-> ### config.dimensions
->
-> ##### Type: `PKDimensionsConfig`
->
-> ```js
-> {
->   width?: string | number;
->   height?: string | number;
->   ratio?: string;
-> }
-> ```
->
-> ##### Description: Dimensions configuration
->
-> > ### config.dimensions.width
-> >
-> > ##### Type: `string | number`
-> >
-> > ##### Default: `''`
-> >
-> > ##### Description: The width of the player.
-> >
-> > If number was provided, the width will be calculated in pixels (`width: 640` equivalent to `width: '640px'`).
-> > If string was provided, any valid css syntax can be passed, for example: `width: '100%'`, `width: 'auto'`, etc.
-> >
-> > ### config.dimensions.height
-> >
-> > ##### Type: `string | number`
-> >
-> > ##### Default: `''`
-> >
-> > ##### Description: The height of the player.
-> >
-> > If number was provided, the height will be calculated in pixels (`height: 360` equivalent to `width: '360px'`).
-> > If string was provided, any valid css syntax can be passed, for example: `height: '100%'`, `height: 'auto'`, etc.
-> >
-> > ### config.dimensions.ratio
-> >
-> > ##### Type: `string`
-> >
-> > ##### Default: `''`
-> >
-> > ##### Description: Defines the aspect ratio of the player.
-> >
-> > The aspect ratio should be written in the form of `'width:height'`, for example: `'4:3'` (classic TV ratio).
-> > If one of the `height` or `width` parameters is additionally provided in the configuration, the value of the other parameter not provided will be calculated accordingly to match the aspect ratio. If both were provided, the `height` value would be overridden.
 
 ##
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,7 @@ var config = {
   text: {
     enableCEA708Captions: false,
     useNativeTextTrack: false,
-    forceCenterCaptions: false,
+    forceCenter: false,
     captionsTextTrack1Label: 'English',
     captionsTextTrack1LanguageCode: 'en',
     captionsTextTrack2Label: 'Spanish',

--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -2,7 +2,6 @@
 declare type PKPlaybackConfigObject = {
   audioLanguage: string,
   textLanguage: string,
-  useNativeTextTrack: boolean,
   volume: number,
   playsinline: boolean,
   crossOrigin: string,

--- a/flow-typed/types/text-config.js
+++ b/flow-typed/types/text-config.js
@@ -6,7 +6,7 @@ declare type PKTextConfigObject = {
   useNativeTextTrack: boolean,
   textTrackDisplaySetting: Object,
   textStyle: TextStyle,
-  forceCenterCaptions: boolean,
+  forceCenter: boolean,
   captionsTextTrack1Label: string,
   captionsTextTrack1LanguageCode: string,
   captionsTextTrack2Label: string,

--- a/flow-typed/types/text-config.js
+++ b/flow-typed/types/text-config.js
@@ -5,7 +5,7 @@ declare type PKTextConfigObject = {
   enableCEA708Captions: boolean,
   useNativeTextTrack: boolean,
   textTrackDisplaySetting: Object,
-  textStyle: TextStyle | Object,
+  textStyle: TextStyle | PKTextStyleObject,
   forceCenter: boolean,
   captionsTextTrack1Label: string,
   captionsTextTrack1LanguageCode: string,

--- a/flow-typed/types/text-config.js
+++ b/flow-typed/types/text-config.js
@@ -5,7 +5,7 @@ declare type PKTextConfigObject = {
   enableCEA708Captions: boolean,
   useNativeTextTrack: boolean,
   textTrackDisplaySetting: Object,
-  textStyle: TextStyle,
+  textStyle: TextStyle | Object,
   forceCenter: boolean,
   captionsTextTrack1Label: string,
   captionsTextTrack1LanguageCode: string,

--- a/flow-typed/types/text-config.js
+++ b/flow-typed/types/text-config.js
@@ -1,0 +1,14 @@
+// @flow
+import {TextStyle} from '../../src/track/text-style';
+
+declare type PKTextConfigObject = {
+  enableCEA708Captions: boolean,
+  useNativeTextTrack: boolean,
+  textTrackDisplaySetting: Object,
+  textStyle: TextStyle,
+  forceCenterCaptions: boolean,
+  captionsTextTrack1Label: string,
+  captionsTextTrack1LanguageCode: string,
+  captionsTextTrack2Label: string,
+  captionsTextTrack2LanguageCode: string
+};

--- a/flow-typed/types/text-style.js
+++ b/flow-typed/types/text-style.js
@@ -1,0 +1,11 @@
+// @flow
+declare type PKTextStyleObject = {
+  fontSize: string,
+  fontScale: number,
+  fontFamily: string,
+  fontColor: Array<number>,
+  fontOpacity: number,
+  backgroundColor: Array<number>,
+  backgroundOpacity: number,
+  fontEdge: Array<Array<number>>
+};

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -188,18 +188,20 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       displayTextTrack: false,
       progressiveSources: []
     };
-    if (Utils.Object.hasPropertyPath(config, 'playback.useNativeTextTrack')) {
-      adapterConfig.displayTextTrack = Utils.Object.getPropertyPath(config, 'playback.useNativeTextTrack');
+    if (Utils.Object.hasPropertyPath(config, 'text.useNativeTextTrack')) {
+      adapterConfig.displayTextTrack = Utils.Object.getPropertyPath(config, 'text.useNativeTextTrack');
     }
     if (Utils.Object.hasPropertyPath(config, 'sources.progressive')) {
       adapterConfig.progressiveSources = Utils.Object.getPropertyPath(config, 'sources.progressive');
     }
-    if (config.playback) {
-      adapterConfig.enableCEA708Captions = config.playback.enableCEA708Captions;
-      adapterConfig.captionsTextTrack1Label = config.playback.captionsTextTrack1Label;
-      adapterConfig.captionsTextTrack1LanguageCode = config.playback.captionsTextTrack1LanguageCode;
-      adapterConfig.captionsTextTrack2Label = config.playback.captionsTextTrack2Label;
-      adapterConfig.captionsTextTrack2LanguageCode = config.playback.captionsTextTrack2LanguageCode;
+    if (Utils.Object.hasPropertyPath(config, 'text')) {
+      adapterConfig.enableCEA708Captions = config.text.enableCEA708Captions;
+      adapterConfig.captionsTextTrack1Label = config.text.captionsTextTrack1Label;
+      adapterConfig.captionsTextTrack1LanguageCode = config.text.captionsTextTrack1LanguageCode;
+      adapterConfig.captionsTextTrack2Label = config.text.captionsTextTrack2Label;
+      adapterConfig.captionsTextTrack2LanguageCode = config.text.captionsTextTrack2LanguageCode;
+    }
+    if (Utils.Object.hasPropertyPath(config, 'playback')) {
       if (Utils.Object.hasPropertyPath(config.playback, 'options.html5.native')) {
         Utils.Object.mergeDeep(adapterConfig, config.playback.options.html5.native);
       }

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -10,15 +10,18 @@ const DefaultConfig = {
     },
     metadata: {}
   },
-  playback: {
-    audioLanguage: '',
-    textLanguage: '',
-    useNativeTextTrack: false,
+  text: {
     enableCEA708Captions: false,
+    useNativeTextTrack: false,
+    forceCenterCaptions: false,
     captionsTextTrack1Label: 'English',
     captionsTextTrack1LanguageCode: 'en',
     captionsTextTrack2Label: 'Spanish',
-    captionsTextTrack2LanguageCode: 'es',
+    captionsTextTrack2LanguageCode: 'es'
+  },
+  playback: {
+    audioLanguage: '',
+    textLanguage: '',
     volume: 1,
     startTime: -1,
     playsinline: true,

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -13,7 +13,7 @@ const DefaultConfig = {
   text: {
     enableCEA708Captions: false,
     useNativeTextTrack: false,
-    forceCenterCaptions: false,
+    forceCenter: false,
     captionsTextTrack1Label: 'English',
     captionsTextTrack1LanguageCode: 'en',
     captionsTextTrack2Label: 'Spanish',

--- a/src/player.js
+++ b/src/player.js
@@ -1250,7 +1250,7 @@ export default class Player extends FakeEventTarget {
   }
 
   _applyTextTrackConfig(): void {
-    if (Utils.Object.getPropertyPath(this._config, 'text.forceCenterCaptions')) {
+    if (Utils.Object.getPropertyPath(this._config, 'text.forceCenter')) {
       this.setTextDisplaySettings({position: 'auto', align: 'center', size: '100'});
     } else if (Utils.Object.hasPropertyPath(this._config, 'text.textTrackDisplaySetting')) {
       this.setTextDisplaySettings(this._config.text.textTrackDisplaySetting);

--- a/src/player.js
+++ b/src/player.js
@@ -1257,7 +1257,7 @@ export default class Player extends FakeEventTarget {
     }
     try {
       if (Utils.Object.hasPropertyPath(this._config, 'text.textStyle')) {
-        this.textStyle = this._config.text.textStyle;
+        this.textStyle = new TextStyle(this._config.text.textStyle);
       }
     } catch (e) {
       Player._logger.warn(e);

--- a/src/player.js
+++ b/src/player.js
@@ -1252,12 +1252,17 @@ export default class Player extends FakeEventTarget {
   _applyTextTrackConfig(): void {
     if (Utils.Object.getPropertyPath(this._config, 'text.forceCenter')) {
       this.setTextDisplaySettings({position: 'auto', align: 'center', size: '100'});
-    } else if (Utils.Object.hasPropertyPath(this._config, 'text.textTrackDisplaySetting')) {
+    }
+    if (Utils.Object.hasPropertyPath(this._config, 'text.textTrackDisplaySetting')) {
       this.setTextDisplaySettings(this._config.text.textTrackDisplaySetting);
     }
     try {
       if (Utils.Object.hasPropertyPath(this._config, 'text.textStyle')) {
-        this.textStyle = new TextStyle(this._config.text.textStyle);
+        if (this._config.text.textStyle instanceof TextStyle) {
+          this.textStyle = this._config.text.textStyle;
+        } else {
+          this._textStyle.setTextStyle(this._config.text.textStyle);
+        }
       }
     } catch (e) {
       Player._logger.warn(e);

--- a/src/player.js
+++ b/src/player.js
@@ -481,6 +481,7 @@ export default class Player extends FakeEventTarget {
     } else {
       Utils.Object.mergeDeep(this._config, config);
     }
+    this._applyTextTrackConfig();
   }
 
   /**
@@ -1248,6 +1249,21 @@ export default class Player extends FakeEventTarget {
     return false;
   }
 
+  _applyTextTrackConfig(): void {
+    if (Utils.Object.getPropertyPath(this._config, 'text.forceCenterCaptions')) {
+      this.setTextDisplaySettings({position: 'auto', align: 'center', size: '100'});
+    } else if (Utils.Object.hasPropertyPath(this._config, 'text.textTrackDisplaySetting')) {
+      this.setTextDisplaySettings(this._config.text.textTrackDisplaySetting);
+    }
+    try {
+      if (Utils.Object.hasPropertyPath(this._config, 'text.textStyle')) {
+        this.textStyle = this._config.text.textStyle;
+      }
+    } catch (e) {
+      Player._logger.warn(e);
+    }
+  }
+
   /**
    * update the text display settings
    * @param {Object} settings - text cue display settings
@@ -1287,7 +1303,7 @@ export default class Player extends FakeEventTarget {
 
     try {
       this._textStyle = style;
-      if (this._config.playback.useNativeTextTrack) {
+      if (this._config.text.useNativeTextTrack) {
         sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::cue { ${style.toCSS()} }`, 0);
       } else if (this._engine) {
         this._engine.resetAllCues();
@@ -2127,7 +2143,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _maybeAdjustTextTracksIndexes(): void {
-    if (this._config.playback.useNativeTextTrack) {
+    if (this._config.text.useNativeTextTrack) {
       const getNativeLanguageTrackIndex = (textTrack: TextTrack): number => {
         const videoElement = this.getVideoElement();
         return videoElement ? Array.from(videoElement.textTracks).findIndex(track => (track ? track.language === textTrack.language : false)) : -1;
@@ -2246,7 +2262,7 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   _updateTextDisplay(cues: Array<Cue>): void {
-    if (!this._config.playback.useNativeTextTrack) {
+    if (!this._config.text.useNativeTextTrack) {
       processCues(window, cues, this._textDisplayEl, this._textStyle);
     }
   }

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -98,7 +98,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @public
    */
   hideTextTrack(): void {
-    if (this._player.config.playback.useNativeTextTrack) {
+    if (this._player.config.text.useNativeTextTrack) {
       this._resetExternalNativeTextTrack();
     } else {
       // only if external text track was active we need to hide it.
@@ -121,7 +121,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     if (!captions) {
       return [];
     }
-    if (this._player.config.playback.useNativeTextTrack) {
+    if (this._player.config.text.useNativeTextTrack) {
       this._addNativeTextTrack();
     }
     const playerTextTracks = tracks.filter(track => track instanceof TextTrack);
@@ -213,7 +213,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   }
   _selectTextTrack(textTrack: TextTrack) {
     this.hideTextTrack();
-    if (this._player.config.playback.useNativeTextTrack) {
+    if (this._player.config.text.useNativeTextTrack) {
       this._addCuesToNativeTextTrack(this._textTrackModel[textTrack.language].cues);
     } else {
       this._setTextTrack(textTrack);
@@ -515,7 +515,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @private
    */
   _setTextTrack(textTrack: TextTrack): void {
-    if (!this._player.config.playback.useNativeTextTrack) {
+    if (!this._player.config.text.useNativeTextTrack) {
       this._isTextTrackActive = true;
       ExternalCaptionsHandler._logger.debug('External text track changed', textTrack);
       this._activeTextCues = [];

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -183,11 +183,13 @@ class TextStyle {
   }
 
   setTextStyle(settings: Object) {
-    Object.keys(settings).forEach(function (key) {
-      if (Object.prototype.hasOwnProperty.call(this, key)) {
-        this[key] = settings[key];
-      }
-    });
+    if (settings) {
+      Object.keys(settings).forEach(function (key) {
+        if (Object.prototype.hasOwnProperty.call(this, key)) {
+          this[key] = settings[key];
+        }
+      });
+    }
   }
 
   getTextShadow(): string {

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -1,4 +1,5 @@
 // @flow
+import * as Utils from '../utils/util';
 /**
  * We use this number to calculate the scale of the text. so it will be : 1 + 0.25 * FontSizes.value
  * So, if the user selects 400% the scale would be: 1 + 0.25 * 4 = 2. so the font size should be multiplied by 2.
@@ -138,58 +139,50 @@ class TextStyle {
     return 'rgba(' + color.concat(opacity).join(',') + ')';
   }
 
-  /**
-   * Font size, such as 1, 2, 3...
-   * @type {number}
-   */
-  fontSize: string = '100%';
+  _config: PKTextStyleObject = {
+    /**
+     * Font size, such as 1, 2, 3...
+     * @type {number}
+     */
+    fontSize: '100%',
+    fontScale: 1,
+    /**
+     * @type {TextStyle.FontFamily}
+     */
+    fontFamily: TextStyle.FontFamily.SANS_SERIF,
+    /**
+     * @type {TextStyle.StandardColors}
+     */
+    fontColor: TextStyle.StandardColors.WHITE,
 
-  fontScale: number = 1;
+    /**
+     * @type {TextStyle.StandardOpacities}
+     * @expose
+     */
+    fontOpacity: TextStyle.StandardOpacities.OPAQUE,
 
-  /**
-   * @type {TextStyle.FontFamily}
-   */
-  fontFamily: string = TextStyle.FontFamily.SANS_SERIF;
+    /**
+     * @type {TextStyle.StandardColors}
+     */
+    backgroundColor: TextStyle.StandardColors.BLACK,
 
-  /**
-   * @type {TextStyle.StandardColors}
-   */
-  fontColor: Array<number> = TextStyle.StandardColors.WHITE;
+    /**
+     * @type {TextStyle.StandardOpacities}
+     */
+    backgroundOpacity: TextStyle.StandardOpacities.OPAQUE,
 
-  /**
-   * @type {TextStyle.StandardOpacities}
-   * @expose
-   */
-  fontOpacity: number = TextStyle.StandardOpacities.OPAQUE;
+    /**
+     * @type {TextStyle.EdgeStyles}
+     * @expose
+     */
+    fontEdge: TextStyle.EdgeStyles.NONE
+  };
 
-  /**
-   * @type {TextStyle.StandardColors}
-   */
-  backgroundColor: Array<number> = TextStyle.StandardColors.BLACK;
+  constructor() {}
 
-  /**
-   * @type {TextStyle.StandardOpacities}
-   */
-  backgroundOpacity: number = TextStyle.StandardOpacities.OPAQUE;
-
-  /**
-   * @type {TextStyle.EdgeStyles}
-   * @expose
-   */
-  fontEdge: Array<Array<number>> = TextStyle.EdgeStyles.NONE;
-
-  constructor(settings: Object) {
-    this.setTextStyle(settings);
-  }
-
-  setTextStyle(settings: Object) {
+  setTextStyle(settings: PKTextStyleObject) {
     if (settings) {
-      Object.keys(settings).forEach(key => {
-        if (Object.prototype.hasOwnProperty.call(this, key)) {
-          //$FlowFixMe
-          this[key] = settings[key];
-        }
-      });
+      this._config = Utils.Object.mergeDeep({}, this._config, settings);
     }
   }
 
@@ -197,11 +190,11 @@ class TextStyle {
     // A given edge effect may be implemented with multiple shadows.
     // Collect them all into an array, then combine into one attribute.
     let shadows: Array<string> = [];
-    for (let i = 0; i < this.fontEdge.length; i++) {
+    for (let i = 0; i < this._config.fontEdge.length; i++) {
       // shaka.asserts.assert(this.fontEdge[i].length == 6);
-      const color: Array<number> = this.fontEdge[i].slice(0, 3);
-      let shadow: Array<number> = this.fontEdge[i].slice(3, 6);
-      shadows.push(TextStyle.toRGBA(color, this.fontOpacity) + ' ' + shadow.join('px ') + 'px');
+      const color: Array<number> = this._config.fontEdge[i].slice(0, 3);
+      let shadow: Array<number> = this._config.fontEdge[i].slice(3, 6);
+      shadows.push(TextStyle.toRGBA(color, this._config.fontOpacity) + ' ' + shadow.join('px ') + 'px');
     }
     return shadows.join(',');
   }
@@ -214,9 +207,9 @@ class TextStyle {
    */
   toCSS(): string {
     let attributes: Array<string> = [];
-    attributes.push('font-family: ' + this.fontFamily);
-    attributes.push('color: ' + TextStyle.toRGBA(this.fontColor, this.fontOpacity));
-    attributes.push('background-color: ' + TextStyle.toRGBA(this.backgroundColor, this.backgroundOpacity));
+    attributes.push('font-family: ' + this._config.fontFamily);
+    attributes.push('color: ' + TextStyle.toRGBA(this._config.fontColor, this._config.fontOpacity));
+    attributes.push('background-color: ' + TextStyle.toRGBA(this._config.backgroundColor, this._config.backgroundOpacity));
     attributes.push('text-shadow: ' + this.getTextShadow());
     return attributes.join('!important; ');
   }
@@ -226,16 +219,7 @@ class TextStyle {
    * @returns {TextStyle} the cloned textStyle object
    */
   clone(): TextStyle {
-    let clonedTextStyle = new TextStyle();
-    clonedTextStyle.fontEdge = this.fontEdge;
-    clonedTextStyle.fontSize = this.fontSize;
-    clonedTextStyle.fontScale = this.fontScale;
-    clonedTextStyle.fontColor = this.fontColor;
-    clonedTextStyle.fontOpacity = this.fontOpacity;
-    clonedTextStyle.backgroundColor = this.backgroundColor;
-    clonedTextStyle.backgroundOpacity = this.backgroundOpacity;
-    clonedTextStyle.fontFamily = this.fontFamily;
-    return clonedTextStyle;
+    return new TextStyle(Utils.Object.copyDeep(this.config));
   }
 
   /**
@@ -244,18 +228,79 @@ class TextStyle {
    * @returns {boolean} - Whether the text styles are equal.
    */
   isEqual(textStyle: TextStyle): boolean {
-    return (
-      textStyle.fontEdge === this.fontEdge &&
-      textStyle.fontSize === this.fontSize &&
-      textStyle.fontColor === this.fontColor &&
-      textStyle.fontOpacity === this.fontOpacity &&
-      textStyle.backgroundColor === this.backgroundColor &&
-      textStyle.backgroundOpacity === this.backgroundOpacity
-    );
+    return JSON.stringify(textStyle.config) === JSON.stringify(this._config);
+  }
+
+  get config(): PKTextStyleObject {
+    return Utils.Object.copyDeep(this._config);
   }
 
   get implicitFontScale(): number {
-    return IMPLICIT_SCALE_PERCENTAGE * this.fontScale + 1;
+    return IMPLICIT_SCALE_PERCENTAGE * this._config.fontScale + 1;
+  }
+
+  get fontSize(): string {
+    return this._config.fontSize;
+  }
+
+  set fontSize(fontSize: string) {
+    this._config.fontSize = fontSize;
+  }
+
+  get fontScale(): number {
+    return this._config.fontScale;
+  }
+
+  set fontScale(fontScale: number) {
+    this._config.fontScale = fontScale;
+  }
+
+  get fontFamily(): string {
+    return this._config.fontFamily;
+  }
+
+  set fontFamily(fontFamily: string) {
+    this._config.fontFamily = fontFamily;
+  }
+
+  get fontColor(): Array<number> {
+    return this._config.fontColor;
+  }
+
+  set fontColor(fontColor: Array<number>) {
+    this._config.fontColor = fontColor;
+  }
+
+  get fontOpacity(): number {
+    return this._config.fontOpacity;
+  }
+
+  set fontOpacity(fontOpacity: number) {
+    this._config.fontOpacity = fontOpacity;
+  }
+
+  get backgroundColor(): Array<number> {
+    return this._config.backgroundColor;
+  }
+
+  set backgroundColor(backgroundColor: Array<number>) {
+    this._config.backgroundColor = backgroundColor;
+  }
+
+  get backgroundOpacity(): number {
+    return this._config.backgroundOpacity;
+  }
+
+  set backgroundOpacity(backgroundOpacity: number) {
+    this._config.backgroundOpacity = backgroundOpacity;
+  }
+
+  get fontEdge(): Array<Array<number>> {
+    return this._config.backgroundColor;
+  }
+
+  set fontEdge(fontEdge: Array<Array<number>>) {
+    this._config.fontEdge = fontEdge;
   }
 }
 

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -183,11 +183,11 @@ class TextStyle {
   }
 
   setTextStyle(settings: Object) {
-    for (let name in settings) {
-      if (this[name]) {
-        this[name] = settings[name];
+    Object.keys(settings).forEach(function (key) {
+      if (Object.prototype.hasOwnProperty.call(this, key)) {
+        this[key] = settings[key];
       }
-    }
+    });
   }
 
   getTextShadow(): string {

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -178,9 +178,11 @@ class TextStyle {
     fontEdge: TextStyle.EdgeStyles.NONE
   };
 
-  constructor() {}
+  constructor(settings?: PKTextStyleObject) {
+    this.setTextStyle(settings);
+  }
 
-  setTextStyle(settings: PKTextStyleObject) {
+  setTextStyle(settings?: PKTextStyleObject) {
     if (settings) {
       this._config = Utils.Object.mergeDeep({}, this._config, settings);
     }
@@ -296,7 +298,7 @@ class TextStyle {
   }
 
   get fontEdge(): Array<Array<number>> {
-    return this._config.backgroundColor;
+    return this._config.fontEdge;
   }
 
   set fontEdge(fontEdge: Array<Array<number>>) {

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -184,8 +184,9 @@ class TextStyle {
 
   setTextStyle(settings: Object) {
     if (settings) {
-      Object.keys(settings).forEach(function (key) {
+      Object.keys(settings).forEach(key => {
         if (Object.prototype.hasOwnProperty.call(this, key)) {
+          //$FlowFixMe
           this[key] = settings[key];
         }
       });

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -178,6 +178,18 @@ class TextStyle {
    */
   fontEdge: Array<Array<number>> = TextStyle.EdgeStyles.NONE;
 
+  constructor(settings: Object) {
+    this.setTextStyle(settings);
+  }
+
+  setTextStyle(settings: Object) {
+    for (let name in settings) {
+      if (this[name]) {
+        this[name] = settings[name];
+      }
+    }
+  }
+
   getTextShadow(): string {
     // A given edge effect may be implemented with multiple shadows.
     // Collect them all into an array, then combine into one attribute.

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -346,7 +346,7 @@ describe('NativeAdapter: _getParsedTracks', function () {
     video = document.createElement('video');
     nativeInstance = NativeAdapter.createAdapter(video, sourcesConfig.MultipleSources.progressive[0], {
       sources: sourcesConfig.MultipleSources,
-      playback: {enableCEA708Captions: true, captionsTextTrack1Label: ''}
+      text: {enableCEA708Captions: true, captionsTextTrack1Label: ''}
     });
   });
 

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1225,6 +1225,72 @@ describe('Player', function () {
         currentTextStyle.fontColor.should.deep.equal(textStyle.fontColor);
         currentTextStyle.fontEdge.should.deep.equal(textStyle.fontEdge);
       });
+    });
+
+    describe('setTextDisplaySettings', () => {
+      it('should change textDisplay settings', () => {
+        const settings = {line: -4};
+        player.setTextDisplaySettings(settings);
+        player._textDisplaySettings.should.deep.equal(settings);
+      });
+
+      it('should change textDisplay settings and remove setting from cue for empty values', () => {
+        const settings = {line: -4, position: '10%'};
+        player._activeTextCues[0] = {
+          position: 'auto',
+          align: 'center',
+          size: 100,
+          vertical: ''
+        };
+        player.setTextDisplaySettings(settings);
+        player._textDisplaySettings.should.deep.equal(settings);
+        player._activeTextCues[0].should.deep.equal(Utils.Object.mergeDeep(player._activeTextCues[0], settings));
+        const settingsToRemovePositionValue = {line: -4, position: ''};
+        player.setTextDisplaySettings(settingsToRemovePositionValue);
+        player._activeTextCues[0].should.deep.equal(Utils.Object.mergeDeep(player._activeTextCues[0], {line: -4}));
+      });
+    });
+
+    describe('configure text track display', () => {
+      it('should change textDisplay settings by config', () => {
+        const settings = {line: -4};
+        player = new Player({text: {textTrackDisplaySetting: settings}});
+        player._textDisplaySettings.should.deep.equal(settings);
+      });
+
+      it('should forceCenter override textTrackDisplaySetting', () => {
+        const settings = {position: '10%', align: 'left', size: '10'};
+        player = new Player({text: {forceCenter: true, textTrackDisplaySetting: settings}});
+        player._textDisplaySettings.should.deep.equal({position: 'auto', align: 'center', size: '100'});
+      });
+
+      it('should forceCenter keep the other values from textTrackDisplaySetting', () => {
+        const settings = {line: '-4', lineAlign: 'end', position: '10%'};
+        player = new Player({text: {forceCenter: true, textTrackDisplaySetting: settings}});
+        player._textDisplaySettings.should.deep.equal(Utils.Object.mergeDeep(settings, {position: 'auto', align: 'center', size: '100'}));
+      });
+
+      it('should configure change of textTrackDisplaySetting will apply forceCenter', () => {
+        const settings = {position: '10%', align: 'left', size: '10'};
+        player = new Player({text: {forceCenter: true, textTrackDisplaySetting: settings}});
+        player.configure({text: {textTrackDisplaySetting: settings}});
+        player._textDisplaySettings.should.deep.equal({position: 'auto', align: 'center', size: '100'});
+      });
+
+      it('should empty configure will not take the previous config and change the values from setTextDisplaySettings', () => {
+        const settings = {position: '10%', align: 'left', size: '10'};
+        player = new Player({text: {forceCenter: true, textTrackDisplaySetting: settings}});
+        player.setTextDisplaySettings(settings);
+        player.configure({text: {}});
+        player._textDisplaySettings.should.deep.equal(settings);
+      });
+
+      it('should keep the current setting for empty config', () => {
+        const settings = {line: '-4', lineAlign: 'end', position: '10%'};
+        player.setTextDisplaySettings(settings);
+        player.configure({text: {}});
+        player._textDisplaySettings.should.deep.equal(settings);
+      });
 
       it('should change style setting by config', () => {
         player = new Player({
@@ -1240,20 +1306,6 @@ describe('Player', function () {
         currentTextStyle.backgroundColor.should.deep.equal(TextStyle.StandardColors.RED);
         currentTextStyle.fontColor.should.deep.equal(TextStyle.StandardColors.CYAN);
         currentTextStyle.fontEdge.should.deep.equal(TextStyle.EdgeStyles.RAISED);
-      });
-    });
-
-    describe('setTextDisplaySettings', () => {
-      it('should change textDisplay settings', () => {
-        const settings = {line: -4};
-        player.setTextDisplaySettings(settings);
-        player._textDisplaySettings.should.deep.equal(settings);
-      });
-
-      it('should change textDisplay settings by config', () => {
-        const settings = {line: -4};
-        player = new Player({text: {textTrackDisplaySetting: settings}});
-        player._textDisplaySettings.should.deep.equal(settings);
       });
     });
   });

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1221,9 +1221,25 @@ describe('Player', function () {
         textStyle.fontEdge = TextStyle.EdgeStyles.RAISED;
         player.textStyle = textStyle;
         const currentTextStyle = player.textStyle;
-        currentTextStyle.backgroundColor.should.be.equal(textStyle.backgroundColor);
-        currentTextStyle.fontColor.should.be.equal(textStyle.fontColor);
-        currentTextStyle.fontEdge.should.be.equal(textStyle.fontEdge);
+        currentTextStyle.backgroundColor.should.deep.equal(textStyle.backgroundColor);
+        currentTextStyle.fontColor.should.deep.equal(textStyle.fontColor);
+        currentTextStyle.fontEdge.should.deep.equal(textStyle.fontEdge);
+      });
+
+      it('should change style setting by config', () => {
+        player = new Player({
+          text: {
+            textStyle: {
+              backgroundColor: TextStyle.StandardColors.RED,
+              fontColor: TextStyle.StandardColors.CYAN,
+              fontEdge: TextStyle.EdgeStyles.RAISED
+            }
+          }
+        });
+        const currentTextStyle = player.textStyle;
+        currentTextStyle.backgroundColor.should.deep.equal(TextStyle.StandardColors.RED);
+        currentTextStyle.fontColor.should.deep.equal(TextStyle.StandardColors.CYAN);
+        currentTextStyle.fontEdge.should.deep.equal(TextStyle.EdgeStyles.RAISED);
       });
     });
 
@@ -1231,7 +1247,13 @@ describe('Player', function () {
       it('should change textDisplay settings', () => {
         const settings = {line: -4};
         player.setTextDisplaySettings(settings);
-        player._textDisplaySettings.should.be.equal(settings);
+        player._textDisplaySettings.should.deep.equal(settings);
+      });
+
+      it('should change textDisplay settings by config', () => {
+        const settings = {line: -4};
+        player = new Player({text: {textTrackDisplaySetting: settings}});
+        player._textDisplaySettings.should.deep.equal(settings);
       });
     });
   });

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1300,7 +1300,7 @@ describe('Player', function () {
       beforeEach(() => {
         config = Utils.Object.mergeDeep(getConfigStructure(), {
           sources: Utils.Object.mergeDeep({captions: [ExternalCaption.He, ExternalCaption.Ru]}, sourcesConfig.Mp4),
-          playback: {useNativeTextTrack: true}
+          text: {useNativeTextTrack: true}
         });
         player = new Player(config);
         playerContainer.appendChild(player.getView());
@@ -1396,7 +1396,7 @@ describe('Player', function () {
       beforeEach(() => {
         config = Utils.Object.mergeDeep(getConfigStructure(), {
           sources: Utils.Object.mergeDeep({captions: [ExternalCaption.He, ExternalCaption.Ru]}, sourcesConfig.Mp4),
-          playback: {useNativeTextTrack: false}
+          text: {useNativeTextTrack: false}
         });
         player = new Player(config);
         playerContainer.appendChild(player.getView());

--- a/test/src/state/state-manger.spec.js
+++ b/test/src/state/state-manger.spec.js
@@ -78,7 +78,6 @@ describe('StateManager', () => {
       done();
     });
     stateManager._updateState(StateType.LOADING);
-    stateManager._dispatchEvent();
   });
 
   it('should reset the state manager', () => {

--- a/test/src/utils/test-utils.js
+++ b/test/src/utils/test-utils.js
@@ -6,8 +6,8 @@ function getConfigStructure(targetId) {
   return {
     targetId,
     sources: {},
-    text:{
-      enableCEA708Captions: true,
+    text: {
+      enableCEA708Captions: true
     },
     playback: {
       preload: 'none',

--- a/test/src/utils/test-utils.js
+++ b/test/src/utils/test-utils.js
@@ -6,8 +6,10 @@ function getConfigStructure(targetId) {
   return {
     targetId,
     sources: {},
-    playback: {
+    text:{
       enableCEA708Captions: true,
+    },
+    playback: {
       preload: 'none',
       autoplay: false,
       muted: false,


### PR DESCRIPTION
### Description of the Changes

Issue: text track doesn't have a config for styling, there is only an API for styling.
Solution: create a text container for the text track and add the options for styling the text track.
Add an option to disable external setting by set attribute explicit as null or ''.
fix test: should dispatch new state event - updateState dispatch the event so two events dispatched cause FEC-10760

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
