### PR TITLE
feat(FEC-10915): let shaka and hls.js use their own default bandwidth estimators

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,6 @@ var config = {
     fpsDroppedMonitoringThreshold: 0.2,
     capLevelOnFPSDrop: true,
     capLevelToPlayerSize: false,
-    defaultBandwidthEstimate: 500e3,
     restrictions: {
       minBitrate: 0,
       maxBitrate: Infinity
@@ -1354,7 +1353,6 @@ var config = {
 >   fpsDroppedMonitoringThreshold: 0.2,
 >   capLevelOnFPSDrop: true,
 >   capLevelToPlayerSize: false,
->   defaultBandwidthEstimate: 500e3,
 >   restrictions: {
 >     minBitrate: 0,
 >     maxBitrate: Infinity
@@ -1417,8 +1415,6 @@ var config = {
 > > ### config.abr.defaultBandwidthEstimate
 > >
 > > ##### Type: `number`
-> >
-> > ##### Default: 500000
 > >
 > > ##### Description: The default bandwidth estimate to use if there is not enough data, in bit/sec.
 > >

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -70,7 +70,6 @@ const DefaultConfig = {
     fpsDroppedMonitoringThreshold: 0.2,
     capLevelOnFPSDrop: true,
     capLevelToPlayerSize: false,
-    defaultBandwidthEstimate: 500e3,
     restrictions: {
       minBitrate: 0,
       maxBitrate: Infinity


### PR DESCRIPTION
### Description of the Changes

remove `defaultBandwidthEstimate` from `player-config.js`

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
