### PR TITLE
fix(FEC-11606): merge active cue-points from all metadata TextTracks

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1165,7 +1165,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     const listenToCueChange = track => {
       track.mode = PKTextTrack.MODE.HIDDEN;
       this._eventManager.listen(track, 'cuechange', () => {
-        this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: Array.from(track.activeCues)}));
+        this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: Array.from(track.activeCues), label: track.label}));
       });
     };
     const metadataTrack = Array.from(this._el.textTracks).find((track: TextTrack) => PKTextTrack.isMetaDataTrack(track));

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1165,7 +1165,13 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     const listenToCueChange = track => {
       track.mode = PKTextTrack.MODE.HIDDEN;
       this._eventManager.listen(track, 'cuechange', () => {
-        this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: Array.from(track.activeCues)}));
+        let activeCues = [];
+        Array.from(this._el.textTracks).forEach((track: TextTrack) => {
+          if (PKTextTrack.isMetaDataTrack(track)) {
+            activeCues = activeCues.concat(Array.from(track.activeCues));
+          }
+        });
+        this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: activeCues}));
       });
     };
     const metadataTrack = Array.from(this._el.textTracks).find((track: TextTrack) => PKTextTrack.isMetaDataTrack(track));

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -7,6 +7,7 @@ import MediaSourceProvider from './media-source/media-source-provider';
 import VideoTrack from '../../track/video-track';
 import AudioTrack from '../../track/audio-track';
 import PKTextTrack, {getActiveCues} from '../../track/text-track';
+import {Cue} from '../../track/vtt-cue';
 import ImageTrack from '../../track/image-track';
 import * as Utils from '../../utils/util';
 import Html5AutoPlayCapability from './capabilities/html5-autoplay';
@@ -1172,6 +1173,9 @@ export default class Html5 extends FakeEventTarget implements IEngine {
           if (PKTextTrack.isMetaDataTrack(track)) {
             activeCues = activeCues.concat(getActiveCues(track.activeCues));
           }
+        });
+        activeCues = activeCues.sort((a: Cue, b: Cue) => {
+          return a.startTime - b.startTime;
         });
         this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: activeCues}));
       });

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1165,7 +1165,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     const listenToCueChange = track => {
       track.mode = PKTextTrack.MODE.HIDDEN;
       this._eventManager.listen(track, 'cuechange', () => {
-        this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: Array.from(track.activeCues), label: track.label}));
+        this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: Array.from(track.activeCues)}));
       });
     };
     const metadataTrack = Array.from(this._el.textTracks).find((track: TextTrack) => PKTextTrack.isMetaDataTrack(track));

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1170,7 +1170,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
         let activeCues = [];
         Array.from(this._el.textTracks).forEach((track: TextTrack) => {
           if (PKTextTrack.isMetaDataTrack(track)) {
-            activeCues = activeCues.concat(Array.from(track.activeCues));
+            activeCues = activeCues.concat(getActiveCues(track.activeCues));
           }
         });
         this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: activeCues}));


### PR DESCRIPTION
### Description of the Changes

Merge active cue-points from all metadata TextTracks for TIMED_METADATA payload

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
