### PR TITLE
fix(FEC-11645): id3 metadata doesn't fired when streaming with captions

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1080,9 +1080,11 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @private
    */
   _removeCueChangeListeners(): void {
-    for (let i = 0; i < this._el.textTracks.length; i++) {
-      this._eventManager.unlisten(this._el.textTracks[i], 'cuechange');
-    }
+    Array.from(this._el.textTracks)
+      .filter(track => !PKTextTrack.isMetaDataTrack(track))
+      .forEach(track => {
+        this._eventManager.unlisten(track, 'cuechange');
+      });
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

dont turn off the metadata track listener when selecting a text track

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
