### PR TITLE
fix(REACH2-919): correct order of captions that has the same time

### DIFF
--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -1036,7 +1036,7 @@ function processCues(window, cues, overlay, style) {
   (function () {
     let styleBox, cue;
 
-    for (let i = 0; i < cues.length; i++) {
+    for (let i = cues.length - 1; i >= 0; i--) {
       cue = cues[i];
 
       // Compute the intial position and styles of the cue div.


### PR DESCRIPTION
### Description of the Changes

For captions with the same time player renders subtitles in wrong order. (https://kaltura.atlassian.net/browse/REACH2-919)
Current fix change the order of iteration and subtitles displays correctly.

<img width="323" alt="Screen Shot 2021-01-12 at 11 56 04 AM" src="https://user-images.githubusercontent.com/51074448/104452486-be92ea80-55ab-11eb-9131-c6c451e8c6ad.png">


<img width="646" alt="Screen Shot 2021-01-12 at 11 55 41 AM" src="https://user-images.githubusercontent.com/51074448/104452470-ba66cd00-55ab-11eb-9004-c8724df6c382.png">


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
