### PR TITLE
fix(FEC-11035): playback error dispatch from player instead of from engine

### DIFF
--- a/src/engines/engine-decorator.js
+++ b/src/engines/engine-decorator.js
@@ -56,7 +56,7 @@ class EngineDecorator extends FakeEventTarget implements IEngineDecorator {
 
   dispatchEvent(event: FakeEvent): boolean {
     const activeDecorator = this._pluginDecorators.find(decorator => decorator.active);
-    return activeDecorator ? activeDecorator.dispatchEvent && activeDecorator.dispatchEvent(event) : super.dispatchEvent(event);
+    return activeDecorator && activeDecorator.dispatchEvent ? activeDecorator.dispatchEvent(event) : super.dispatchEvent(event);
   }
 
   _destroy(): void {

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -502,10 +502,9 @@ export default class Html5 extends FakeEventTarget implements IEngine {
           resolve({});
         })
         .catch(error => {
-          this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
           reject(error);
         });
-    });
+    }).catch(error => this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error)));
   }
 
   /**

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -491,18 +491,21 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   load(startTime: ?number): Promise<Object> {
     this._el.load();
-    return this._canLoadMediaSourceAdapterPromise
-      .then(() => {
-        if (this._mediaSourceAdapter) {
-          return this._mediaSourceAdapter.load(startTime).catch(error => {
-            return Promise.reject(error);
-          });
-        }
-        return Promise.resolve({});
-      })
-      .catch(error => {
-        return Promise.reject(error);
-      });
+    return new Promise((resolve, reject) => {
+      this._canLoadMediaSourceAdapterPromise
+        .then(() => {
+          if (this._mediaSourceAdapter) {
+            this._mediaSourceAdapter.load(startTime).catch(error => {
+              reject(error);
+            });
+          }
+          resolve({});
+        })
+        .catch(error => {
+          this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
+          reject(error);
+        });
+    });
   }
 
   /**

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -495,11 +495,13 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._canLoadMediaSourceAdapterPromise
         .then(() => {
           if (this._mediaSourceAdapter) {
-            this._mediaSourceAdapter.load(startTime).catch(error => {
-              reject(error);
-            });
+            this._mediaSourceAdapter
+              .load(startTime)
+              .then(tracks => resolve(tracks))
+              .catch(error => reject(error));
+          } else {
+            resolve({});
           }
-          resolve({});
         })
         .catch(error => {
           reject(error);

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -908,10 +908,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const pkTextTracks = this._getPKTextTracks();
     const pkOffTrack = pkTextTracks.find(track => track.language === 'off');
     const getActiveVidTextTrackIndex = () => {
-      const activeTrackIndex = this._nativeTextTracksMap.findIndex(
-        textTrack => textTrack && this._getDisplayTextTrackModeString() === textTrack.mode
-      );
-      return activeTrackIndex ? activeTrackIndex : -1;
+      return this._nativeTextTracksMap.findIndex(textTrack => textTrack && this._getDisplayTextTrackModeString() === textTrack.mode);
     };
     NativeAdapter._logger.debug('Video element text track change');
     const vidIndex = getActiveVidTextTrackIndex();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -899,13 +899,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const pkTextTracks = this._getPKTextTracks();
     const pkOffTrack = pkTextTracks.find(track => track.language === 'off');
     const getActiveVidTextTrackIndex = () => {
-      for (let i = 0; i < this._nativeTextTracksMap.length; i++) {
-        const textTrack = this._nativeTextTracksMap[i];
-        if (this._getDisplayTextTrackModeString() === textTrack.mode) {
-          return i;
-        }
-      }
-      return -1;
+      const activeTrackIndex = this._nativeTextTracksMap.findIndex(
+        textTrack => textTrack && this._getDisplayTextTrackModeString() === textTrack.mode
+      );
+      return activeTrackIndex ? activeTrackIndex : -1;
     };
     NativeAdapter._logger.debug('Video element text track change');
     const vidIndex = getActiveVidTextTrackIndex();

--- a/src/player.js
+++ b/src/player.js
@@ -1981,8 +1981,7 @@ export default class Player extends FakeEventTarget {
           this.dispatchEvent(new FakeEvent(CustomEventType.TRACKS_CHANGED, {tracks: this._tracks}));
           resetFlags();
         })
-        .catch(error => {
-          this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
+        .catch(() => {
           resetFlags();
         });
     }
@@ -2010,17 +2009,13 @@ export default class Player extends FakeEventTarget {
       this._load();
       this._shouldLoadAfterAttach = false;
     }
-    this.ready()
-      .then(() => {
-        const liveOrDvrOutOfWindow = this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0));
-        if (!this._firstPlay && liveOrDvrOutOfWindow) {
-          this.seekToLiveEdge();
-        }
-        this._engine.play();
-      })
-      .catch(error => {
-        this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
-      });
+    this.ready().then(() => {
+      const liveOrDvrOutOfWindow = this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0));
+      if (!this._firstPlay && liveOrDvrOutOfWindow) {
+        this.seekToLiveEdge();
+      }
+      this._engine.play();
+    });
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -1979,9 +1979,8 @@ export default class Player extends FakeEventTarget {
           }
           this._updateTracks(data.tracks);
           this.dispatchEvent(new FakeEvent(CustomEventType.TRACKS_CHANGED, {tracks: this._tracks}));
-          resetFlags();
         })
-        .catch(() => {
+        .finally(() => {
           resetFlags();
         });
     }


### PR DESCRIPTION
### Description of the Changes

Issue: engine doesn't expose an error for playback error, it dispatched from the player instead - the engine decorator can't ignore the playback error.
Solution: change the dispatch from the player to the engine to make sure the playback error could reject on the engine decorator.
tests failed for scenario _nativeTextTracksMap has index 0 and 2(metadata between) so for raise an error when it gets to i = 1 that doesn't exist. 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
