### PR TITLE
fix(FEC-9370): safari video starts from beginning, not from startTime

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -444,8 +444,15 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._handleLiveDurationChange();
       }
     };
-    if (startTime && startTime > -1) {
-      this._videoElement.currentTime = startTime;
+    const setStartTime = seekTo => {
+      if (seekTo && seekTo > -1) {
+        this._videoElement.currentTime = seekTo;
+      }
+    };
+    setStartTime(startTime);
+    if (!this.isLive()) {
+      //for stream that have two duration change - like ima dai sample
+      this._eventManager.listen(this._videoElement, Html5EventType.DURATION_CHANGE, () => setStartTime(startTime));
     }
     if (this._videoElement.textTracks.length > 0) {
       parseTracksAndResolve();


### PR DESCRIPTION
### Description of the Changes

Issue: there are videos like ima dai sample that the video tag fires duration change twice and disable the seek action because of that.
Solution: for every duration change(should be 1 for media) we'll make the seek, for this media, it'll make the seek after the second duration change and then we'll be in the correct place.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
