### PR TITLE
feat(FEC-11761): expose stream timed metadata - phase 2

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1165,9 +1165,9 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   }
 
   _handleMetadataTrackEvents(): void {
-    const listenToCueChange = track => {
-      track.mode = PKTextTrack.MODE.HIDDEN;
-      this._eventManager.listen(track, 'cuechange', () => {
+    const listenToCueChange = metadataTrack => {
+      metadataTrack.mode = PKTextTrack.MODE.HIDDEN;
+      this._eventManager.listen(metadataTrack, 'cuechange', () => {
         let activeCues = [];
         Array.from(this._el.textTracks).forEach((track: TextTrack) => {
           if (PKTextTrack.isMetaDataTrack(track)) {

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -327,7 +327,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._eventManager.listen(mediaSourceAdapter, CustomEventType.MEDIA_RECOVERED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(mediaSourceAdapter, CustomEventType.TIMED_METADATA_ADDED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(mediaSourceAdapter, 'hlsFragParsingMetadata', (event: FakeEvent) => this.dispatchEvent(event));
-      this._eventManager.listen(mediaSourceAdapter, 'timelineregionenter', (event: FakeEvent) => this.dispatchEvent(event));
       if (this._droppedFramesWatcher) {
         this._eventManager.listen(this._droppedFramesWatcher, CustomEventType.FPS_DROP, (event: FakeEvent) => this.dispatchEvent(event));
       }

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -9,7 +9,7 @@ import AudioTrack from '../../track/audio-track';
 import PKTextTrack, {getActiveCues} from '../../track/text-track';
 import ImageTrack from '../../track/image-track';
 import {Cue} from '../../track/vtt-cue';
-import {createCuePoint} from '../../track/cue-point';
+import {createTimedMetadata} from '../../track/timed-metadata';
 import * as Utils from '../../utils/util';
 import Html5AutoPlayCapability from './capabilities/html5-autoplay';
 import Error from '../../error/error';
@@ -1180,7 +1180,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
         this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: activeCues}));
         this.dispatchEvent(
           new FakeEvent(CustomEventType.TIMED_METADATA_CHANGE, {
-            cues: activeCues.map(cue => createCuePoint(cue))
+            cues: activeCues.map(cue => createTimedMetadata(cue))
           })
         );
       });

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1178,13 +1178,11 @@ export default class Html5 extends FakeEventTarget implements IEngine {
           return a.startTime - b.startTime;
         });
         this.dispatchEvent(new FakeEvent(CustomEventType.TIMED_METADATA, {cues: activeCues}));
-        if (activeCues.length) {
-          this.dispatchEvent(
-            new FakeEvent(CustomEventType.TIMED_METADATA_CHANGE, {
-              cues: activeCues.map(cue => createCuePoint(cue))
-            })
-          );
-        }
+        this.dispatchEvent(
+          new FakeEvent(CustomEventType.TIMED_METADATA_CHANGE, {
+            cues: activeCues.map(cue => createCuePoint(cue))
+          })
+        );
       });
     };
 

--- a/src/event/event-type.js
+++ b/src/event/event-type.js
@@ -241,6 +241,10 @@ const CustomEventType: PKEventTypes = {
    */
   TIMED_METADATA: 'timedmetadata',
   /**
+   * Fired when the timed metadata triggered
+   */
+  TIMED_METADATA_CHANGE: 'timedmetadatachange',
+  /**
    * Fires when new timed metadata added
    */
   TIMED_METADATA_ADDED: 'timedmetadataadded',

--- a/src/player.js
+++ b/src/player.js
@@ -1921,6 +1921,7 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEventType.TEXT_CUE_CHANGED, (event: FakeEvent) => this._onCueChange(event));
       this._eventManager.listen(this._engine, CustomEventType.ABR_MODE_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.TIMED_METADATA, (event: FakeEvent) => this.dispatchEvent(event));
+      this._eventManager.listen(this._engine, CustomEventType.TIMED_METADATA_CHANGE, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.TIMED_METADATA_ADDED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.PLAY_FAILED, (event: FakeEvent) => {
         this._onPlayFailed(event);

--- a/src/playkit.js
+++ b/src/playkit.js
@@ -11,7 +11,7 @@ import ImageTrack from './track/image-track';
 import VideoTrack from './track/video-track';
 import AudioTrack from './track/audio-track';
 import TextTrack from './track/text-track';
-import {CuePoint, createTextTrackCue} from './track/cue-point';
+import {CuePoint, createTextTrackCue, createCuePoint} from './track/cue-point';
 import TextStyle from './track/text-style';
 import {Cue} from './track/vtt-cue';
 import Env from './utils/env';
@@ -64,7 +64,7 @@ export {BaseMiddleware};
 export {Track, VideoTrack, AudioTrack, TextTrack, ImageTrack, TextStyle, Cue};
 
 // Export the cue point class and function
-export {CuePoint, createTextTrackCue};
+export {CuePoint, createTextTrackCue, createCuePoint};
 
 // Export utils library
 export {Utils};

--- a/src/playkit.js
+++ b/src/playkit.js
@@ -11,7 +11,7 @@ import ImageTrack from './track/image-track';
 import VideoTrack from './track/video-track';
 import AudioTrack from './track/audio-track';
 import TextTrack from './track/text-track';
-import {CuePoint, createTextTrackCue, createCuePoint} from './track/cue-point';
+import {TimedMetadata, createTextTrackCue, createTimedMetadata} from './track/timed-metadata';
 import TextStyle from './track/text-style';
 import {Cue} from './track/vtt-cue';
 import Env from './utils/env';
@@ -63,8 +63,8 @@ export {BaseMiddleware};
 // Export the tracks classes
 export {Track, VideoTrack, AudioTrack, TextTrack, ImageTrack, TextStyle, Cue};
 
-// Export the cue point class and function
-export {CuePoint, createTextTrackCue, createCuePoint};
+// Export the timed metadata class and function
+export {TimedMetadata, createTextTrackCue, createTimedMetadata};
 
 // Export utils library
 export {Utils};

--- a/src/track/cue-point.js
+++ b/src/track/cue-point.js
@@ -13,9 +13,9 @@ class CuePoint {
    * @param {number} endTime - end time.
    * @param {string} id - id.
    * @param {string} type - type.
-   * @param {string|Object} metadata - metadata.
+   * @param {any} metadata - metadata.
    */
-  constructor(startTime: number, endTime: number, id: string, type: string, metadata: string | Object) {
+  constructor(startTime: number, endTime: number, id: string, type: string, metadata: any) {
     this.startTime = startTime;
     this.endTime = endTime;
     this.id = id;
@@ -25,6 +25,7 @@ class CuePoint {
 }
 
 CuePoint.TYPE = {
+  ID3: 'id3',
   EMSG: 'emsg',
   CUSTOM: 'custom'
 };
@@ -50,4 +51,36 @@ function createTextTrackCue(cuePoint: CuePoint): TextTrackCue {
   return cue;
 }
 
-export {CuePoint, createTextTrackCue};
+/**
+ * Create a cue point from a standard TextTrackCue.
+ * @param {TextTrackCue} cue - text track cue.
+ * @returns {?CuePoint} - the created cue point.
+ * @private
+ */
+function createCuePoint(cue: TextTrackCue): ?CuePoint {
+  if (cue) {
+    const {startTime, endTime, id, value} = cue;
+    return new CuePoint(startTime, endTime, id, _getType(cue), value);
+  }
+  return null;
+}
+
+/**
+ * @param {TextTrackCue} cue - cue
+ * @return {string} - type
+ * @private
+ */
+function _getType(cue: TextTrackCue): string {
+  const {
+    type,
+    track: {label},
+    value: {key}
+  } = cue;
+  let cuePointType = Object.values(CuePoint.TYPE).find(type => type === key);
+  if (!cuePointType) {
+    cuePointType = type === 'org.id3' || label === 'id3' ? CuePoint.TYPE.ID3 : CuePoint.TYPE.CUSTOM;
+  }
+  return cuePointType;
+}
+
+export {CuePoint, createTextTrackCue, createCuePoint};

--- a/src/track/cue-point.js
+++ b/src/track/cue-point.js
@@ -27,6 +27,7 @@ class CuePoint {
 CuePoint.TYPE = {
   ID3: 'id3',
   EMSG: 'emsg',
+  CUE_POINT: 'cuepoint',
   CUSTOM: 'custom'
 };
 
@@ -59,8 +60,13 @@ function createTextTrackCue(cuePoint: CuePoint): TextTrackCue {
  */
 function createCuePoint(cue: TextTrackCue): ?CuePoint {
   if (cue) {
-    const {startTime, endTime, id, value} = cue;
-    return new CuePoint(startTime, endTime, id, _getType(cue), value);
+    const {
+      startTime,
+      endTime,
+      id,
+      value: {data}
+    } = cue;
+    return new CuePoint(startTime, endTime, id, _getType(cue), data);
   }
   return null;
 }
@@ -80,6 +86,7 @@ function _getType(cue: TextTrackCue): string {
   if (!cuePointType) {
     cuePointType = type === 'org.id3' || label === 'id3' ? CuePoint.TYPE.ID3 : CuePoint.TYPE.CUSTOM;
   }
+  //$FlowFixMe
   return cuePointType;
 }
 

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -99,7 +99,7 @@ function getActiveCues(textTrackCueList: TextTrackCueList): Array<Cue> {
   let normalizedCues: Array<Cue> = [];
   for (let cue of textTrackCueList) {
     //Normalize cues to be of type of VTT model
-    if (window.VTTCue && cue instanceof window.VTTCue) {
+    if ((window.VTTCue && cue instanceof window.VTTCue) || (window.DataCue && cue instanceof window.DataCue)) {
       normalizedCues.push(cue);
     } else if (window.TextTrackCue && cue instanceof window.TextTrackCue) {
       try {

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -95,7 +95,7 @@ TextTrack.isExternalTrack = (track: any) => {
  * @returns {void}
  * @private
  */
-function getActiveCues(textTrackCueList: TextTrackCueList) {
+function getActiveCues(textTrackCueList: TextTrackCueList): Array<Cue> {
   let normalizedCues: Array<Cue> = [];
   for (let cue of textTrackCueList) {
     //Normalize cues to be of type of VTT model

--- a/src/utils/binary-search.js
+++ b/src/utils/binary-search.js
@@ -1,0 +1,26 @@
+//@flow
+/**
+ * @param {Array<any>} list The array to search.
+ * @param {Function} comparisonFn
+ *      Called and provided a candidate item as the first argument.
+ *      Should return:
+ *          > -1 if the item should be located at a lower index than the provided item.
+ *          > 1 if the item should be located at a higher index than the provided item.
+ *          > 0 if the item is the item you're looking for.
+ *
+ * @return {any} The object if it is found or null otherwise.
+ */
+export function binarySearch(list: Array<any> = [], comparisonFn: Function = () => 1): any {
+  if (list.length === 0 || (list.length === 1 && comparisonFn(list[0]) !== 0)) {
+    return null;
+  }
+  const mid = Math.floor(list.length / 2);
+  if (comparisonFn(list[mid]) === 0) {
+    return list[mid];
+  }
+  if (comparisonFn(list[mid]) > 0) {
+    return binarySearch(list.slice(0, mid), comparisonFn);
+  } else {
+    return binarySearch(list.slice(mid + 1), comparisonFn);
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
 export * from './util';
 export {ResizeWatcher} from './resize-watcher';
 export {MultiMap} from './multi-map';
+export {binarySearch} from './binary-search';

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -8,7 +8,7 @@ import Track from '../../src/track/track';
 import VideoTrack from '../../src/track/video-track';
 import AudioTrack from '../../src/track/audio-track';
 import TextTrack from '../../src/track/text-track';
-import {createTextTrackCue, CuePoint} from '../../src/track/cue-point';
+import {createTextTrackCue, TimedMetadata} from '../../src/track/timed-metadata';
 import {createElement, getConfigStructure, removeElement, removeVideoElementsFromTestPage} from './utils/test-utils';
 import Locale from '../../src/utils/locale';
 import Html5 from '../../src/engines/html5/html5';
@@ -2379,10 +2379,10 @@ describe('Player', function () {
           const metadataTrack2 = player.getVideoElement().addTextTrack(TextTrack.KIND.METADATA, 'metadata2');
 
           const {currentTime, duration} = player;
-          const cuePoint1 = new CuePoint(currentTime + 1, duration - 2, 'id1', 'type1', {info: 'some_info1'});
-          const cuePoint2 = new CuePoint(currentTime + 2, duration - 1, 'id2', 'type2', {info: 'some_info2'});
-          const textTrackCue1 = createTextTrackCue(cuePoint1);
-          const textTrackCue2 = createTextTrackCue(cuePoint2);
+          const timedMetadata1 = new TimedMetadata(currentTime + 1, duration - 2, 'id1', 'type1', {info: 'some_info1'});
+          const timedMetadata2 = new TimedMetadata(currentTime + 2, duration - 1, 'id2', 'type2', {info: 'some_info2'});
+          const textTrackCue1 = createTextTrackCue(timedMetadata1);
+          const textTrackCue2 = createTextTrackCue(timedMetadata2);
           metadataTrack1.addCue(textTrackCue1);
           metadataTrack2.addCue(textTrackCue2);
           let eventCounter = -1;
@@ -2420,16 +2420,16 @@ describe('Player', function () {
               switch (eventCounter) {
                 case 1:
                   e.payload.cues.length.should.equal(1);
-                  e.payload.cues[0].should.deep.equal({...cuePoint1, type: 'custom'});
+                  e.payload.cues[0].should.deep.equal({...timedMetadata1, type: 'custom'});
                   break;
                 case 3:
                   e.payload.cues.length.should.equal(2);
-                  e.payload.cues[0].should.deep.equal({...cuePoint1, type: 'custom'});
-                  e.payload.cues[1].should.deep.equal({...cuePoint2, type: 'custom'});
+                  e.payload.cues[0].should.deep.equal({...timedMetadata1, type: 'custom'});
+                  e.payload.cues[1].should.deep.equal({...timedMetadata2, type: 'custom'});
                   break;
                 case 5:
                   e.payload.cues.length.should.equal(1);
-                  e.payload.cues[0].should.deep.equal({...cuePoint2, type: 'custom'});
+                  e.payload.cues[0].should.deep.equal({...timedMetadata2, type: 'custom'});
                   break;
                 case 7:
                   e.payload.cues.length.should.equal(0);

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -8,6 +8,7 @@ import Track from '../../src/track/track';
 import VideoTrack from '../../src/track/video-track';
 import AudioTrack from '../../src/track/audio-track';
 import TextTrack from '../../src/track/text-track';
+import {createTextTrackCue, CuePoint} from '../../src/track/cue-point';
 import {createElement, getConfigStructure, removeElement, removeVideoElementsFromTestPage} from './utils/test-utils';
 import Locale from '../../src/utils/locale';
 import Html5 from '../../src/engines/html5/html5';
@@ -2346,6 +2347,105 @@ describe('Player', function () {
           done();
         });
         player.textStyle = new TextStyle();
+      });
+    });
+
+    describe('timed metadata and timed metadata change', () => {
+      let config;
+      let player;
+      let playerContainer;
+
+      before(() => {
+        playerContainer = createElement('DIV', targetId);
+      });
+
+      beforeEach(() => {
+        config = getConfigStructure();
+      });
+
+      afterEach(() => {
+        player.destroy();
+      });
+
+      after(() => {
+        removeVideoElementsFromTestPage();
+        removeElement(targetId);
+      });
+
+      it('should dispatch timed metadata and timed metadata change on time', done => {
+        let onPlaying = () => {
+          player.removeEventListener(player.Event.PLAYING, onPlaying);
+          const metadataTrack1 = player.getVideoElement().addTextTrack(TextTrack.KIND.METADATA, 'metadata1');
+          const metadataTrack2 = player.getVideoElement().addTextTrack(TextTrack.KIND.METADATA, 'metadata2');
+
+          const {currentTime, duration} = player;
+          const cuePoint1 = new CuePoint(currentTime + 1, duration - 2, 'id1', 'type1', {info: 'some_info1'});
+          const cuePoint2 = new CuePoint(currentTime + 2, duration - 1, 'id2', 'type2', {info: 'some_info2'});
+          const textTrackCue1 = createTextTrackCue(cuePoint1);
+          const textTrackCue2 = createTextTrackCue(cuePoint2);
+          metadataTrack1.addCue(textTrackCue1);
+          metadataTrack2.addCue(textTrackCue2);
+          let eventCounter = -1;
+          player.addEventListener(player.Event.TIMED_METADATA, e => {
+            try {
+              eventCounter++;
+              switch (eventCounter) {
+                case 0:
+                  e.payload.cues.length.should.equal(1);
+                  e.payload.cues[0].value.key.should.equal('type1');
+                  e.payload.cues[0].value.data.should.deep.equal({info: 'some_info1'});
+                  break;
+                case 2:
+                  e.payload.cues.length.should.equal(2);
+                  e.payload.cues[0].value.key.should.equal('type1');
+                  e.payload.cues[0].value.data.should.deep.equal({info: 'some_info1'});
+                  e.payload.cues[1].value.key.should.equal('type2');
+                  e.payload.cues[1].value.data.should.deep.equal({info: 'some_info2'});
+                  break;
+                case 4:
+                  e.payload.cues.length.should.equal(1);
+                  e.payload.cues[0].value.key.should.equal('type2');
+                  e.payload.cues[0].value.data.should.deep.equal({info: 'some_info2'});
+                  break;
+                case 6:
+                  e.payload.cues.length.should.equal(0);
+              }
+            } catch (e) {
+              done(e);
+            }
+          });
+          player.addEventListener(player.Event.TIMED_METADATA_CHANGE, e => {
+            try {
+              eventCounter++;
+              switch (eventCounter) {
+                case 1:
+                  e.payload.cues.length.should.equal(1);
+                  e.payload.cues[0].should.deep.equal({...cuePoint1, type: 'custom'});
+                  break;
+                case 3:
+                  e.payload.cues.length.should.equal(2);
+                  e.payload.cues[0].should.deep.equal({...cuePoint1, type: 'custom'});
+                  e.payload.cues[1].should.deep.equal({...cuePoint2, type: 'custom'});
+                  break;
+                case 5:
+                  e.payload.cues.length.should.equal(1);
+                  e.payload.cues[0].should.deep.equal({...cuePoint2, type: 'custom'});
+                  break;
+                case 7:
+                  e.payload.cues.length.should.equal(0);
+                  done();
+              }
+            } catch (e) {
+              done(e);
+            }
+          });
+        };
+
+        player = new Player(config);
+        player.setSources(sourcesConfig.Mp4);
+        playerContainer.appendChild(player.getView());
+        player.addEventListener(player.Event.PLAYING, onPlaying);
+        player.play();
       });
     });
   });

--- a/test/src/utils/binary-search.spec.js
+++ b/test/src/utils/binary-search.spec.js
@@ -1,0 +1,19 @@
+import {binarySearch} from '../../../src/utils';
+
+describe('binarySearch', () => {
+  it('should find primitives', () => {
+    binarySearch([1, 2, 3, 4, 7, 8, 9, 10], int => int - 7).should.equal(7);
+    binarySearch([1, 2, 3, 4, 7, 8, 9, 10], int => int - 2).should.equal(2);
+    binarySearch([0, 1, 2, 3, 4, 7, 8, 9, 10], int => int - 0).should.equal(0);
+    binarySearch([-1, 2, 3, 4, 7, 8, 9, 10], int => int + 1).should.equal(-1);
+    (binarySearch([-1, 2, 3, 4, 7, 8, 9, 10], int => int - 11) === null).should.be.true;
+  });
+  it('should find object', () => {
+    binarySearch([{num: 0}, {num: 10}, {num: 100}, {num: 1000}], obj => obj.num - 1000).should.deep.equal({num: 1000});
+    (binarySearch([{num: 0}, {num: 10}, {num: 100}, {num: 1000}], obj => obj.num - 2000) === null).should.be.true;
+  });
+  it('should has default', () => {
+    (binarySearch(undefined, int => int - 1) === null).should.be.true;
+    (binarySearch([-1, 2, 3, 4, 7, 8, 9, 10]) === null).should.be.true;
+  });
+});


### PR DESCRIPTION
### Description of the Changes

* new type `TimedMetadata` instead of `CuePoint`
* new `TIMED_METADATA_CHANGE` event which triggered when with `TIMED_METADATA` but with payload of `TimedMetadata` array instead of `VttCue` array
* remove `track.label` and merge all metadata tracks cues instead (reverts https://github.com/kaltura/playkit-js/pull/609, closes https://github.com/kaltura/playkit-js/pull/610)
* new function `createTimedMetadata` to create a `TimedMetadata` based on `VttCue`
* new helper function `binarySearch` (for https://github.com/kaltura/playkit-js-hls/pull/157)

Solves FEC-11761
Related to - 
https://github.com/kaltura/playkit-js-hls/pull/157 
https://github.com/kaltura/playkit-js-dash/pull/174
https://github.com/kaltura/kaltura-player-js/pull/512
https://github.com/kaltura/playkit-js-dual-screen/pull/52
https://github.com/kaltura/playkit-js-kaltura-cuepoints/pull/15


### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [x] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [x] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
