### PR TITLE
fix(FEC-11277): native IOS isFullscreen doesn't response correct answer

### DIFF
--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -99,16 +99,16 @@ class FullscreenController {
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();
           if (videoElement && typeof videoElement.webkitEnterFullScreen === 'function') {
-            const videoEnterFullScreen = () => {
+            const iosEnterFullScreen = () => {
               videoElement.webkitEnterFullScreen();
               this._isInFullscreen = true;
             };
             if (this._player.isInPictureInPicture()) {
               // iOS < 13 (iPad) has an issue to enter to full screen from PiP
-              setTimeout(() => videoEnterFullScreen(), EXIT_PIP_TIMEOUT);
+              setTimeout(() => iosEnterFullScreen(), EXIT_PIP_TIMEOUT);
               this._player.exitPictureInPicture();
             } else {
-              videoEnterFullScreen();
+              iosEnterFullScreen();
             }
           }
         }

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -99,14 +99,17 @@ class FullscreenController {
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();
           if (videoElement && typeof videoElement.webkitEnterFullScreen === 'function') {
+            const videoEnterFullScreen = () => {
+              videoElement.webkitEnterFullScreen();
+              this._isInFullscreen = true;
+            };
             if (this._player.isInPictureInPicture()) {
               // iOS < 13 (iPad) has an issue to enter to full screen from PiP
-              setTimeout(() => videoElement.webkitEnterFullScreen(), EXIT_PIP_TIMEOUT);
+              setTimeout(() => videoEnterFullScreen(), EXIT_PIP_TIMEOUT);
               this._player.exitPictureInPicture();
             } else {
-              videoElement.webkitEnterFullScreen();
+              videoEnterFullScreen();
             }
-            this._isInFullscreen = true;
           }
         }
       } else {

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -106,6 +106,7 @@ class FullscreenController {
             } else {
               videoElement.webkitEnterFullScreen();
             }
+            this._isInFullscreen = true;
           }
         }
       } else {
@@ -130,6 +131,7 @@ class FullscreenController {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();
           if (videoElement && typeof videoElement.webkitExitFullscreen === 'function') {
             videoElement.webkitExitFullscreen();
+            this._isInFullscreen = false;
           }
         }
       } else {


### PR DESCRIPTION
### Description of the Changes

Issue: Captions on the native player are cut and misplaced in the first few seconds.
`IsFullscreen` returns an incorrect response in IOS.
Solution: add the custom flag for ios fullscreen request.
Fix the caption issue as well.
The flag indicates that a specific player is in fullscreen.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
