### PR TITLE
fix(FEC-11082): DOM play error on SmartTV on when stall happen on the beginning

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1759,7 +1759,6 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEventType.ABR_MODE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.TIMED_METADATA, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.PLAY_FAILED, (event: FakeEvent) => {
-        this.pause();
         this._onPlayFailed(event);
         this.dispatchEvent(event);
       });


### PR DESCRIPTION
### Description of the Changes

Issue: shaka stall detector calling pause and play before first play promise resolved, it cause DOM exception and playback stop after this pause. flow is playback play() -> stall detector pause() play() -> play failed handler pause().
Solution: remove the pause from play failed handler since after play is failed browser handle it.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
