### PR TITLE
fix(FEC-10041): Allow IMA and IMA DAI to be used in parallel

### DIFF
--- a/flow-typed/types/ad-options.js
+++ b/flow-typed/types/ad-options.js
@@ -13,5 +13,6 @@ declare type PKAdOptions = {
   width: number,
   height: number,
   bitrate: number,
-  bumper: boolean
+  bumper: boolean,
+  inStream: boolean
 };

--- a/src/engines/engine-decorator.js
+++ b/src/engines/engine-decorator.js
@@ -41,14 +41,14 @@ class EngineDecorator extends FakeEventTarget implements IEngineDecorator {
         if (prop === '_listeners') {
           return this._listeners;
         }
-        const activeDecorator = this._pluginDecorators.find(decorator => prop in decorator && decorator.active);
+        const activeDecorator = this._pluginDecorators.find(decorator => decorator.active);
         // $FlowFixMe
-        return activeDecorator ? activeDecorator[prop] : obj[prop];
+        return activeDecorator && prop in activeDecorator ? activeDecorator[prop] : obj[prop];
       },
       set: (obj, prop, value) => {
         const activeDecorator = this._pluginDecorators.find(decorator => prop in decorator && decorator.active);
         // $FlowFixMe
-        activeDecorator ? (activeDecorator[prop] = value) : (obj[prop] = value);
+        activeDecorator && prop in activeDecorator ? (activeDecorator[prop] = value) : (obj[prop] = value);
         return true;
       }
     });


### PR DESCRIPTION
### Description of the Changes

Issue: IMA and DAI don't work in parallel.
decorator selection could take one value from one decorator and another one from the second if it's not implemented on the first one.
Solution: add inStream to avoid attach detach for DAI.
check if the decorator doesn't have the prop after we get the active and make sure we're using always the first one if two decorators are active.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
