### PR TITLE
fix(FEC-11510): No default font size selected in cvaa

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -737,7 +737,7 @@
   - [StandardColors][733]
   - [StandardOpacities][734]
   - [EdgeStyles][735]
-- [fontScale][736]
+  - [FontSizes][736]
 - [TextTrack][737]
 - [Track][738]
   - [Parameters][739]
@@ -4796,9 +4796,7 @@ that your application is in compliance with this or any other guideline.
 
 ### fontSize
 
-Font size, such as 1, 2, 3...
-
-Type: [number][898]
+font size percentage, according to the options in FontSizes enum
 
 ### fontFamily
 
@@ -4876,23 +4874,9 @@ shadow color, followed by pixel values for x-offset, y-offset, and blur.
 
 Type: ![Array][890]&lt;![Array][890]&lt;[number][898]>>
 
-## fontScale
+### FontSizes
 
-Copyright 2013 vtt.js Contributors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-[http://www.apache.org/licenses/LICENSE-2.0][924]
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-Type: [number][898]
+Possible font sizes are 50%, 75%, 100%, 200%, 300%, 400%
 
 ## TextTrack
 
@@ -5062,14 +5046,14 @@ Type: [boolean][892]
 ### displayState
 
 This is used as part of the rendering model, to keep cues in a consistent position.
-[http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#text-track-cue-display-state][925]
+[http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#text-track-cue-display-state][924]
 
 Type: [undefined][908]
 
 ### \_id
 
 VTTCue and TextTrackCue properties
-[http://dev.w3.org/html5/webvtt/#vttcue-interface][926]
+[http://dev.w3.org/html5/webvtt/#vttcue-interface][925]
 
 ##
 
@@ -5083,7 +5067,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-[http://www.apache.org/licenses/LICENSE-2.0][924]
+[http://www.apache.org/licenses/LICENSE-2.0][926]
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -6474,7 +6458,7 @@ Returns **([number][898] \| [NaN][928])** 0 if the versions are equal- a negativ
 [733]: #standardcolors
 [734]: #standardopacities
 [735]: #edgestyles
-[736]: #fontscale
+[736]: #fontsizes
 [737]: #texttrack
 [738]: #track-1
 [739]: #parameters-113
@@ -6662,8 +6646,8 @@ Returns **([number][898] \| [NaN][928])** 0 if the versions are equal- a negativ
 [921]: #textstylestandardopacities
 [922]: #textstyleedgestyles
 [923]: https://goo.gl/ZcqOOM
-[924]: http://www.apache.org/licenses/LICENSE-2.0
-[925]: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#text-track-cue-display-state
-[926]: http://dev.w3.org/html5/webvtt/#vttcue-interface
+[924]: http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#text-track-cue-display-state
+[925]: http://dev.w3.org/html5/webvtt/#vttcue-interface
+[926]: http://www.apache.org/licenses/LICENSE-2.0
 [927]: https://developer.mozilla.org/docs/Web/API/Element
 [928]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NaN

--- a/flow-typed/types/text-style.js
+++ b/flow-typed/types/text-style.js
@@ -1,7 +1,6 @@
 // @flow
 declare type PKTextStyleObject = {
   fontSize: string,
-  fontScale: number,
   fontFamily: string,
   fontColor: Array<number>,
   fontOpacity: number,

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -173,7 +173,7 @@ class TextStyle {
    */
   fontSize: string = '100%';
 
-  fontScale: number = 1;
+  fontScale: number = 0;
 
   /**
    * @type {TextStyle.FontFamily}

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -99,6 +99,9 @@ class TextStyle {
     ]
   };
 
+  /**
+   * Possible font sizes are 50%, 75%, 100%, 200%, 300%, 400%
+   */
   static FontSizes: Array<Object> = [
     {
       value: -2,
@@ -145,7 +148,6 @@ class TextStyle {
     let textStyle = new TextStyle();
     textStyle.fontEdge = getValue(setting.fontEdge, textStyle.fontEdge);
     textStyle.fontSize = getValue(setting.fontSize, textStyle.fontSize);
-    textStyle.fontScale = getValue(setting.fontScale, textStyle.fontScale);
     textStyle.fontColor = getValue(setting.fontColor, textStyle.fontColor);
     textStyle.fontOpacity = getValue(setting.fontOpacity, textStyle.fontOpacity);
     textStyle.backgroundColor = getValue(setting.backgroundColor, textStyle.backgroundColor);
@@ -158,7 +160,6 @@ class TextStyle {
     return {
       fontEdge: text.fontEdge,
       fontSize: text.fontSize,
-      fontScale: text.fontScale,
       fontColor: text.fontColor,
       fontOpacity: text.fontOpacity,
       backgroundColor: text.backgroundColor,
@@ -167,13 +168,21 @@ class TextStyle {
     };
   }
 
-  /**
-   * Font size, such as 1, 2, 3...
-   * @type {number}
-   */
-  fontSize: string = '100%';
+  _fontSizeIndex: number = 2; // 100%
 
-  fontScale: number = 0;
+  set fontSize(fontSize: string) {
+    const index = TextStyle.FontSizes.findIndex(({label}) => label === fontSize);
+    if (index !== -1) {
+      this._fontSizeIndex = index;
+    }
+  }
+
+  /**
+   * Font size percentage, according to FontSizes enum
+   */
+  get fontSize() {
+    return TextStyle.FontSizes[this._fontSizeIndex].label;
+  }
 
   /**
    * @type {TextStyle.FontFamily}
@@ -253,7 +262,8 @@ class TextStyle {
   }
 
   get implicitFontScale(): number {
-    return IMPLICIT_SCALE_PERCENTAGE * this.fontScale + 1;
+    const fontSizeValue = TextStyle.FontSizes[this._fontSizeIndex].value;
+    return IMPLICIT_SCALE_PERCENTAGE * fontSizeValue + 1;
   }
 }
 

--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -4,7 +4,7 @@ import TextStyle from './text-style';
 import TextTrack from './text-track';
 
 /* eslint-disable */
-/**
+/*
  * Copyright 2013 vtt.js Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1398,7 +1398,6 @@ describe('Player', function () {
         let textStyle = new TextStyle();
         textStyle.fontEdge = TextStyle.EdgeStyles.RAISED;
         textStyle.fontSize = '75%';
-        textStyle.fontScale = '3';
         textStyle.fontColor = TextStyle.StandardColors.BLACK;
         textStyle.fontOpacity = TextStyle.StandardOpacities.SEMI_HIGH;
         textStyle.backgroundOpacity = TextStyle.StandardOpacities.SEMI_LOW;
@@ -1408,7 +1407,6 @@ describe('Player', function () {
         const currentTextStyle = player.textStyle;
         currentTextStyle.fontEdge.should.deep.equal(textStyle.fontEdge);
         currentTextStyle.fontSize.should.equal(textStyle.fontSize);
-        currentTextStyle.fontScale.should.equal(textStyle.fontScale);
         currentTextStyle.fontColor.should.deep.equal(textStyle.fontColor);
         currentTextStyle.fontOpacity.should.equal(textStyle.fontOpacity);
         currentTextStyle.backgroundOpacity.should.equal(textStyle.backgroundOpacity);
@@ -1420,7 +1418,6 @@ describe('Player', function () {
         const settings = {
           fontEdge: TextStyle.EdgeStyles.NONE,
           fontSize: '75%',
-          fontScale: '3',
           fontColor: TextStyle.StandardColors.CYAN,
           fontOpacity: TextStyle.StandardOpacities.TRANSPARENT,
           backgroundOpacity: TextStyle.StandardOpacities.TRANSPARENT,
@@ -1430,7 +1427,6 @@ describe('Player', function () {
         const textStyle = TextStyle.fromJson(settings);
         textStyle.fontEdge.should.deep.equal(settings.fontEdge);
         textStyle.fontSize.should.equal(settings.fontSize);
-        textStyle.fontScale.should.equal(settings.fontScale);
         textStyle.fontColor.should.deep.equal(settings.fontColor);
         textStyle.fontOpacity.should.equal(settings.fontOpacity);
         textStyle.backgroundOpacity.should.equal(settings.backgroundOpacity);
@@ -1442,7 +1438,6 @@ describe('Player', function () {
         const settings = {
           fontEdge: TextStyle.EdgeStyles.RAISED,
           fontSize: '75%',
-          fontScale: '3',
           fontColor: TextStyle.StandardColors.CYAN,
           fontOpacity: TextStyle.StandardOpacities.SEMI_LOW,
           backgroundOpacity: TextStyle.StandardOpacities.SEMI_LOW,
@@ -1452,7 +1447,6 @@ describe('Player', function () {
         let textStyle = new TextStyle();
         textStyle.fontEdge = TextStyle.EdgeStyles.RAISED;
         textStyle.fontSize = '75%';
-        textStyle.fontScale = '3';
         textStyle.fontColor = TextStyle.StandardColors.CYAN;
         textStyle.fontOpacity = TextStyle.StandardOpacities.SEMI_LOW;
         textStyle.backgroundColor = TextStyle.StandardColors.RED;
@@ -1465,7 +1459,6 @@ describe('Player', function () {
         const settings = {
           fontEdge: TextStyle.EdgeStyles.RAISED,
           fontSize: '75%',
-          fontScale: '3',
           fontColor: TextStyle.StandardColors.CYAN,
           fontOpacity: TextStyle.StandardOpacities.SEMI_LOW,
           backgroundOpacity: TextStyle.StandardOpacities.SEMI_LOW,
@@ -1475,7 +1468,6 @@ describe('Player', function () {
         let textStyle = new TextStyle();
         textStyle.fontEdge = TextStyle.EdgeStyles.RAISED;
         textStyle.fontSize = '75%';
-        textStyle.fontScale = '3';
         textStyle.fontColor = TextStyle.StandardColors.CYAN;
         textStyle.fontOpacity = TextStyle.StandardOpacities.SEMI_LOW;
         textStyle.backgroundColor = TextStyle.StandardColors.RED;
@@ -1488,7 +1480,6 @@ describe('Player', function () {
         let clonedTextStyle = new TextStyle();
         clonedTextStyle.fontEdge = TextStyle.EdgeStyles.RAISED;
         clonedTextStyle.fontSize = '75%';
-        clonedTextStyle.fontScale = '3';
         clonedTextStyle.fontColor = TextStyle.StandardColors.CYAN;
         clonedTextStyle.fontOpacity = TextStyle.StandardOpacities.SEMI_LOW;
         clonedTextStyle.backgroundColor = TextStyle.StandardColors.RED;


### PR DESCRIPTION
### Description of the Changes

Modify default font size to 100%.
Remove uses of fontScale and expose fontSize in API.

Fixes FEC-11510.

Related PRs: 
https://github.com/kaltura/playkit-js-ui/pull/639.
https://github.com/kaltura/kaltura-player-js/pull/491

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
