### PR TITLE
(FEC-11744): Player_Web_Mac_Safari - Start Over button moves program to live position (when you click on it for 2nd time and more)

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -331,7 +331,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         const playbackStartTime = this._startTimeAttach || startTime || 0;
         this._loadPromiseReject = reject;
         this._eventManager.listenOnce(this._videoElement, Html5EventType.LOADED_DATA, () => this._onLoadedData(resolve, playbackStartTime));
-        this._eventManager.listenOnce(this._videoElement, Html5EventType.PLAY, () => this._onPlay(playbackStartTime));
+        this._eventManager.listenOnce(this._videoElement, Html5EventType.PLAYING, () => this._onPlaying(playbackStartTime));
         this._eventManager.listen(this._videoElement, Html5EventType.TIME_UPDATE, () => this._onTimeUpdate());
         this._eventManager.listen(this._videoElement, Html5EventType.PLAY, () => this._resetHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.PAUSE, () => this._clearHeartbeatTimeout());
@@ -464,7 +464,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @private
    * @returns {void}
    */
-  _onPlay(startTime: ?number): void {
+  _onPlaying(startTime: ?number): void {
     if (this.isLive()) {
       this._setStartTime(startTime);
     }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -330,7 +330,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._lastTimeUpdate = startTime || 0;
         const playbackStartTime = this._startTimeAttach || startTime || 0;
         this._loadPromiseReject = reject;
-        this._eventManager.listenOnce(this._videoElement, Html5EventType.LOADED_DATA, () => this._onLoadedData(resolve, playbackStartTime));
+        this._eventManager.listenOnce(this._videoElement, Html5EventType.LOADED_DATA, () => this._onLoadedData(resolve));
+        this._eventManager.listenOnce(this._videoElement, Html5EventType.PLAY, () => this._setStartTime(playbackStartTime));
         this._eventManager.listen(this._videoElement, Html5EventType.TIME_UPDATE, () => this._onTimeUpdate());
         this._eventManager.listen(this._videoElement, Html5EventType.PLAY, () => this._resetHeartbeatTimeout());
         this._eventManager.listen(this._videoElement, Html5EventType.PAUSE, () => this._clearHeartbeatTimeout());
@@ -464,7 +465,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @private
    * @returns {void}
    */
-  _onLoadedData(resolve: Function, startTime: ?number): void {
+  _onLoadedData(resolve: Function): void {
     const parseTracksAndResolve = () => {
       this._playerTracks = this._getParsedTracks();
       this._addNativeAudioTrackChangeListener();
@@ -477,15 +478,19 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         this._handleLiveDurationChange();
       }
     };
-    if (startTime && startTime > -1) {
-      this._videoElement.currentTime = startTime;
-    }
     if (this._videoElement.textTracks.length > 0) {
       parseTracksAndResolve();
     } else {
       this._eventManager.listenOnce(this._videoElement, Html5EventType.CAN_PLAY, parseTracksAndResolve.bind(this));
     }
     this._startTimeAttach = NaN;
+  }
+
+  _setStartTime(startTime: ?number) {
+    if (startTime && startTime > -1) {
+      console.log('1111111111', 'CAME HERE', startTime);
+      this._videoElement.currentTime = startTime;
+    }
   }
 
   _onTimeUpdate(): void {


### PR DESCRIPTION
### Description of the Changes

***issue:*** the native-adapter failed to set the duration on onlodedeData event properly since it is too early
***fix:*** move the duration setting to the play event (on live)

solves: FEC-11744
### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
