### PR TITLE
fix(FEC-11280): IOS playsinline=false doesn't response correctly for isFullScreen

### DIFF
--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -22,7 +22,7 @@ class FullscreenController {
   _player: Player;
   // Flag to indicate that player is in fullscreen(when different element on fullscreen - api return correct state).
   // Not relevant for IOS
-  _isInFullscreen: boolean = false;
+  _isElementInFullscreen: boolean = false;
   _isInBrowserFullscreen: boolean;
   _isScreenLocked: boolean = false;
   _isScreenOrientationSupport: boolean =
@@ -50,7 +50,7 @@ class FullscreenController {
    * @memberof FullScreenController
    * @returns {boolean} - the current fullscreen state of the document
    */
-  _isNativeFullscreen(): boolean {
+  _isNativeDocumentFullscreen(): boolean {
     return !!(document.fullscreenElement || document.webkitFullscreenElement || document.mozFullScreenElement || document.msFullscreenElement);
   }
 
@@ -69,7 +69,7 @@ class FullscreenController {
       !!videoElement.webkitDisplayingFullscreen &&
       (!videoElement.webkitPresentationMode || videoElement.webkitPresentationMode === 'fullscreen');
     return (
-      (this._isNativeFullscreen() && this._isInFullscreen) ||
+      (this._isNativeDocumentFullscreen() && this._isElementInFullscreen) ||
       iosFullscreen ||
       //indicator for manually full screen in ios - with css flag
       this._isInBrowserFullscreen
@@ -168,7 +168,7 @@ class FullscreenController {
     }
     Promise.resolve(this._nativeEnterFullScreen(fullScreenElement)).then(
       () => {
-        this._isInFullscreen = true;
+        this._isElementInFullscreen = true;
         const screenLockOrientionMode = Utils.Object.getPropertyPath(this._player, 'config.playback.screenLockOrientionMode');
         const validOrientation =
           screenLockOrientionMode !== ScreenOrientationType.NONE && Object.values(ScreenOrientationType).includes(screenLockOrientionMode);
@@ -211,7 +211,7 @@ class FullscreenController {
   _requestExitFullscreen(): void {
     Promise.resolve(this._nativeExitFullScreen()).then(
       () => {
-        this._isInFullscreen = false;
+        this._isElementInFullscreen = false;
         if (this._isScreenOrientationSupport && this._isScreenLocked) {
           // $FlowFixMe
           screen.orientation.unlock();

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -62,14 +62,15 @@ class FullscreenController {
   isFullscreen(): boolean {
     //for ios mobile checking video element
     const videoElement: ?HTMLVideoElement = typeof this._player.getVideoElement === 'function' ? this._player.getVideoElement() : null;
+    // $FlowFixMe for ios mobile
     const iosFullscreen =
       this._player.env.os.name === 'iOS' &&
       !!videoElement &&
       !!videoElement.webkitDisplayingFullscreen &&
       (!videoElement.webkitPresentationMode || videoElement.webkitPresentationMode === 'fullscreen');
     return (
-      iosFullscreen ||
       (this._isNativeFullscreen() && this._isInFullscreen) ||
+      iosFullscreen ||
       //indicator for manually full screen in ios - with css flag
       this._isInBrowserFullscreen
     );

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -55,22 +55,31 @@ class FullscreenController {
   }
 
   /**
+   * if native ios fullscreen mode
+   * @memberof FullScreenController
+   * @returns {boolean} - the current fullscreen state of the video element in ios
+   */
+  _isIOSFullscreen(): boolean {
+    //for ios mobile checking video element
+    const videoElement: ?HTMLVideoElement = typeof this._player.getVideoElement === 'function' ? this._player.getVideoElement() : null;
+    // $FlowFixMe for ios mobile
+    return (
+      this._player.env.os.name === 'iOS' &&
+      !!videoElement &&
+      !!videoElement.webkitDisplayingFullscreen &&
+      (!videoElement.webkitPresentationMode || videoElement.webkitPresentationMode === 'fullscreen')
+    );
+  }
+
+  /**
    * if fullscreen mode
    * @memberof FullScreenController
    * @returns {boolean} - the current fullscreen state of the document
    */
   isFullscreen(): boolean {
-    //for ios mobile checking video element
-    const videoElement: ?HTMLVideoElement = typeof this._player.getVideoElement === 'function' ? this._player.getVideoElement() : null;
-    // $FlowFixMe for ios mobile
-    const iosFullscreen =
-      this._player.env.os.name === 'iOS' &&
-      !!videoElement &&
-      !!videoElement.webkitDisplayingFullscreen &&
-      (!videoElement.webkitPresentationMode || videoElement.webkitPresentationMode === 'fullscreen');
     return (
       (this._isNativeDocumentFullscreen() && this._isElementInFullscreen) ||
-      iosFullscreen ||
+      this._isIOSFullscreen() ||
       //indicator for manually full screen in ios - with css flag
       this._isInBrowserFullscreen
     );

--- a/test/src/fullscreen/fullscreen-controller.spec.js
+++ b/test/src/fullscreen/fullscreen-controller.spec.js
@@ -41,7 +41,7 @@ describe('check inBrowserFullscreen config', function () {
   });
 
   it('should switch correctly to fullscreen in iOS between native and inBrowserFullscreen config', () => {
-    sandbox.stub(player._fullscreenController, '_isNativeFullscreen').callsFake(() => {
+    sandbox.stub(player._fullscreenController, '_isNativeDocumentFullscreen').callsFake(() => {
       return false;
     });
     player.env.os.name = 'iOS';
@@ -61,7 +61,7 @@ describe('check inBrowserFullscreen config', function () {
     player.isFullscreen().should.be.false;
     player.enterFullscreen();
     sandbox.restore();
-    sandbox.stub(player._fullscreenController, '_isNativeFullscreen').callsFake(() => {
+    sandbox.stub(player._fullscreenController, '_isNativeDocumentFullscreen').callsFake(() => {
       return true;
     });
     // indicator for specific player if it's in fullscreen or another element in fullscreen
@@ -76,7 +76,7 @@ describe('check inBrowserFullscreen config', function () {
         playsinline: false
       }
     });
-    sandbox.stub(player._fullscreenController, '_isNativeFullscreen').callsFake(() => {
+    sandbox.stub(player._fullscreenController, '_isNativeDocumentFullscreen').callsFake(() => {
       return true;
     });
     // indicator for specific player if it's in fullscreen or another element in fullscreen
@@ -88,7 +88,7 @@ describe('check inBrowserFullscreen config', function () {
     player.isFullscreen().should.be.false;
 
     sandbox.restore();
-    sandbox.stub(player._fullscreenController, '_isNativeFullscreen').callsFake(() => {
+    sandbox.stub(player._fullscreenController, '_isNativeDocumentFullscreen').callsFake(() => {
       return false;
     });
 

--- a/test/src/fullscreen/fullscreen-controller.spec.js
+++ b/test/src/fullscreen/fullscreen-controller.spec.js
@@ -21,13 +21,12 @@ describe('check inBrowserFullscreen config', function () {
         playsinline: true
       }
     };
-    config.sources = sourcesConfig.Mp4;
   });
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     player = new Player(config);
-    player.setSources(config.sources);
+    player.setSources(sourcesConfig.Mp4);
     playerContainer.appendChild(player.getView());
   });
 
@@ -41,7 +40,7 @@ describe('check inBrowserFullscreen config', function () {
   });
 
   it('should switch correctly to fullscreen in iOS between native and inBrowserFullscreen config', () => {
-    sandbox.stub(player._fullscreenController, '_isNativeDocumentFullscreen').callsFake(() => {
+    sandbox.stub(player._fullscreenController, '_isIOSFullscreen').callsFake(() => {
       return false;
     });
     player.env.os.name = 'iOS';
@@ -61,11 +60,9 @@ describe('check inBrowserFullscreen config', function () {
     player.isFullscreen().should.be.false;
     player.enterFullscreen();
     sandbox.restore();
-    sandbox.stub(player._fullscreenController, '_isNativeDocumentFullscreen').callsFake(() => {
+    sandbox.stub(player._fullscreenController, '_isIOSFullscreen').callsFake(() => {
       return true;
     });
-    // indicator for specific player if it's in fullscreen or another element in fullscreen
-    player._fullscreenController._isInFullscreen = true;
     player.isFullscreen().should.be.true;
   });
 
@@ -80,11 +77,11 @@ describe('check inBrowserFullscreen config', function () {
       return true;
     });
     // indicator for specific player if it's in fullscreen or another element in fullscreen
-    player._fullscreenController._isInFullscreen = true;
+    player._fullscreenController._isElementInFullscreen = true;
     player.isFullscreen().should.be.true;
 
     // indicator for specific player if it's in fullscreen or another element in fullscreen
-    player._fullscreenController._isInFullscreen = false;
+    player._fullscreenController._isElementInFullscreen = false;
     player.isFullscreen().should.be.false;
 
     sandbox.restore();
@@ -92,7 +89,7 @@ describe('check inBrowserFullscreen config', function () {
       return false;
     });
 
-    player._fullscreenController._isInFullscreen = false;
+    player._fullscreenController._isElementInFullscreen = false;
     player.isFullscreen().should.be.false;
   });
 });


### PR DESCRIPTION
### Description of the Changes

issue: Captions on the native player are cut and misplaced in the first few seconds.
playsinline=false starts in fullscreen without any indication.
Solution: split the check for IOS since it is relevant for specific player fullscreen status.

Solves FEC-11280

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
