### PR TITLE
fix(FEC-10844): advanced caption settings custom caption is always marked even when choose sample

### DIFF
--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -1,6 +1,4 @@
 // @flow
-import * as Utils from '../utils/util';
-
 /**
  * We use this number to calculate the scale of the text. so it will be : 1 + 0.25 * FontSizes.value
  * So, if the user selects 400% the scale would be: 1 + 0.25 * 4 = 2. so the font size should be multiplied by 2.
@@ -140,30 +138,23 @@ class TextStyle {
     return 'rgba(' + color.concat(opacity).join(',') + ')';
   }
 
-  static get defaultValues(): PKTextStyleObject {
-    return {
-      fontEdge: TextStyle.EdgeStyles.NONE,
-      fontSize: '100%',
-      fontScale: 1,
-      fontColor: TextStyle.StandardColors.WHITE,
-      fontOpacity: TextStyle.StandardOpacities.OPAQUE,
-      backgroundColor: TextStyle.StandardColors.BLACK,
-      backgroundOpacity: TextStyle.StandardOpacities.OPAQUE,
-      fontFamily: TextStyle.FontFamily.SANS_SERIF
-    };
-  }
-
   static fromJson(setting: PKTextStyleObject): TextStyle {
-    const currentSetting = Utils.Object.mergeDeep(TextStyle.defaultValues, setting);
+    const getValue = (newValue, defaultValue) => {
+      let value = defaultValue;
+      if (typeof newValue !== 'undefined' && newValue !== null) {
+        value = newValue;
+      }
+      return value;
+    };
     let textStyle = new TextStyle();
-    textStyle.fontEdge = currentSetting.fontEdge;
-    textStyle.fontSize = currentSetting.fontSize;
-    textStyle.fontScale = currentSetting.fontScale;
-    textStyle.fontColor = currentSetting.fontColor;
-    textStyle.fontOpacity = currentSetting.fontOpacity;
-    textStyle.backgroundColor = currentSetting.backgroundColor;
-    textStyle.backgroundOpacity = currentSetting.backgroundOpacity;
-    textStyle.fontFamily = currentSetting.fontFamily;
+    textStyle.fontEdge = getValue(setting.fontEdge, textStyle.fontEdge);
+    textStyle.fontSize = getValue(setting.fontSize, textStyle.fontSize);
+    textStyle.fontScale = getValue(setting.fontScale, textStyle.fontScale);
+    textStyle.fontColor = getValue(setting.fontColor, textStyle.fontColor);
+    textStyle.fontOpacity = getValue(setting.fontOpacity, textStyle.fontOpacity);
+    textStyle.backgroundColor = getValue(setting.backgroundColor, textStyle.backgroundColor);
+    textStyle.backgroundOpacity = getValue(setting.backgroundOpacity, textStyle.backgroundOpacity);
+    textStyle.fontFamily = getValue(setting.fontFamily, textStyle.fontFamily);
     return textStyle;
   }
 
@@ -184,41 +175,41 @@ class TextStyle {
    * Font size, such as 1, 2, 3...
    * @type {number}
    */
-  fontSize: string = TextStyle.defaultValues.fontSize;
+  fontSize: string = '100%';
 
-  fontScale: number = TextStyle.defaultValues.fontScale;
+  fontScale: number = 1;
 
   /**
    * @type {TextStyle.FontFamily}
    */
-  fontFamily: string = TextStyle.defaultValues.fontFamily;
+  fontFamily: string = TextStyle.FontFamily.SANS_SERIF;
 
   /**
    * @type {TextStyle.StandardColors}
    */
-  fontColor: Array<number> = TextStyle.defaultValues.fontColor;
+  fontColor: Array<number> = TextStyle.StandardColors.WHITE;
 
   /**
    * @type {TextStyle.StandardOpacities}
    * @expose
    */
