### PR TITLE
fix(FEC-11035): catch resolve the promise chain and load create promise for each call.

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -292,6 +292,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   detachMediaSource(): void {
     if (this._mediaSourceAdapter) {
       this._mediaSourceAdapter.detachMediaSource();
+      this._loadPromise = null;
     }
   }
 

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -51,6 +51,12 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @private
    */
   _canLoadMediaSourceAdapterPromise: Promise<*>;
+  /**
+   * Promise for load
+   * @type {Promise<*>}
+   * @private
+   */
+  _loadPromise: ?Promise<*>;
   _droppedFramesWatcher: ?DroppedFramesWatcher;
   _reset: boolean = false;
   /**
@@ -510,17 +516,12 @@ export default class Html5 extends FakeEventTarget implements IEngine {
         this._canLoadMediaSourceAdapterPromise
           .then(() => {
             if (this._mediaSourceAdapter) {
-              this._mediaSourceAdapter
-                .load(startTime)
-                .then(tracks => resolve(tracks))
-                .catch(error => reject(error));
+              this._mediaSourceAdapter.load(startTime).then(resolve).catch(reject);
             } else {
               resolve({});
             }
           })
-          .catch(error => {
-            reject(error);
-          });
+          .catch(reject);
       }).catch(error => {
         this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
         return Promise.reject(error);


### PR DESCRIPTION
### Description of the Changes

**Issues**: 

>   1. catch once resolve the promise chain for next.
>   2. Multiple load promises created by multiple load calls.

**Solution**: 

> 1. return promise reject to reject the chain 
> 2. create the loadPromise once until we'll get a reset or destroy.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
