### PR TITLE
fix(FEC-11611): Pass the program ID when sending a bookmark

### DIFF
--- a/flow-typed/types/metadata-config.js
+++ b/flow-typed/types/metadata-config.js
@@ -1,6 +1,6 @@
 // @flow
 declare type PKMetadataConfigObject = {
-  name: string,
+  name?: string,
   description?: string,
   mediaType?: string,
   metas?: Object,

--- a/flow-typed/types/metadata-config.js
+++ b/flow-typed/types/metadata-config.js
@@ -1,5 +1,10 @@
 // @flow
 declare type PKMetadataConfigObject = {
-  name?: string,
-  description?: string
+  name: string,
+  description?: string,
+  mediaType?: string,
+  metas?: Object,
+  tags?: Object,
+  epgId?: string,
+  recordingId?: string
 };

--- a/src/player.js
+++ b/src/player.js
@@ -472,7 +472,7 @@ export default class Player extends FakeEventTarget {
    */
   setSourcesMetadata(sourcesMetadata: PKMetadataConfigObject): void {
     if (this._sources) {
-      if (!this?._sources?.metadata) {
+      if (!this._sources.metadata) {
         this._sources.metadata = {};
       }
       Utils.Object.mergeDeep(this._sources.metadata, sourcesMetadata);

--- a/src/player.js
+++ b/src/player.js
@@ -467,11 +467,11 @@ export default class Player extends FakeEventTarget {
 
   /**
    * Configures the player according to a given configuration.
-   * @param {PKMetadataConfigObject} sourceMetadata - The sources metadata for the player instance.
+   * @param {PKMetadataConfigObject} sourcesMetadata - The sources metadata for the player instance.
    * @returns {void}
    */
-  setSourcesMetadata(sourceMetadata: PKMetadataConfigObject): void {
-    Utils.Object.mergeDeep(this._sources.metadata, sourceMetadata);
+  setSourcesMetadata(sourcesMetadata: PKMetadataConfigObject): void {
+    Utils.Object.mergeDeep(this._sources.metadata, sourcesMetadata);
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -467,6 +467,15 @@ export default class Player extends FakeEventTarget {
 
   /**
    * Configures the player according to a given configuration.
+   * @param {PKMetadataConfigObject} sourceMetaData - The sources metadata for the player instance.
+   * @returns {void}
+   */
+  setSourcesMetaData(sourceMetaData: PKMetadataConfigObject): void {
+    Utils.Object.mergeDeep(this._sources.metadata, sourceMetaData);
+  }
+
+  /**
+   * Configures the player according to a given configuration.
    * @param {PKSourcesConfigObject} sources - The sources for the player instance.
    * @returns {void}
    */

--- a/src/player.js
+++ b/src/player.js
@@ -472,7 +472,7 @@ export default class Player extends FakeEventTarget {
    */
   setSourcesMetadata(sourcesMetadata: PKMetadataConfigObject): void {
     if (this._sources) {
-      if (this?._sources?.metadata) {
+      if (!this?._sources?.metadata) {
         this._sources.metadata = {};
       }
       Utils.Object.mergeDeep(this._sources.metadata, sourcesMetadata);

--- a/src/player.js
+++ b/src/player.js
@@ -466,12 +466,17 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
-   * Configures the player according to a given configuration.
+   * Configures the player metadata according to a given configuration.
    * @param {PKMetadataConfigObject} sourcesMetadata - The sources metadata for the player instance.
    * @returns {void}
    */
   setSourcesMetadata(sourcesMetadata: PKMetadataConfigObject): void {
-    Utils.Object.mergeDeep(this._sources.metadata, sourcesMetadata);
+    if (this._sources) {
+      if (this?._sources?.metadata) {
+        this._sources.metadata = {};
+      }
+      Utils.Object.mergeDeep(this._sources.metadata, sourcesMetadata);
+    }
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -467,11 +467,11 @@ export default class Player extends FakeEventTarget {
 
   /**
    * Configures the player according to a given configuration.
-   * @param {PKMetadataConfigObject} sourceMetaData - The sources metadata for the player instance.
+   * @param {PKMetadataConfigObject} sourceMetadata - The sources metadata for the player instance.
    * @returns {void}
    */
-  setSourcesMetaData(sourceMetaData: PKMetadataConfigObject): void {
-    Utils.Object.mergeDeep(this._sources.metadata, sourceMetaData);
+  setSourcesMetaData(sourceMetadata: PKMetadataConfigObject): void {
+    Utils.Object.mergeDeep(this._sources.metadata, sourceMetadata);
   }
 
   /**

--- a/src/player.js
+++ b/src/player.js
@@ -470,7 +470,7 @@ export default class Player extends FakeEventTarget {
    * @param {PKMetadataConfigObject} sourceMetadata - The sources metadata for the player instance.
    * @returns {void}
    */
-  setSourcesMetaData(sourceMetadata: PKMetadataConfigObject): void {
+  setSourcesMetadata(sourceMetadata: PKMetadataConfigObject): void {
     Utils.Object.mergeDeep(this._sources.metadata, sourceMetadata);
   }
 


### PR DESCRIPTION
### Description of the Changes

add setSourcesMetadata api (to enable dynamically cofigure the epgId (programId) in the sources.metadata)

related pr:
https://github.com/kaltura/playkit-js-providers/pull/155
https://github.com/kaltura/playkit-js-ott-analytics/pull/64
https://github.com/kaltura/kaltura-player-js/pull/504
https://github.com/kaltura/kaltura-player-js/pull/503

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
