### PR TITLE
fix: (FEC-11484): safari - captions icon missing on specific entry (regression)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "webpack-dev-server --mode development",
     "watch": "webpack --progress --colors --watch --mode development",
     "test": "NODE_ENV=test karma start --color --mode development",
+    "test:watch": "NODE_ENV=test karma start --browsers=Chrome --single-run=false --auto-watch",
     "release": "standard-version",
     "pushTaggedRelease": "git push --follow-tags --no-verify origin master",
     "eslint": "eslint . --color",

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -148,7 +148,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @private
    */
   _maybeAddTrack(track: TextTrack, caption: PKExternalCaptionObject, playerTextTracks: Array<Track>, newTextTracks: Array<TextTrack>): void {
-    const sameLangTrack = playerTextTracks.find(textTrack => Track.langComparer(caption.language, textTrack.language));
+    const sameLangTrack = playerTextTracks.find(textTrack => textTrack.available && Track.langComparer(caption.language, textTrack.language));
     if (!sameLangTrack) {
       newTextTracks.push(track);
       this._updateTextTracksModel(caption);

--- a/test/src/track/external-captions-handler.spec.js
+++ b/test/src/track/external-captions-handler.spec.js
@@ -422,6 +422,11 @@ describe('ExternalCaptionsHandler', () => {
       externalCaptionsHandler.getExternalTracks([new TextTrack({language: 'en', label: 'english'})]).length.should.equal(1);
     });
 
+    it('should return an array with 2 textTracks elements both same language (the internal track is not available))', () => {
+      player._tracks.push(new TextTrack({language: 'en', label: 'english', available: false}));
+      externalCaptionsHandler.getExternalTracks(player._tracks).length.should.equal(2);
+    });
+
     it('should return an empty array (no captions)', () => {
       config = getConfigStructure();
       let sources = sourcesConfig.MultipleSources;


### PR DESCRIPTION
### Description of the Changes

**Captions on Safari - Captions icon missing on specific entry on V7 player 1.11.1 (regression)**

When running on Safari (seen both on Mac or iPad)
Captions icon missing on specific entry on V7 player 1.11.1 (regression)

**bug :** the ExternalCaptionHandler prevents duplicate tracks from being added to the list of tracks by comparing the external track to the existing tracks.

**fix:** that the comparison will be made only in relation to the availability tracks

solves: (FEC-11484)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
