### PR TITLE
fix(FEC-11145): spinner is displayed while changing the focus

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -318,17 +318,17 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._eventManager.listen(this._videoElement, Html5EventType.SEEKED, () => this._syncCurrentTime());
         this._eventManager.listen(this._videoElement, Html5EventType.WAITING, () => (this._waitingEventTriggered = true));
         this._eventManager.listen(this._videoElement, Html5EventType.PLAYING, () => (this._waitingEventTriggered = false));
-        // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
-        this._eventManager.listen(window, 'focus', () => {
-          if (!this._isProgressivePlayback()) {
+        if (Env.isIOS) {
+          // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
+          this._eventManager.listen(window, 'focus', () => {
             setTimeout(() => {
               // In IOS HLS, sometimes when coming back from lock screen/Idle mode, the stream will get stuck, and only a small seek nudge will fix it.
               this._videoElement.currentTime =
                 this._videoElement.currentTime > NUDGE_SEEK_AFTER_FOCUS ? this._videoElement.currentTime - NUDGE_SEEK_AFTER_FOCUS : 0;
               this._syncCurrentTime();
             }, BACK_TO_FOCUS_TIMEOUT);
-          }
-        });
+          });
+        }
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();
         }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -318,17 +318,17 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._eventManager.listen(this._videoElement, Html5EventType.SEEKED, () => this._syncCurrentTime());
         this._eventManager.listen(this._videoElement, Html5EventType.WAITING, () => (this._waitingEventTriggered = true));
         this._eventManager.listen(this._videoElement, Html5EventType.PLAYING, () => (this._waitingEventTriggered = false));
-        if (Env.isIOS) {
-          // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
-          this._eventManager.listen(window, 'focus', () => {
-            setTimeout(() => {
+        // Sometimes when playing live in safari and switching between tabs the currentTime goes back with no seek events
+        this._eventManager.listen(window, 'focus', () => {
+          setTimeout(() => {
+            if (Env.isIOS) {
               // In IOS HLS, sometimes when coming back from lock screen/Idle mode, the stream will get stuck, and only a small seek nudge will fix it.
               this._videoElement.currentTime =
                 this._videoElement.currentTime > NUDGE_SEEK_AFTER_FOCUS ? this._videoElement.currentTime - NUDGE_SEEK_AFTER_FOCUS : 0;
-              this._syncCurrentTime();
-            }, BACK_TO_FOCUS_TIMEOUT);
-          });
-        }
+            }
+            this._syncCurrentTime();
+          }, BACK_TO_FOCUS_TIMEOUT);
+        });
         if (this._isProgressivePlayback()) {
           this._setProgressiveSource();
         }


### PR DESCRIPTION
### Description of the Changes

issue:
in safari spinner is displayed while changing the focus.

solution:
limit event listener "focus" only to IOS.

Solves FEC-11145

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
