### PR TITLE
fix(FEC-11054): subtitle container width is not getting reset when user exits full screen mode

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1839,6 +1839,7 @@ export default class Player extends FakeEventTarget {
    */
   _resetTextCuesAndReposition(): void {
     this._engine.resetAllCues();
+    this._externalCaptionsHandler.resetAllCues();
     this._updateTextDisplay([]);
     for (let i = 0; i < this._activeTextCues.length; i++) {
       this._activeTextCues[i].hasBeenReset = true;


### PR DESCRIPTION
### Description of the Changes

reset the both internal and external captions on resize and full screen change

Solves FEC-11054

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
