### PR TITLE
fix(FEC-10564): keep the poster for display for an audio-only entry

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1092,6 +1092,16 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
+   * Checking if the current playback is audio only.
+   * @function isAudio
+   * @returns {boolean} - Whether playback is audio.
+   * @private
+   */
+  isAudio(): boolean {
+    return this._config.sources.type === MediaType.AUDIO;
+  }
+
+  /**
    * Get whether the video is seeked to live edge in dvr
    * @returns {boolean} - Whether the video is seeked to live edge in dvr
    * @public
@@ -1842,6 +1852,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _handleAutoPlay(): void {
+    this._posterManager.show();
     if (this._config.playback.autoplay === true) {
       const allowMutedAutoPlay = this._config.playback.allowMutedAutoPlay;
       Player.getCapabilities(this.engineType).then(capabilities => {
@@ -1861,8 +1872,6 @@ export default class Player extends FakeEventTarget {
           }
         }
       });
-    } else {
-      this._posterManager.show();
     }
 
     const onAutoPlay = () => {
@@ -1997,7 +2006,9 @@ export default class Player extends FakeEventTarget {
     if (this._firstPlay) {
       this._firstPlay = false;
       this.dispatchEvent(new FakeEvent(CustomEventType.FIRST_PLAY));
-      this._posterManager.hide();
+      if (!this.isAudio()) {
+        this._posterManager.hide();
+      }
       this.hideBlackCover();
       if (typeof this._playbackAttributesState.rate === 'number') {
         this.playbackRate = this._playbackAttributesState.rate;

--- a/src/player.js
+++ b/src/player.js
@@ -1852,7 +1852,9 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _handleAutoPlay(): void {
-    this._posterManager.show();
+    if (this.isAudio() && this._config.playback.autoplay === false) {
+      this._posterManager.show();
+    }
     if (this._config.playback.autoplay === true) {
       const allowMutedAutoPlay = this._config.playback.allowMutedAutoPlay;
       Player.getCapabilities(this.engineType).then(capabilities => {

--- a/src/player.js
+++ b/src/player.js
@@ -1852,7 +1852,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _handleAutoPlay(): void {
-    if (this.isAudio() && this._config.playback.autoplay === false) {
+    if (this.isAudio() || this._config.playback.autoplay === false) {
       this._posterManager.show();
     }
     if (this._config.playback.autoplay === true) {


### PR DESCRIPTION
### Description of the Changes

Issue: audio stream has a black screen when it plays.
Solution: check if it's audio by sources.type and keep the poster.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
