### PR TITLE
feat(FEC-10657): add max stale level reloads config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -461,6 +461,7 @@ var config = {
 > > ```
 
 > ##
+>
 > ### config.text
 >
 > ##### Type: `PKTextConfigObject`
@@ -586,6 +587,7 @@ var config = {
 > > ##### Description: RFC 3066 language code for the CEA-708 captions track 2.
 >
 > ##
+>
 > ### config.playback
 >
 > ##### Type: `PKPlaybackConfigObject`
@@ -1093,6 +1095,17 @@ var config = {
 > > >   LICENSE: 2
 > > > }
 > > > ```
+> >
+> > ##
+> >
+> > ### config.network.maxStaleLevelReloads
+> >
+> > ##### Type: `number`
+> >
+> > ##### Default: `20`
+> >
+> > ##### Description: The maximal amount of times player should request a manifest refresh, when no new segments appear in the refreshed manifest.
+> >
 > > >
 > > > ##
 > > >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1095,17 +1095,6 @@ var config = {
 > > >   LICENSE: 2
 > > > }
 > > > ```
-> >
-> > ##
-> >
-> > ### config.network.maxStaleLevelReloads
-> >
-> > ##### Type: `number`
-> >
-> > ##### Default: `20`
-> >
-> > ##### Description: The maximal amount of times player should request a manifest refresh, when no new segments appear in the refreshed manifest.
-> >
 > > >
 > > > ##
 > > >
@@ -1271,9 +1260,17 @@ var config = {
 > >   }
 > > };
 > > ```
-
-##
-
+> >
+> > ##
+> >
+> > ### config.network.maxStaleLevelReloads
+> >
+> > ##### Type: `number`
+> >
+> > ##### Default: `20`
+> >
+> > ##### Description: The maximal amount of times player should request a manifest refresh, when no new segments appear in the refreshed manifest.
+> >
 > ### config.customLabels
 >
 > ##### Type: `PKCustomLabelsConfigObject`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1270,7 +1270,7 @@ var config = {
 > > ##### Default: `20`
 > >
 > > ##### Description: The maximal amount of times player should request a manifest refresh, when no new segments appear in the refreshed manifest.
-> >
+>
 > ### config.customLabels
 >
 > ##### Type: `PKCustomLabelsConfigObject`

--- a/flow-typed/types/network-config.js
+++ b/flow-typed/types/network-config.js
@@ -1,5 +1,6 @@
 // @flow
 declare type PKNetworkConfigObject = {
   requestFilter?: Function,
-  responseFilter?: Function
+  responseFilter?: Function,
+  maxStaleLevelReloads: number
 };

--- a/src/error/code.js
+++ b/src/error/code.js
@@ -44,6 +44,11 @@ const Code: CodeType = {
    */
   RESPONSE_FILTER_ERROR: 1007,
 
+  /**
+   * Live manifest is refreshed more than a preconfigured amount of times without any new segment.
+   */
+  LIVE_MANIFEST_REFRESH_ERROR: 1008,
+
   /** The text parser failed to parse a text stream due to an invalid header. */
   INVALID_TEXT_HEADER: 2000,
 

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -78,7 +78,9 @@ const DefaultConfig = {
   drm: {
     keySystem: ''
   },
-  network: {}
+  network: {
+    maxStaleLevelReloads: 20
+  }
 };
 
 export {DefaultConfig};


### PR DESCRIPTION
### Description of the Changes

* Add default configuration for `maxStaleLevelReloads`.
* Update docs.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
