### PR TITLE
fix(FEC-10823): change initial poster hiding to first playing or ad playing

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2034,9 +2034,6 @@ export default class Player extends FakeEventTarget {
     if (this._firstPlay) {
       this._firstPlay = false;
       this.dispatchEvent(new FakeEvent(CustomEventType.FIRST_PLAY));
-      if (!this.isAudio()) {
-        this._posterManager.hide();
-      }
       this.hideBlackCover();
       if (typeof this._playbackAttributesState.rate === 'number') {
         this.playbackRate = this._playbackAttributesState.rate;
@@ -2052,6 +2049,9 @@ export default class Player extends FakeEventTarget {
   _onPlaying(): void {
     if (!this._firstPlaying) {
       this._firstPlaying = true;
+      if (!this.isAudio()) {
+        this._posterManager.hide();
+      }
       this.dispatchEvent(new FakeEvent(CustomEventType.FIRST_PLAYING));
     }
     if (this._engine && this._pendingSelectedVideoTrack) {


### PR DESCRIPTION
### Description of the Changes

Issue: black screen when play request and playing delayed.
Solution: keep the poster as far as possible.

FEC-10823.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
