### PR TITLE
fix(FEC-11745): Player_Web_Mac_Safari - Flash of live stream after Start Over

### DIFF
--- a/flow-typed/interfaces/media-source-adapter.js
+++ b/flow-typed/interfaces/media-source-adapter.js
@@ -30,6 +30,7 @@ declare interface IMediaSourceAdapter extends FakeEventTarget {
   isAdaptiveBitrateEnabled(): boolean;
   seekToLiveEdge(): void;
   isLive(): boolean;
+  isOnLiveEdge(): boolean;
   getStartTimeOfDvrWindow(): number;
   setMaxBitrate(bitrate: number): void;
   attachMediaSource(): void;

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -15,8 +15,6 @@ import getLogger from '../../utils/logger';
 import {DroppedFramesWatcher} from '../dropped-frames-watcher';
 import {ThumbnailInfo} from '../../thumbnail/thumbnail-info';
 
-const CURRENT_OR_NEXT_SEGMENT_COUNT: number = 2;
-
 /**
  * Html5 engine for playback.
  * @classdesc
@@ -470,7 +468,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
 
   isOnLiveEdge(): boolean {
     if (this._mediaSourceAdapter) {
-      return this.liveDuration - this.currentTime <= this._mediaSourceAdapter.getSegmentDuration() * CURRENT_OR_NEXT_SEGMENT_COUNT;
+      return this._mediaSourceAdapter.isOnLiveEdge();
     }
     return false;
   }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -120,6 +120,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
 
   _waitingEventTriggered: ?boolean = false;
 
+  _wasCurrentTimeSetSuccessfully: boolean;
+
   _segmentDuration: number = 0;
 
   /**
@@ -324,6 +326,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @returns {Promise<Object>} - The loaded data
    */
   load(startTime: ?number): Promise<Object> {
+    this._wasCurrentTimeSetSuccessfully = false;
     this._maybeSetDrmPlayback();
     if (!this._loadPromise) {
       this._loadPromise = new Promise((resolve, reject) => {
@@ -504,6 +507,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   _setStartTime(startTime: ?number) {
     if (startTime && startTime > -1) {
       this._videoElement.currentTime = startTime;
+      this._wasCurrentTimeSetSuccessfully = true;
     }
   }
 
@@ -1167,6 +1171,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    */
   isLive(): boolean {
     return this._videoElement.duration === Infinity;
+  }
+
+  isOnLiveEdge(): boolean {
+    return this._wasCurrentTimeSetSuccessfully ? super.isOnLiveEdge() : false;
   }
 
   /**

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -507,8 +507,8 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   _setStartTime(startTime: ?number) {
     if (startTime && startTime > -1) {
       this._videoElement.currentTime = startTime;
-      this._wasCurrentTimeSetSuccessfully = true;
     }
+    this._wasCurrentTimeSetSuccessfully = true;
   }
 
   _onTimeUpdate(): void {

--- a/src/engines/html5/media-source/base-media-source-adapter.js
+++ b/src/engines/html5/media-source/base-media-source-adapter.js
@@ -13,6 +13,8 @@ import EventManager from '../../../event/event-manager';
 import ImageTrack from '../../../track/image-track';
 import {ThumbnailInfo} from '../../../thumbnail/thumbnail-info';
 
+const CURRENT_OR_NEXT_SEGMENT_COUNT: number = 2;
+
 export default class BaseMediaSourceAdapter extends FakeEventTarget implements IMediaSourceAdapter {
   /**
    * The id of the adapter.
@@ -216,6 +218,10 @@ export default class BaseMediaSourceAdapter extends FakeEventTarget implements I
 
   isLive(): boolean {
     return BaseMediaSourceAdapter._throwNotImplementedError('isLive');
+  }
+
+  isOnLiveEdge(): boolean {
+    return this.liveDuration - this._videoElement.currentTime <= this.getSegmentDuration() * CURRENT_OR_NEXT_SEGMENT_COUNT;
   }
 
   setMaxBitrate(bitrate: number): void {


### PR DESCRIPTION
### Description of the Changes

**issue:** in live stream played on safari when you seek back to - 0 (start over), the currentTime jump to live edge (and equal to duration) for a few ms before resets back to 0, making the isOnLiveEdge() logic on the engine to evalute to false
**fix:** move the isOnLiveEdge() api defenition to the adapters level and let the native adapter to overide the logic and return false by default as long as currentTime resetting was not completed

solves: FEC-11745

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
