### PR TITLE
fix: decorator API called with incorrect this(proxy) instead of the activeDecorator

### DIFF
--- a/src/engines/engine-decorator.js
+++ b/src/engines/engine-decorator.js
@@ -42,8 +42,13 @@ class EngineDecorator extends FakeEventTarget implements IEngineDecorator {
           return this._listeners;
         }
         const activeDecorator = this._pluginDecorators.find(decorator => decorator.active);
+        const isGetter = (obj, prop) => !!Object.getOwnPropertyDescriptor(obj, prop)['get'];
         // $FlowFixMe
-        return activeDecorator && prop in activeDecorator ? activeDecorator[prop] : obj[prop];
+        return activeDecorator && prop in activeDecorator
+          ? isGetter(activeDecorator.constructor.prototype, prop)
+            ? activeDecorator[prop]
+            : args => activeDecorator[prop](args)
+          : obj[prop];
       },
       set: (obj, prop, value) => {
         const activeDecorator = this._pluginDecorators.find(decorator => prop in decorator && decorator.active);


### PR DESCRIPTION
### Description of the Changes

Issue: API method which overrides by decorator has the proxy as this, it doesn't let us use to register events on the decorator scope and other scope issues.
Solution: make a call directly to decorator API with arguments.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
