### PR TITLE
fix(FEC-10878): order of text captions are broken on Safari browser

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2182,7 +2182,7 @@ export default class Player extends FakeEventTarget {
    */
   _updateTracks(tracks: Array<Track>): void {
     Player._logger.debug('Tracks changed', tracks);
-    if (this.config.playback.useNativeTextTrack) {
+    if (this.config.text.useNativeTextTrack) {
       this._eventManager.listen(this._engine, CustomEventType.TEXT_TRACK_ADDED, (event: FakeEvent) => this._onTextTrackAdded(event));
     }
     this._tracks = tracks.concat(this._externalCaptionsHandler.getExternalTracks(tracks));


### PR DESCRIPTION
### Description of the Changes

Issue: config used previous config
Solution: change the config to new config

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
