### PR TITLE
fix(FEC-11586): [Player, Safari] The 'FF' (Fast forward) seek button is flashing time to time in player due to getting different values from 'isOnLiveEdge' parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ dist: xenial
 language: node_js
 node_js:
   - 'node'
+env:
+  global:
+    - NODE_OPTIONS="--openssl-legacy-provider"
 
 addons:
   chrome: stable

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -122,6 +122,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
 
   _segmentDuration: number = 0;
 
+  _lastUpdatedCurrentTime: number = 0;
+
+  _lastUpdatedDurationProgress: number = 0;
+
   /**
    * A counter to track the number of attempts to recover from media error
    * @type {number}
@@ -1118,7 +1122,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   }
 
   get liveDuration() {
-    return this._getLiveEdge() + this.getSegmentDuration();
+    const currentTime = this._videoElement.currentTime;
+    this._lastUpdatedDurationProgress += currentTime - this._lastUpdatedCurrentTime;
+    this._lastUpdatedCurrentTime = currentTime;
+    return this._liveEdge + this._lastUpdatedDurationProgress;
   }
 
   /**
@@ -1160,6 +1167,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       const liveEdge = this._getLiveEdge();
       if (this._liveEdge !== liveEdge) {
         this._liveEdge = liveEdge;
+        this._lastUpdatedDurationProgress = 0;
+        this._lastUpdatedCurrentTime = this._videoElement.currentTime;
         this._videoElement.dispatchEvent(new window.Event(Html5EventType.DURATION_CHANGE));
       }
       const {buffered, seekable} = this._videoElement;

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -1177,7 +1177,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       const {buffered, seekable} = this._videoElement;
       if (buffered.length && seekable.length) {
         this._segmentDuration = (buffered.end(buffered.length - 1) - seekable.end(seekable.length - 1)) / SAFARI_BUFFERED_SEGMENTS_COUNT;
-        this._liveEdge = this._getLiveEdge();
       }
     } else {
       const liveEdge = this._getLiveEdge();


### PR DESCRIPTION
### Description of the Changes

***issue:*** The live indicator depends on the isOnLiveEdge flag and the isOnLiveEdge flag  is calculated by the following formula:  liveDuration - currentTime <= segmentDuration  × 2.

and the segmentDuration is calculated by the gap between last updated Video.seekable, and Video.bufferd. (and on the assumption that the bufferd is bigger than seekable at any point)

but in practice bufferd Unlike Video.currentTime (which is always progresses), is sometimes reverses which brings the segmentDuration to become a negative number, and hence although that current time is close enough to seekable to be considered on live, the condition returns false since the liveDuration - currentTime would always be a positive number

***fix:*** The solution is to not rely on the bufferd to determine the liveDuration but on the gap between the seekables themself.

solves FEC-11586

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
