### PR TITLE
fix(FEC-11118): video doesn't play, player crushes the application

### DIFF
--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -466,7 +466,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    */
   _resetExternalNativeTextTrack(): void {
     const videoElement = this._player.getVideoElement();
-    if (videoElement) {
+    if (videoElement && videoElement.textTracks) {
       const track = Array.from(videoElement.textTracks).find(track => (track ? track.language === EXTERNAL_TRACK_ID : false));
       if (track) {
         track.cues && Object.values(track.cues).forEach(cue => track.removeCue(cue));
@@ -482,7 +482,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    */
   _addCuesToNativeTextTrack(cues: Array<Cue>): void {
     const videoElement = this._player.getVideoElement();
-    if (videoElement) {
+    if (videoElement && videoElement.textTracks) {
       const track = Array.from(videoElement.textTracks).find(track => (track ? track.language === EXTERNAL_TRACK_ID : false));
       if (track) {
         track.mode = 'showing';
@@ -498,7 +498,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    */
   _addNativeTextTrack(): void {
     const videoElement = this._player.getVideoElement();
-    if (videoElement) {
+    if (videoElement && videoElement.textTracks) {
       const sameLanguageTrackIndex = Array.from(videoElement.textTracks).findIndex(track => (track ? track.language === EXTERNAL_TRACK_ID : false));
       if (sameLanguageTrackIndex > -1) {
         this._resetExternalNativeTextTrack();


### PR DESCRIPTION
### Description of the Changes

`textTracks` not always appears on the video element object since different engines return different object types.

Solves FEC-11118

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