-  fontOpacity: number = TextStyle.defaultValues.fontOpacity;
+  fontOpacity: number = TextStyle.StandardOpacities.OPAQUE;
 
   /**
    * @type {TextStyle.StandardColors}
    */
-  backgroundColor: Array<number> = TextStyle.defaultValues.backgroundColor;
+  backgroundColor: Array<number> = TextStyle.StandardColors.BLACK;
 
   /**
    * @type {TextStyle.StandardOpacities}
    */
-  backgroundOpacity: number = TextStyle.defaultValues.backgroundOpacity;
+  backgroundOpacity: number = TextStyle.StandardOpacities.OPAQUE;
 
   /**
    * @type {TextStyle.EdgeStyles}
    * @expose
    */
-  fontEdge: Array<Array<number>> = TextStyle.defaultValues.fontEdge;
+  fontEdge: Array<Array<number>> = TextStyle.EdgeStyles.NONE;
 
   getTextShadow(): string {
     // A given edge effect may be implemented with multiple shadows.

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -139,7 +139,7 @@ class TextStyle {
   }
 
   static fromJson(setting: PKTextStyleObject): TextStyle {
-    const getValue = (newValue, defaultValue) => {
+    const getValue = (newValue: any, defaultValue: any): any => {
       let value = defaultValue;
       if (typeof newValue !== 'undefined' && newValue !== null) {
         value = newValue;

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -140,11 +140,7 @@ class TextStyle {
 
   static fromJson(setting: PKTextStyleObject): TextStyle {
     const getValue = (newValue: any, defaultValue: any): any => {
-      let value = defaultValue;
-      if (typeof newValue !== 'undefined' && newValue !== null) {
-        value = newValue;
-      }
-      return value;
+      return typeof newValue !== 'undefined' && newValue !== null ? newValue : defaultValue;
     };
     let textStyle = new TextStyle();
     textStyle.fontEdge = getValue(setting.fontEdge, textStyle.fontEdge);

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -1,4 +1,6 @@
 // @flow
+import * as Utils from '../utils/util';
+
 /**
  * We use this number to calculate the scale of the text. so it will be : 1 + 0.25 * FontSizes.value
  * So, if the user selects 400% the scale would be: 1 + 0.25 * 4 = 2. so the font size should be multiplied by 2.
@@ -138,17 +140,31 @@ class TextStyle {
     return 'rgba(' + color.concat(opacity).join(',') + ')';
   }
 
+  static get defaultValues(): PKTextStyleObject {
+    return {
+      fontEdge: TextStyle.EdgeStyles.NONE,
+      fontSize: '100%',
+      fontScale: 1,
+      fontColor: TextStyle.StandardColors.WHITE,
+      fontOpacity: TextStyle.StandardOpacities.OPAQUE,
+      backgroundColor: TextStyle.StandardColors.BLACK,
+      backgroundOpacity: TextStyle.StandardOpacities.OPAQUE,
+      fontFamily: TextStyle.FontFamily.SANS_SERIF
+    };
+  }
+
   static fromJson(setting: PKTextStyleObject): TextStyle {
-    let clonedTextStyle = new TextStyle();
-    clonedTextStyle.fontEdge = setting.fontEdge || clonedTextStyle.fontEdge;
-    clonedTextStyle.fontSize = setting.fontSize || clonedTextStyle.fontSize;
-    clonedTextStyle.fontScale = setting.fontScale || clonedTextStyle.fontScale;
-    clonedTextStyle.fontColor = setting.fontColor || clonedTextStyle.fontColor;
-    clonedTextStyle.fontOpacity = setting.fontOpacity || clonedTextStyle.fontOpacity;
-    clonedTextStyle.backgroundColor = setting.backgroundColor || clonedTextStyle.backgroundColor;
-    clonedTextStyle.backgroundOpacity = setting.backgroundOpacity || clonedTextStyle.backgroundOpacity;
-    clonedTextStyle.fontFamily = setting.fontFamily || clonedTextStyle.fontFamily;
-    return clonedTextStyle;
+    const currentSetting = Utils.Object.mergeDeep(TextStyle.defaultValues, setting);
+    let textStyle = new TextStyle();
+    textStyle.fontEdge = currentSetting.fontEdge;
+    textStyle.fontSize = currentSetting.fontSize;
+    textStyle.fontScale = currentSetting.fontScale;
+    textStyle.fontColor = currentSetting.fontColor;
+    textStyle.fontOpacity = currentSetting.fontOpacity;
+    textStyle.backgroundColor = currentSetting.backgroundColor;
+    textStyle.backgroundOpacity = currentSetting.backgroundOpacity;
+    textStyle.fontFamily = currentSetting.fontFamily;
+    return textStyle;
   }
 
   static toJson(text: TextStyle): PKTextStyleObject {
@@ -168,41 +184,41 @@ class TextStyle {
    * Font size, such as 1, 2, 3...
    * @type {number}
    */
-  fontSize: string = '100%';
+  fontSize: string = TextStyle.defaultValues.fontSize;
 
-  fontScale: number = 1;
+  fontScale: number = TextStyle.defaultValues.fontScale;
 
   /**
    * @type {TextStyle.FontFamily}
    */
-  fontFamily: string = TextStyle.FontFamily.SANS_SERIF;
+  fontFamily: string = TextStyle.defaultValues.fontFamily;
 
   /**
    * @type {TextStyle.StandardColors}
    */
-  fontColor: Array<number> = TextStyle.StandardColors.WHITE;
+  fontColor: Array<number> = TextStyle.defaultValues.fontColor;
 
   /**
    * @type {TextStyle.StandardOpacities}
    * @expose
    */
-  fontOpacity: number = TextStyle.StandardOpacities.OPAQUE;
+  fontOpacity: number = TextStyle.defaultValues.fontOpacity;
 
   /**
    * @type {TextStyle.StandardColors}
    */
-  backgroundColor: Array<number> = TextStyle.StandardColors.BLACK;
+  backgroundColor: Array<number> = TextStyle.defaultValues.backgroundColor;
 
   /**
    * @type {TextStyle.StandardOpacities}
    */
-  backgroundOpacity: number = TextStyle.StandardOpacities.OPAQUE;
+  backgroundOpacity: number = TextStyle.defaultValues.backgroundOpacity;
 
   /**
    * @type {TextStyle.EdgeStyles}
    * @expose
    */
-  fontEdge: Array<Array<number>> = TextStyle.EdgeStyles.NONE;
+  fontEdge: Array<Array<number>> = TextStyle.defaultValues.fontEdge;
 
   getTextShadow(): string {
     // A given edge effect may be implemented with multiple shadows.

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1216,14 +1216,46 @@ describe('Player', function () {
 
       it('should change style setting', () => {
         let textStyle = new TextStyle();
-        textStyle.backgroundColor = TextStyle.StandardColors.RED;
-        textStyle.fontColor = TextStyle.StandardColors.CYAN;
         textStyle.fontEdge = TextStyle.EdgeStyles.RAISED;
+        textStyle.fontSize = '75%';
+        textStyle.fontScale = '3';
+        textStyle.fontColor = TextStyle.StandardColors.CYAN;
+        textStyle.fontOpacity = TextStyle.StandardOpacities.SEMI_LOW;
+        textStyle.backgroundOpacity = TextStyle.StandardOpacities.SEMI_LOW;
+        textStyle.fontFamily = TextStyle.FontFamily.ARIAL;
+        textStyle.backgroundColor = TextStyle.StandardColors.RED;
         player.textStyle = textStyle;
         const currentTextStyle = player.textStyle;
-        currentTextStyle.backgroundColor.should.deep.equal(textStyle.backgroundColor);
-        currentTextStyle.fontColor.should.deep.equal(textStyle.fontColor);
         currentTextStyle.fontEdge.should.deep.equal(textStyle.fontEdge);
+        currentTextStyle.fontSize.should.equal(textStyle.fontSize);
+        currentTextStyle.fontScale.should.equal(textStyle.fontScale);
+        currentTextStyle.fontColor.should.deep.equal(textStyle.fontColor);
+        currentTextStyle.fontOpacity.should.equal(textStyle.fontOpacity);
+        currentTextStyle.backgroundOpacity.should.equal(textStyle.backgroundOpacity);
+        currentTextStyle.fontFamily.should.equal(textStyle.fontFamily);
+        currentTextStyle.backgroundColor.should.deep.equal(textStyle.backgroundColor);
+      });
+
+      it('should create fromJson set the correct value', () => {
+        const settings = {
+          fontEdge: TextStyle.EdgeStyles.RAISED,
+          fontSize: '75%',
+          fontScale: '3',
+          fontColor: TextStyle.StandardColors.CYAN,
+          fontOpacity: TextStyle.StandardOpacities.SEMI_LOW,
+          backgroundOpacity: TextStyle.StandardOpacities.SEMI_LOW,
+          fontFamily: TextStyle.FontFamily.ARIAL,
+          backgroundColor: TextStyle.StandardColors.RED
+        };
+        const textStyle = TextStyle.fromJson(settings);
+        textStyle.fontEdge.should.deep.equal(settings.fontEdge);
+        textStyle.fontSize.should.equal(settings.fontSize);
+        textStyle.fontScale.should.equal(settings.fontScale);
+        textStyle.fontColor.should.deep.equal(settings.fontColor);
+        textStyle.fontOpacity.should.equal(settings.fontOpacity);
+        textStyle.backgroundOpacity.should.equal(settings.backgroundOpacity);
+        textStyle.fontFamily.should.equal(settings.fontFamily);
+        textStyle.backgroundColor.should.deep.equal(settings.backgroundColor);
       });
 
       it('should fromJson return an object equal to explicit set object', () => {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1219,8 +1219,8 @@ describe('Player', function () {
         textStyle.fontEdge = TextStyle.EdgeStyles.RAISED;
         textStyle.fontSize = '75%';
         textStyle.fontScale = '3';
-        textStyle.fontColor = TextStyle.StandardColors.CYAN;
-        textStyle.fontOpacity = TextStyle.StandardOpacities.SEMI_LOW;
+        textStyle.fontColor = TextStyle.StandardColors.BLACK;
+        textStyle.fontOpacity = TextStyle.StandardOpacities.SEMI_HIGH;
         textStyle.backgroundOpacity = TextStyle.StandardOpacities.SEMI_LOW;
         textStyle.fontFamily = TextStyle.FontFamily.ARIAL;
         textStyle.backgroundColor = TextStyle.StandardColors.RED;
@@ -1238,12 +1238,12 @@ describe('Player', function () {
 
       it('should create fromJson set the correct value', () => {
         const settings = {
-          fontEdge: TextStyle.EdgeStyles.RAISED,
+          fontEdge: TextStyle.EdgeStyles.NONE,
           fontSize: '75%',
           fontScale: '3',
           fontColor: TextStyle.StandardColors.CYAN,
-          fontOpacity: TextStyle.StandardOpacities.SEMI_LOW,
-          backgroundOpacity: TextStyle.StandardOpacities.SEMI_LOW,
+          fontOpacity: TextStyle.StandardOpacities.TRANSPARENT,
+          backgroundOpacity: TextStyle.StandardOpacities.TRANSPARENT,
           fontFamily: TextStyle.FontFamily.ARIAL,
           backgroundColor: TextStyle.StandardColors.RED
         };


### PR DESCRIPTION
### Description of the Changes

Issue: the condition of || doesn't work properly with 0 as the current value and always takes the default option.
Solution: create the default values as a static getter to be able to use it on static methods and on the first initialize of the properties.
merge the setting and default value to make sure all set correctly.
add relevant tests.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
