### PR TITLE
fix(FEC-11467): caption selection changes across entries in playlists

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2507,7 +2507,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _setDefaultTrack<T: TextTrack | AudioTrack>(tracks: Array<T>, language: string, defaultTrack: ?Track): void {
-    const updateTrack = function (track) {
+    const updateTrack = track => {
       this.selectTrack(track);
       this._markActiveTrack(track);
     };

--- a/src/player.js
+++ b/src/player.js
@@ -2509,17 +2509,27 @@ export default class Player extends FakeEventTarget {
   _setDefaultTrack<T: TextTrack | AudioTrack>(tracks: Array<T>, language: string, defaultTrack: ?Track): void {
     const sameTrack: ?T = tracks.find(track => Track.langComparer(language, track.language, true));
     if (sameTrack) {
-      this.selectTrack(sameTrack);
-      this._markActiveTrack(sameTrack);
+      this._updateTrack(sameTrack);
     } else {
       const track: ?T = tracks.find(track => Track.langComparer(language, track.language, false));
       if (track) {
-        this.selectTrack(track);
-        this._markActiveTrack(track);
+        this._updateTrack(track);
       } else if (defaultTrack && !defaultTrack.active) {
         this.selectTrack(defaultTrack);
       }
     }
+  }
+
+  /**
+   * Selects a track and marks as active
+   * @function _updateTrack
+   * @param {?Track} track - the track to update
+   * @returns {void}
+   * @private
+   */
+  _updateTrack(track: ?Track) {
+    this.selectTrack(track);
+    this._markActiveTrack(track);
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -2507,29 +2507,21 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _setDefaultTrack<T: TextTrack | AudioTrack>(tracks: Array<T>, language: string, defaultTrack: ?Track): void {
+    const updateTrack = function (track) {
+      this.selectTrack(track);
+      this._markActiveTrack(track);
+    };
     const sameTrack: ?T = tracks.find(track => Track.langComparer(language, track.language, true));
     if (sameTrack) {
-      this._updateTrack(sameTrack);
+      updateTrack(sameTrack);
     } else {
       const track: ?T = tracks.find(track => Track.langComparer(language, track.language, false));
       if (track) {
-        this._updateTrack(track);
+        updateTrack(track);
       } else if (defaultTrack && !defaultTrack.active) {
         this.selectTrack(defaultTrack);
       }
     }
-  }
-
-  /**
-   * Selects a track and marks as active
-   * @function _updateTrack
-   * @param {?Track} track - the track to update
-   * @returns {void}
-   * @private
-   */
-  _updateTrack(track: ?Track) {
-    this.selectTrack(track);
-    this._markActiveTrack(track);
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -2507,12 +2507,18 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   _setDefaultTrack<T: TextTrack | AudioTrack>(tracks: Array<T>, language: string, defaultTrack: ?Track): void {
-    const track: ?T = tracks.find(track => Track.langComparer(language, track.language));
-    if (track) {
-      this.selectTrack(track);
-      this._markActiveTrack(track);
-    } else if (defaultTrack && !defaultTrack.active) {
-      this.selectTrack(defaultTrack);
+    const sameTrack: ?T = tracks.find(track => Track.langComparer(language, track.language, true));
+    if (sameTrack) {
+      this.selectTrack(sameTrack);
+      this._markActiveTrack(sameTrack);
+    } else {
+      const track: ?T = tracks.find(track => Track.langComparer(language, track.language, false));
+      if (track) {
+        this.selectTrack(track);
+        this._markActiveTrack(track);
+      } else if (defaultTrack && !defaultTrack.active) {
+        this.selectTrack(defaultTrack);
+      }
     }
   }
 

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -9,13 +9,18 @@ export default class Track {
    * Comparing language strings.
    * @param {string} inputLang - The configured language.
    * @param {string} trackLang - The default track language.
+   * @param {boolean} equal - Optional flag to check for matching languages.
    * @returns {boolean} - Whether the strings are equal or starts with the same substring.
    */
-  static langComparer(inputLang: string, trackLang: string): boolean {
+  static langComparer(inputLang: string, trackLang: string, equal: ?boolean): boolean {
     try {
       inputLang = inputLang.toLowerCase();
       trackLang = trackLang.toLowerCase();
-      return inputLang ? inputLang.startsWith(trackLang) || trackLang.startsWith(inputLang) : false;
+      if (equal) {
+        return inputLang ? inputLang === trackLang : false;
+      } else {
+        return inputLang ? inputLang.startsWith(trackLang) || trackLang.startsWith(inputLang) : false;
+      }
     } catch (e) {
       return false;
     }

--- a/test/src/track/track.spec.js
+++ b/test/src/track/track.spec.js
@@ -20,9 +20,11 @@ describe('Track', () => {
       Track.langComparer('', 'rus').should.be.false;
     });
 
-    it('should compare languages by equality', () => {
+    it('should compare languages using equality flag', () => {
       Track.langComparer('zh', 'zh', true).should.be.true;
       Track.langComparer('zh_tw', 'zh', true).should.be.false;
+      Track.langComparer('zh', 'zh', false).should.be.true;
+      Track.langComparer('zh', 'en', false).should.be.false;
     });
   });
 });

--- a/test/src/track/track.spec.js
+++ b/test/src/track/track.spec.js
@@ -23,8 +23,7 @@ describe('Track', () => {
     it('should compare languages using equality flag', () => {
       Track.langComparer('zh', 'zh', true).should.be.true;
       Track.langComparer('zh_tw', 'zh', true).should.be.false;
-      Track.langComparer('zh', 'zh', false).should.be.true;
-      Track.langComparer('zh', 'en', false).should.be.false;
+      Track.langComparer('zh_tw', 'zh', false).should.be.true;
     });
   });
 });

--- a/test/src/track/track.spec.js
+++ b/test/src/track/track.spec.js
@@ -19,5 +19,10 @@ describe('Track', () => {
     it('should return false if the input lang is empty', () => {
       Track.langComparer('', 'rus').should.be.false;
     });
+
+    it('should compare languages by equality', () => {
+      Track.langComparer('zh', 'zh', true).should.be.true;
+      Track.langComparer('zh_tw', 'zh', true).should.be.false;
+    });
   });
 });


### PR DESCRIPTION
### Description of the Changes

**issue:**
when playing a playlist which its entries have at least 2 matching prefix of key languages (i.e. "zh" and "zh_tw"), and switching from one entry to another, the caption selection in player changes.

**solution:**
adding equality check in langComparer().
first seeking for an identical caption language, then for prefix.

Solves [FEC-11467](https://kaltura.atlassian.net/browse/FEC-11467)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
