### PR TITLE
fix(FEC-11188): getThumbnail is failing when engine is undefined

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1326,7 +1326,10 @@ export default class Player extends FakeEventTarget {
    * @return {?ThumbnailInfo} - Thumbnail info
    */
   getThumbnail(time: number): ?ThumbnailInfo {
-    return this._engine ? this._engine.getThumbnail(time) : null;
+    if (this._engine) {
+      this._engine.getThumbnail(time);
+    }
+    return null;
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -1326,7 +1326,7 @@ export default class Player extends FakeEventTarget {
    * @return {?ThumbnailInfo} - Thumbnail info
    */
   getThumbnail(time: number): ?ThumbnailInfo {
-    return this._engine.getThumbnail(time);
+    return this._engine ? this._engine.getThumbnail(time) : null;
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -1327,7 +1327,7 @@ export default class Player extends FakeEventTarget {
    */
   getThumbnail(time: number): ?ThumbnailInfo {
     if (this._engine) {
-      this._engine.getThumbnail(time);
+      return this._engine.getThumbnail(time);
     }
     return null;
   }


### PR DESCRIPTION
### Description of the Changes

issue: calling getThumbnail on undefined engine.
solution: checking if engine is defined before calling engine.getThumbnail().

Solves FEC-11188 / [SUP-27405](https://kaltura.atlassian.net/browse/SUP-27405)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
