### PR TITLE
fix(FEC-11435): player not seeking to live edge after preroll ads

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2140,12 +2140,29 @@ export default class Player extends FakeEventTarget {
       this._shouldLoadAfterAttach = false;
     }
     this.ready().then(() => {
-      const liveOrDvrOutOfWindow = this.isLive() && (!this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0));
-      if (!this._firstPlay && liveOrDvrOutOfWindow) {
+      const shouldPlayerSeekToLiveEdge = this._maybeSeekToLiveEdge();
+      if (shouldPlayerSeekToLiveEdge) {
         this.seekToLiveEdge();
       }
       this._engine.play();
     });
+  }
+
+  /**
+   * Checking if player should seek to live edge.
+   * @returns {boolean} - Whether player should seek to live edge.
+   * @private
+   */
+  _maybeSeekToLiveEdge(): boolean {
+    if (this.isLive()) {
+      const liveOrDvrOutOfWindow = !this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0);
+      if (!this._firstPlay) {
+        return liveOrDvrOutOfWindow;
+      } else {
+        return this.src && !this.isOnLiveEdge();
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -2140,8 +2140,7 @@ export default class Player extends FakeEventTarget {
       this._shouldLoadAfterAttach = false;
     }
     this.ready().then(() => {
-      const shouldPlayerSeekToLiveEdge = this._maybeSeekToLiveEdge();
-      if (shouldPlayerSeekToLiveEdge) {
+      if (this._shouldPlayerSeekToLiveEdge()) {
         this.seekToLiveEdge();
       }
       this._engine.play();
@@ -2153,7 +2152,7 @@ export default class Player extends FakeEventTarget {
    * @returns {boolean} - Whether player should seek to live edge.
    * @private
    */
-  _maybeSeekToLiveEdge(): boolean {
+  _shouldPlayerSeekToLiveEdge(): boolean {
     if (this.isLive()) {
       const outOfDvr = !this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0);
       if (!this._firstPlay) {

--- a/src/player.js
+++ b/src/player.js
@@ -2155,11 +2155,11 @@ export default class Player extends FakeEventTarget {
    */
   _maybeSeekToLiveEdge(): boolean {
     if (this.isLive()) {
-      const liveOrDvrOutOfWindow = !this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0);
+      const outOfDvr = !this.isDvr() || (typeof this.currentTime === 'number' && this.currentTime < 0);
       if (!this._firstPlay) {
-        return liveOrDvrOutOfWindow;
+        return outOfDvr;
       } else {
-        return this.src !== null && this.src !== '' && !this.isOnLiveEdge();
+        return !!this.src && !this.isOnLiveEdge();
       }
     }
     return false;

--- a/src/player.js
+++ b/src/player.js
@@ -2159,7 +2159,7 @@ export default class Player extends FakeEventTarget {
       if (!this._firstPlay) {
         return liveOrDvrOutOfWindow;
       } else {
-        return this.src && !this.isOnLiveEdge();
+        return this.src !== null && this.src !== '' && !this.isOnLiveEdge();
       }
     }
     return false;


### PR DESCRIPTION
### Description of the Changes

checking if player should seek to live edge after playing pre-roll ads, when streaming live.
Solves FEC-11435

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
