### PR TITLE
fix(FEC-11119): VR (360) media doesn't work on safari browser - no video displayed

### DIFF
--- a/src/engines/engine-decorator.js
+++ b/src/engines/engine-decorator.js
@@ -35,7 +35,7 @@ class EngineDecorator extends FakeEventTarget implements IEngineDecorator {
           target = activeDecorator && prop in activeDecorator ? activeDecorator : obj;
         }
         // $FlowFixMe
-        return typeof target[prop].bind === 'function' ? target[prop].bind(target) : target[prop];
+        return target[prop] && typeof target[prop].bind === 'function' ? target[prop].bind(target) : target[prop];
       },
       set: (obj, prop, value) => {
         const activeDecorator = this._pluginDecorators.find(decorator => prop in decorator && decorator.active);


### PR DESCRIPTION
### Description of the Changes

fix null pointer in the engine decorator (when `target[prop]` is `null`)

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
