### PR TITLE
fix(FEC-11277): iOS14 - captions on native player are cut and misplaced in the first few seconds

### DIFF
--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -66,8 +66,7 @@ class FullscreenController {
     return (
       this._player.env.os.name === 'iOS' &&
       !!videoElement &&
-      !!videoElement.webkitDisplayingFullscreen &&
-      (!videoElement.webkitPresentationMode || videoElement.webkitPresentationMode === 'fullscreen')
+      (videoElement.webkitPresentationMode === 'fullscreen' || (!videoElement.webkitPresentationMode && videoElement.webkitDisplayingFullscreen))
     );
   }
 


### PR DESCRIPTION
### Description of the Changes

Issue: in iOS14 `webkitDisplayingFullscreen` is not reliable for fullscreen active- it changed to `true` a bit after `webkitbeginfullscreen` triggered
Solutions: use `webkitPresentationMode === 'fullscreen'` for fullscreen active where applicable 

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
