### PR TITLE
fix(FEC-10963): filter duplicate captions

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2287,7 +2287,18 @@ export default class Player extends FakeEventTarget {
    */
   _onCueChange(event: FakeEvent): void {
     Player._logger.debug('Text cue changed', event.payload.cues);
-    this._activeTextCues = event.payload.cues;
+    //TODO: remove filter once FEC-11048 fix is done
+    try {
+      this._activeTextCues = event.payload.cues.filter((cue, index, cues) => {
+        const prevCue = cues[index - 1];
+        if (!prevCue) {
+          return true;
+        }
+        return !(cue.startTime === prevCue.startTime) && cue.endTime === prevCue.endTime && cue.text.trim() === prevCue.text.trim();
+      });
+    } catch (e) {
+      this._activeTextCues = event.payload.cues;
+    }
     this._updateCueDisplaySettings();
     this._updateTextDisplay(this._activeTextCues);
   }

--- a/src/player.js
+++ b/src/player.js
@@ -2294,7 +2294,7 @@ export default class Player extends FakeEventTarget {
         if (!prevCue) {
           return true;
         }
-        return !(cue.startTime === prevCue.startTime) && cue.endTime === prevCue.endTime && cue.text.trim() === prevCue.text.trim();
+        return !(cue.startTime === prevCue.startTime && cue.endTime === prevCue.endTime && cue.text.trim() === prevCue.text.trim());
       });
     } catch (e) {
       this._activeTextCues = event.payload.cues;


### PR DESCRIPTION
### Description of the Changes

When vtt file is sliced it sometimes may contain same caption line in both slices of the vtt file as the time range of it is crossing the slicing border.
If the line has a trailing whitespace it will be treated differently if it is in the end of the vtt slice or at the start(or middle) as we trim the entire vtt fragment we get but not the individual time blocks.

Example:
```
Frag1.vtt
WEB VTT

1
00:00:00.360 --&gt; 00:00:01.520 
first line

2
00:00:01.600 --&gt; 00:00:02.680 
second line ending with trailing whitespace
```
```
Frag2.vtt
WEB VTT

3
00:00:01.600 --&gt; 00:00:02.680 
second line ending with trailing whitespace 

4
00:00:03.400 --&gt; 00:00:04.000
third line
```

In the first fragment we will clip the trailing whitespace cause we do it in webvtt-parser for the entire frag before we start line by line processing.
In the second fragment we won't clip it as it is in the middle of the string.

The end result is that we will create a different hash for each of these lines, and then they will appear duplicate.

Solution is to just clip each cue text as well.

Please note - this is a workaround until we land the fix we did in hls.js itslef and then we will remove this.

Solves FEC-10963.
Related to FEC-11048.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
