### PR TITLE
fix(FEC-11451): video tracks are always returned with active false in…

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -545,7 +545,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           height: videoHeight,
           width: videoWidth,
           active: true,
-          index: 0
+          index: Array.from(videoTracks).findIndex((track: VideoTrack) => track.selected)
         };
         this._onTrackChanged(new VideoTrack(setting));
       }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -544,7 +544,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           language: '',
           height: videoHeight,
           width: videoWidth,
-          active: true
+          active: true,
+          index: 0
         };
         this._onTrackChanged(new VideoTrack(setting));
       }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -537,7 +537,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
 
   _handleVideoTracksChange(): void {
     if (!this._isProgressivePlayback()) {
-      const {videoHeight, videoWidth} = this._videoElement;
+      const {videoHeight, videoWidth, videoTracks} = this._videoElement;
       if (!this._videoDimensions || videoHeight !== this._videoDimensions.videoHeight || videoWidth !== this._videoDimensions.videoWidth) {
         this._videoDimensions = {videoHeight, videoWidth};
         const setting = {


### PR DESCRIPTION
### Description of the Changes

**issue**: video tracks are always returned with active false in native adapter, so when you call kalturaPlayer.getActiveTracks() you always get the video track undefined because it is filtered by active = true

**fix**: add the missing index property in the videoTrack object, 
look at this line https://github.com/kaltura/playkit-js/blob/master/src/player.js#L2381,
Which is the cause of the problem, since the index property does not exist, the condition will always return false

**solves: (FEC-11451)**

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
