### PR TITLE
feat(FEC-10925): remove captions update delay

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -100,13 +100,6 @@ const OFF: string = 'off';
 const DURATION_OFFSET: number = 0.1;
 
 /**
- * The toggle fullscreen rendering timeout value
- * @type {number}
- * @const
- */
-const REPOSITION_CUES_TIMEOUT: number = 1000;
-
-/**
  * The threshold in seconds from duration that we still consider it as live edge
  * @type {number}
  * @const
@@ -322,13 +315,6 @@ export default class Player extends FakeEventTarget {
     audioLanguage: '',
     textLanguage: ''
   };
-
-  /**
-   * holds false or an id for the timeout the reposition the text cues after togelling full screen
-   * @type {any}
-   * @private
-   */
-  _repositionCuesTimeout: any;
   /**
    * Whether a load media request has sent, the player should wait to media.
    * @type {boolean}
@@ -415,7 +401,6 @@ export default class Player extends FakeEventTarget {
     this._env = Env;
     this._tracks = [];
     this._firstPlay = true;
-    this._repositionCuesTimeout = false;
     this._loadingMedia = false;
     this._loading = false;
     this._playbackStart = false;
@@ -626,7 +611,6 @@ export default class Player extends FakeEventTarget {
     this._posterManager.destroy();
     this._stateManager.destroy();
     this._fullscreenController.destroy();
-    this._clearRepositionTimeout();
     this._activeTextCues = [];
     this._textDisplaySettings = {};
     this._config = {};
@@ -1818,18 +1802,7 @@ export default class Player extends FakeEventTarget {
     for (let i = 0; i < this._activeTextCues.length; i++) {
       this._activeTextCues[i].hasBeenReset = true;
     }
-    // handling only the last reposition
-    this._clearRepositionTimeout();
-    this._repositionCuesTimeout = setTimeout(() => {
-      this._updateTextDisplay(this._activeTextCues);
-      this._repositionCuesTimeout = false;
-    }, REPOSITION_CUES_TIMEOUT);
-  }
-
-  _clearRepositionTimeout() {
-    if (this._repositionCuesTimeout) {
-      clearTimeout(this._repositionCuesTimeout);
-    }
+    this._updateTextDisplay(this._activeTextCues);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

We used to rely on fullscreen event to change captions size and position. this event used to fire before screen dimensions were settled.
We now use a more precise resize observer manager and can remove the delay that causes a blinking effect.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
