### PR TITLE
fix(FEC-11655): System highlights 2 options (captions) after clicking the "Change media" button on Safari

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -698,6 +698,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const captionsTextTrackLanguageCodes = [this._config.captionsTextTrack1LanguageCode, this._config.captionsTextTrack2LanguageCode];
     const textTracks = this._videoElement.textTracks;
     const parsedTracks = [];
+    let index = 0;
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
         if (!PKTextTrack.isExternalTrack(textTracks[i])) {
@@ -707,7 +708,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
             label: textTracks[i].label,
             language: textTracks[i].language,
             available: true,
-            index: i
+            index: index++
           };
           if (settings.kind === PKTextTrack.KIND.SUBTITLES) {
             parsedTracks.push(new PKTextTrack(settings));

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -698,7 +698,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const captionsTextTrackLanguageCodes = [this._config.captionsTextTrack1LanguageCode, this._config.captionsTextTrack2LanguageCode];
     const textTracks = this._videoElement.textTracks;
     const parsedTracks = [];
-    let index = 0;
+    let internalTrackIndex = 0;
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
         if (!PKTextTrack.isExternalTrack(textTracks[i])) {
@@ -708,7 +708,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
             label: textTracks[i].label,
             language: textTracks[i].language,
             available: true,
-            index: index++
+            index: internalTrackIndex++
           };
           if (settings.kind === PKTextTrack.KIND.SUBTITLES) {
             parsedTracks.push(new PKTextTrack(settings));


### PR DESCRIPTION
### Description of the Changes

***issue:***  look at _getParsedTextTracks() on https://github.com/kaltura/playkit-js/blob/master/src/engines/html5/media-source/adapters/native-adapter.js#L696
 when this method called at the second time (like after calling changeMedie() in this case) the textTracks including the external text trcak.

and the first condition evaluates to false and therefore the indexes start from 1 instead of 0 which leads to an incorrect index value (that is - same index for two different tracks) on the getExternalTracks() method in (https://github.com/kaltura/playkit-js/blob/master/src/track/external-captions-handler.js#L118) since  it is relying on the textTracks.langth.

and that bring the method the _markActiveTrack(track: Track) method on https://github.com/kaltura/playkit-js/blob/master/src/player.js#L2414 to mark both tracks as active

***fix:*** in the native adapter not relying on the for index which progresses regardless of actual track index

solves: FEC-11655

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
