### PR TITLE
fix(FEC-11414):  Externals text tracks with native subtitles not supported on IE 11

### DIFF
--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -486,7 +486,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
         track.mode = TextTrack.MODE.SHOWING;
         // For IE 11 which is not support VTTCue API
         if (window.VTTCue === undefined) {
-          let convertedCues: TextTrackCue[] = this._convertCues(cues);
+          let convertedCues: Array<TextTrackCue> = this._convertCues(cues);
           convertedCues.forEach(cue => track.addCue(cue));
         } else {
           cues.forEach(cue => track.addCue(cue));
@@ -499,9 +499,9 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * converting cues to be instances of TextTrackCue
    * for browser which dose not support VTTCue API
    * @param {Array<Cue>} cues - the cues to be converted
-   * @returns {TextTrackCue[]} the converted cues
+   * @returns {Array<TextTrackCue>} the converted cues
    */
-  _convertCues(cues: Array<Cue>): TextTrackCue[] {
+  _convertCues(cues: Array<Cue>): Array<TextTrackCue> {
     return cues.map(cue => new TextTrackCue(cue.startTime, cue.endTime, cue.text));
   }
 

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -484,9 +484,25 @@ class ExternalCaptionsHandler extends FakeEventTarget {
       const track = Array.from(videoElement.textTracks).find(track => (track ? TextTrack.isExternalTrack(track) : false));
       if (track) {
         track.mode = TextTrack.MODE.SHOWING;
-        cues.forEach(cue => track.addCue(cue));
+        // For IE 11 which is not support VTTCue API
+        if (window.VTTCue === undefined) {
+          let convertedCues: TextTrackCue[] = this._convertCues(cues);
+          convertedCues.forEach(cue => track.addCue(cue));
+        } else {
+          cues.forEach(cue => track.addCue(cue));
+        }
       }
     }
+  }
+
+  /**
+   * converting cues to be instances of TextTrackCue
+   * for browser which dose not support VTTCue API
+   * @param {Array<Cue>} cues - the cues to be converted
+   * @returns {TextTrackCue[]} the converted cues
+   */
+  _convertCues(cues: Array<Cue>): TextTrackCue[] {
+    return cues.map(cue => new TextTrackCue(cue.startTime, cue.endTime, cue.text));
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Internet Explorer 11 does not support VTTCue api and therefore throws an invalid argument error when trying to call addCue(cue) on native track with cue which is instance of VTTCue instead of TextTrackCue

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
