### PR TITLE
fix(FEC-11697): 2 captions are selected in the menu

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -976,15 +976,15 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   _onNativeTextTrackChange(): void {
     const pkTextTracks = this._getPKTextTracks();
     const pkOffTrack = pkTextTracks.find(track => track.language === 'off');
-    const getActiveVidTextTrackIndex = () => {
+    const getActiveVidTextTrackIndex = (): number => {
       for (const textTrackId in this._nativeTextTracksMap) {
         if (this._getDisplayTextTrackModeString() === this._nativeTextTracksMap[textTrackId].mode) {
-          return textTrackId;
+          return Number(textTrackId);
         }
       }
       return -1;
     };
-    const vidIndex = getActiveVidTextTrackIndex();
+    const vidIndex: number = getActiveVidTextTrackIndex();
     const activePKtextTrack = this._getActivePKTextTrack();
     const pkIndex = activePKtextTrack ? activePKtextTrack.index : -1;
     if (vidIndex !== pkIndex) {

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -721,7 +721,6 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const captionsTextTrackLanguageCodes = [this._config.captionsTextTrack1LanguageCode, this._config.captionsTextTrack2LanguageCode];
     const textTracks = this._videoElement.textTracks;
     const parsedTracks = [];
-    let internalTrackIndex = 0;
     if (textTracks) {
       for (let i = 0; i < textTracks.length; i++) {
         if (!PKTextTrack.isExternalTrack(textTracks[i])) {
@@ -730,18 +729,19 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
             active: textTracks[i].mode === PKTextTrack.MODE.SHOWING,
             label: textTracks[i].label,
             language: textTracks[i].language,
-            available: true,
-            index: internalTrackIndex++
+            available: true
           };
           if (settings.kind === PKTextTrack.KIND.SUBTITLES) {
-            parsedTracks.push(new PKTextTrack(settings));
-            this._nativeTextTracksMap[settings.index] = textTracks[i];
+            const newTrack: PKTextTrack = new PKTextTrack(settings);
+            parsedTracks.push(newTrack);
+            this._nativeTextTracksMap[newTrack.index] = textTracks[i];
           } else if (settings.kind === PKTextTrack.KIND.CAPTIONS && this._config.enableCEA708Captions) {
             settings.label = settings.label || captionsTextTrackLabels.shift();
             settings.language = settings.language || captionsTextTrackLanguageCodes.shift();
             settings.available = this._captionsHidden;
-            parsedTracks.push(new PKTextTrack(settings));
-            this._nativeTextTracksMap[settings.index] = textTracks[i];
+            const newTrack: PKTextTrack = new PKTextTrack(settings);
+            parsedTracks.push(newTrack);
+            this._nativeTextTracksMap[newTrack.index] = textTracks[i];
           }
         }
       }

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -149,7 +149,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @type {number}
    * @private
    */
-  _nativeTextTracksMap = [];
+  _nativeTextTracksMap = {};
   /**
    *
    * @type {number}
@@ -589,7 +589,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           this._waitingEventTriggered = false;
           this._progressiveSources = [];
           this._loadPromise = null;
-          this._nativeTextTracksMap = [];
+          this._nativeTextTracksMap = {};
           this._loadPromiseReject = null;
           this._liveEdge = 0;
           this._lastTimeUpdate = 0;
@@ -977,7 +977,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const pkTextTracks = this._getPKTextTracks();
     const pkOffTrack = pkTextTracks.find(track => track.language === 'off');
     const getActiveVidTextTrackIndex = () => {
-      return this._nativeTextTracksMap.findIndex(textTrack => textTrack && this._getDisplayTextTrackModeString() === textTrack.mode);
+      return Object.values(this._nativeTextTracksMap).findIndex(textTrack => textTrack && this._getDisplayTextTrackModeString() === textTrack.mode);
     };
     const vidIndex = getActiveVidTextTrackIndex();
     const activePKtextTrack = this._getActivePKTextTrack();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -977,10 +977,12 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const pkTextTracks = this._getPKTextTracks();
     const pkOffTrack = pkTextTracks.find(track => track.language === 'off');
     const getActiveVidTextTrackIndex = () => {
-      const activeTrack: TextTrack = Object.entries(this._nativeTextTracksMap).find(
-        ([, textTrack]) => this._getDisplayTextTrackModeString() === textTrack.mode
-      );
-      return activeTrack ? activeTrack.index : -1;
+      for (const textTrackId in this._nativeTextTracksMap) {
+        if (this._getDisplayTextTrackModeString() === this._nativeTextTracksMap[textTrackId].mode) {
+          return textTrackId;
+        }
+      }
+      return -1;
     };
     const vidIndex = getActiveVidTextTrackIndex();
     const activePKtextTrack = this._getActivePKTextTrack();

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -977,7 +977,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     const pkTextTracks = this._getPKTextTracks();
     const pkOffTrack = pkTextTracks.find(track => track.language === 'off');
     const getActiveVidTextTrackIndex = () => {
-      return Object.values(this._nativeTextTracksMap).findIndex(textTrack => textTrack && this._getDisplayTextTrackModeString() === textTrack.mode);
+      const activeTrack: TextTrack = Object.entries(this._nativeTextTracksMap).find(
+        ([, textTrack]) => this._getDisplayTextTrackModeString() === textTrack.mode
+      );
+      return activeTrack ? activeTrack.index : -1;
     };
     const vidIndex = getActiveVidTextTrackIndex();
     const activePKtextTrack = this._getActivePKTextTrack();

--- a/src/player.js
+++ b/src/player.js
@@ -2527,7 +2527,6 @@ export default class Player extends FakeEventTarget {
       this._tracks.push(
         new TextTrack({
           active: false,
-          index: textTracks.length,
           kind: TextTrack.KIND.SUBTITLES,
           label: 'Off',
           language: OFF

--- a/src/player.js
+++ b/src/player.js
@@ -657,6 +657,7 @@ export default class Player extends FakeEventTarget {
     this._activeTextCues = [];
     this._updateTextDisplay([]);
     this._tracks = [];
+    TextTrack.resetTracksCount();
     this._resetStateFlags();
     this._engineType = '';
     this._streamType = '';

--- a/src/player.js
+++ b/src/player.js
@@ -657,7 +657,7 @@ export default class Player extends FakeEventTarget {
     this._activeTextCues = [];
     this._updateTextDisplay([]);
     this._tracks = [];
-    TextTrack.resetTracksCount();
+    TextTrack.reset();
     this._resetStateFlags();
     this._engineType = '';
     this._streamType = '';

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -124,14 +124,13 @@ class ExternalCaptionsHandler extends FakeEventTarget {
       this._addNativeTextTrack();
     }
     const playerTextTracks = tracks.filter(track => track instanceof TextTrack);
-    let textTracksLength = playerTextTracks.length || 0;
     const newTextTracks = [];
     captions.forEach(caption => {
       if (!caption.language) {
         const error = new Error(Error.Severity.RECOVERABLE, Error.Category.TEXT, Error.Code.UNKNOWN_LANGUAGE, {caption: caption});
         this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
       } else {
-        const track = this._createTextTrack(caption, textTracksLength++);
+        const track = this._createTextTrack(caption);
         this._maybeAddTrack(track, caption, playerTextTracks, newTextTracks);
       }
     });
@@ -160,14 +159,12 @@ class ExternalCaptionsHandler extends FakeEventTarget {
   /**
    * creates a new text track
    * @param {PKExternalCaptionObject} caption - caption to create the text track with
-   * @param {number} index - index of the text track
    * @returns {TextTrack} - new text track
    * @private
    */
-  _createTextTrack(caption: PKExternalCaptionObject, index: number): TextTrack {
+  _createTextTrack(caption: PKExternalCaptionObject): TextTrack {
     return new TextTrack({
       active: !!caption.default,
-      index: index,
       kind: TextTrack.KIND.SUBTITLES,
       label: caption.label,
       language: caption.language,

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -28,7 +28,7 @@ const TextTrack: TextTrack = class TextTrack extends Track {
    * @returns {number} - the next track index.
    */
   static _generateIndex(): number {
-    return Track._tracksCount++;
+    return TextTrack._tracksCount++;
   }
 
   /**

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -57,6 +57,15 @@ const TextTrack: TextTrack = class TextTrack extends Track {
   }
 
   /**
+   * Setter for the kind of the text track.
+   * @public
+   * @param {string} value - The kind of text the track.
+   */
+  set kind(value: string) {
+    this._kind = value;
+  }
+
+  /**
    * Getter for the external of the text track.
    * @public
    * @returns {boolean} - The kind of the text track.

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -64,15 +64,6 @@ const TextTrack: TextTrack = class TextTrack extends Track {
   }
 
   /**
-   * Setter for the kind of the text track.
-   * @public
-   * @param {string} value - The kind of text the track.
-   */
-  set kind(value: string) {
-    this._kind = value;
-  }
-
-  /**
    * Getter for the external of the text track.
    * @public
    * @returns {boolean} - The kind of the text track.

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -34,7 +34,7 @@ const TextTrack: TextTrack = class TextTrack extends Track {
    * reset the track count.
    * @returns {void}
    */
-  static resetTracksCount(): void {
+  static reset(): void {
     TextTrack._tracksCount = 0;
   }
 
@@ -92,7 +92,6 @@ const TextTrack: TextTrack = class TextTrack extends Track {
     this._kind = settings.kind;
     this._external = settings.external;
     this._index = TextTrack._generateIndex();
-    console.error('121212', this);
   }
 };
 

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -17,6 +17,21 @@ const TextTrack: TextTrack = class TextTrack extends Track {
   isExternalTrack: Function;
 
   /**
+   * use as a uniq identifier of the track.
+   * @static
+   * @type {number}
+   * @private
+   */
+  static _tracksCount: number = 0;
+  /**
+   * index generator.
+   * @returns {number} - the next track index.
+   */
+  static _generateIndex(): number {
+    return Track._tracksCount++;
+  }
+
+  /**
    * The kind of the text track:
    * subtitles/captions/metadata.
    * @member
@@ -60,6 +75,7 @@ const TextTrack: TextTrack = class TextTrack extends Track {
     this._label = this.label || this.language;
     this._kind = settings.kind;
     this._external = settings.external;
+    this._index = TextTrack._generateIndex();
   }
 };
 

--- a/src/track/text-track.js
+++ b/src/track/text-track.js
@@ -30,6 +30,13 @@ const TextTrack: TextTrack = class TextTrack extends Track {
   static _generateIndex(): number {
     return TextTrack._tracksCount++;
   }
+  /**
+   * reset the track count.
+   * @returns {void}
+   */
+  static resetTracksCount(): void {
+    TextTrack._tracksCount = 0;
+  }
 
   /**
    * The kind of the text track:
@@ -85,6 +92,7 @@ const TextTrack: TextTrack = class TextTrack extends Track {
     this._kind = settings.kind;
     this._external = settings.external;
     this._index = TextTrack._generateIndex();
+    console.error('121212', this);
   }
 };
 

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -640,7 +640,7 @@ describe('NativeAdapter: selectTextTrack', function () {
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(new TextTrack({language: 'fr', kind: 'subtitles'}));
+        nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('hidden');
@@ -662,7 +662,7 @@ describe('NativeAdapter: selectTextTrack', function () {
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(new TextTrack({language: 'fr', kind: 'captions'}));
+        nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('hidden');
@@ -680,7 +680,7 @@ describe('NativeAdapter: selectTextTrack', function () {
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-          nativeInstance.selectTextTrack(new TextTrack({language: 'en', kind: 'subtitles'}));
+          nativeInstance.selectTextTrack(nativeInstance._playerTracks[0]);
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('hidden');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
@@ -700,7 +700,7 @@ describe('NativeAdapter: selectTextTrack', function () {
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-          nativeInstance.selectTextTrack(new TextTrack({kind: 'subtitles'}));
+          nativeInstance.selectTextTrack(new TextTrack({index: 3, kind: 'subtitles'}));
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
@@ -718,7 +718,7 @@ describe('NativeAdapter: selectTextTrack', function () {
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(new TextTrack({kind: 'subtitles'}));
+        nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -700,7 +700,7 @@ describe('NativeAdapter: selectTextTrack', function () {
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-          nativeInstance.selectTextTrack(new TextTrack({index: 3, kind: 'subtitles'}));
+          nativeInstance.selectTextTrack(new TextTrack({kind: 'subtitles'}));
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
@@ -713,18 +713,23 @@ describe('NativeAdapter: selectTextTrack', function () {
   });
 
   it('should not change the selected for metadata text track', done => {
-    nativeInstance.load().then(() => {
-      if (nativeInstance._videoElement.textTracks) {
-        nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
-        nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
-        nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
-        nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
-        nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
-        nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-      }
-      done();
-    });
+    nativeInstance
+      .load()
+      .then(() => {
+        if (nativeInstance._videoElement.textTracks) {
+          nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
+          nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
+          nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
+          nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
+          nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
+          nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
+          nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
+        }
+        done();
+      })
+      .catch(e => {
+        done(e);
+      });
   });
 });
 

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -634,20 +634,25 @@ describe('NativeAdapter: selectTextTrack', function () {
       event.payload.selectedTextTrack.language.should.equal('fr');
       done();
     };
-    nativeInstance.load().then(() => {
-      if (nativeInstance._videoElement.textTracks) {
-        nativeInstance.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, onTextTrackChanged);
-        nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
-        nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
-        nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
-        nativeInstance._videoElement.textTracks[0].mode.should.be.equal('disabled');
-        nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
-        nativeInstance._videoElement.textTracks[2].mode.should.be.equal('hidden');
-      } else {
+    nativeInstance
+      .load()
+      .then(() => {
+        if (nativeInstance._videoElement.textTracks) {
+          nativeInstance.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, onTextTrackChanged);
+          nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
+          nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
+          nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
+          nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
+          nativeInstance._videoElement.textTracks[0].mode.should.be.equal('disabled');
+          nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
+          nativeInstance._videoElement.textTracks[2].mode.should.be.equal('hidden');
+        } else {
+          done();
+        }
+      })
+      .catch(() => {
         done();
-      }
-    });
+      });
   });
 
   it('should select a new captions track', done => {
@@ -656,20 +661,25 @@ describe('NativeAdapter: selectTextTrack', function () {
       event.payload.selectedTextTrack.language.should.equal('fr');
       done();
     };
-    nativeInstance.load().then(() => {
-      if (nativeInstance._videoElement.textTracks) {
-        nativeInstance.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, onTextTrackChanged);
-        nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
-        nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
-        nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
-        nativeInstance._videoElement.textTracks[0].mode.should.be.equal('disabled');
-        nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
-        nativeInstance._videoElement.textTracks[2].mode.should.be.equal('hidden');
-      } else {
+    nativeInstance
+      .load()
+      .then(() => {
+        if (nativeInstance._videoElement.textTracks) {
+          nativeInstance.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, onTextTrackChanged);
+          nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
+          nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
+          nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
+          nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
+          nativeInstance._videoElement.textTracks[0].mode.should.be.equal('disabled');
+          nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
+          nativeInstance._videoElement.textTracks[2].mode.should.be.equal('hidden');
+        } else {
+          done();
+        }
+      })
+      .catch(() => {
         done();
-      }
-    });
+      });
   });
 
   it('should not change the selected text track', done => {
@@ -720,7 +730,7 @@ describe('NativeAdapter: selectTextTrack', function () {
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-          nativeInstance.selectTextTrack(nativeInstance._playerTracks[1]);
+          nativeInstance.selectTextTrack(new TextTrack({kind: 'subtitles'}));
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');

--- a/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
+++ b/test/src/engines/html5/media-source/adapters/native-adapter.spec.js
@@ -640,7 +640,7 @@ describe('NativeAdapter: selectTextTrack', function () {
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(new TextTrack({index: 2, language: 'fr', kind: 'subtitles'}));
+        nativeInstance.selectTextTrack(new TextTrack({language: 'fr', kind: 'subtitles'}));
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('hidden');
@@ -662,7 +662,7 @@ describe('NativeAdapter: selectTextTrack', function () {
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(new TextTrack({index: 2, language: 'fr', kind: 'captions'}));
+        nativeInstance.selectTextTrack(new TextTrack({language: 'fr', kind: 'captions'}));
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('hidden');
@@ -680,7 +680,7 @@ describe('NativeAdapter: selectTextTrack', function () {
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-          nativeInstance.selectTextTrack(new TextTrack({index: 0, language: 'en', kind: 'subtitles'}));
+          nativeInstance.selectTextTrack(new TextTrack({language: 'en', kind: 'subtitles'}));
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('hidden');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
@@ -700,7 +700,7 @@ describe('NativeAdapter: selectTextTrack', function () {
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-          nativeInstance.selectTextTrack(new TextTrack({index: 3, kind: 'subtitles'}));
+          nativeInstance.selectTextTrack(new TextTrack({kind: 'subtitles'}));
           nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
           nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
           nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
@@ -718,7 +718,7 @@ describe('NativeAdapter: selectTextTrack', function () {
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');
-        nativeInstance.selectTextTrack(new TextTrack({index: 1, kind: 'subtitles'}));
+        nativeInstance.selectTextTrack(new TextTrack({kind: 'subtitles'}));
         nativeInstance._videoElement.textTracks[0].mode.should.be.equal('showing');
         nativeInstance._videoElement.textTracks[1].mode.should.be.equal('disabled');
         nativeInstance._videoElement.textTracks[2].mode.should.be.equal('disabled');

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1142,7 +1142,8 @@ describe('Player', function () {
           tracks[0].active.should.be.true;
           tracks[1].active.should.be.false;
           const track = player._tracks.find(track => track.language === 'fr');
-          player.selectTrack({...track, kind: 'subtitles'});
+          track.kind = 'subtitles';
+          player.selectTrack(track);
         })
         .catch(e => {
           done(e);
@@ -1172,7 +1173,8 @@ describe('Player', function () {
           tracks[0].active.should.be.true;
           tracks[1].active.should.be.false;
           const track = player._tracks.find(track => track.language === 'fr');
-          player.selectTrack({...track, kind: 'captions'});
+          track.kind = 'captions';
+          player.selectTrack(track);
         })
         .catch(e => {
           done(e);

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1152,13 +1152,13 @@ describe('Player', function () {
     });
 
     it('should select a new captions track', done => {
-      player.load();
       player
         .ready()
         .then(() => {
+          let selectedTrackIndex;
           player.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, event => {
             (event.payload.selectedTextTrack instanceof TextTrack).should.be.true;
-            event.payload.selectedTextTrack.index.should.equal(1);
+            event.payload.selectedTextTrack.index.should.equal(selectedTrackIndex);
             video.textTracks[0].mode.should.be.equal('disabled');
             video.textTracks[1].mode.should.be.equal('hidden');
             tracks[0].active.should.be.false;
@@ -1174,11 +1174,13 @@ describe('Player', function () {
           tracks[1].active.should.be.false;
           const track = player._tracks.find(track => track.language === 'fr');
           track.kind = 'captions';
+          selectedTrackIndex = track.index;
           player.selectTrack(track);
         })
         .catch(e => {
           done(e);
         });
+      player.load();
     });
 
     it('should not change the selected text track', done => {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1226,7 +1226,6 @@ describe('Player', function () {
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
         tracks[1].active.should.be.false;
-        // player.selectTrack(new TextTrack({index: 1, kind: 'metadata'}));
         player.selectTrack(new TextTrack({...player._tracks.find(track => track.language === 'fr'), kind: 'metadata'}));
         video.textTracks[0].mode.should.be.equal('hidden');
         video.textTracks[1].mode.should.be.equal('disabled');

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -19,6 +19,7 @@ import {EngineProvider} from '../../src/engines/engine-provider';
 import FakeEvent from '../../src/event/fake-event';
 import Html5AutoPlayCapability from '../../src/engines/html5/capabilities/html5-autoplay';
 import * as Utils from '../../src/utils/util';
+import {TrackType} from '../../src/track/track-type';
 
 const targetId = 'player-placeholder_player.spec';
 let sourcesConfig = PKObject.copyDeep(SourcesConfig);
@@ -1141,7 +1142,7 @@ describe('Player', function () {
           video.textTracks[1].mode.should.be.equal('disabled');
           tracks[0].active.should.be.true;
           tracks[1].active.should.be.false;
-          const track = player._tracks.find(track => track.language === 'fr');
+          const track = player.getTracks(TrackType.TEXT).find(track => track.language === 'fr');
           track.kind = 'subtitles';
           player.selectTrack(track);
         })
@@ -1172,7 +1173,7 @@ describe('Player', function () {
           video.textTracks[1].mode.should.be.equal('disabled');
           tracks[0].active.should.be.true;
           tracks[1].active.should.be.false;
-          const track = player._tracks.find(track => track.language === 'fr');
+          const track = player.getTracks(TrackType.TEXT).find(track => track.language === 'fr');
           track.kind = 'captions';
           selectedTrackIndex = track.index;
           player.selectTrack(track);
@@ -1192,7 +1193,7 @@ describe('Player', function () {
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
         tracks[1].active.should.be.false;
-        player.selectTrack(player._tracks.find(track => track.language === 'en'));
+        player.selectTrack(player.getTracks(TrackType.TEXT).find(track => track.language === 'en'));
         video.textTracks[0].mode.should.be.equal('hidden');
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
@@ -1230,7 +1231,8 @@ describe('Player', function () {
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
         tracks[1].active.should.be.false;
-        player.selectTrack(new TextTrack({...player._tracks.find(track => track.language === 'fr'), kind: 'metadata'}));
+        const track = player.getTracks(TrackType.TEXT).find(track => track.language === 'fr');
+        track.kind = 'metadata';
         video.textTracks[0].mode.should.be.equal('hidden');
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
@@ -1308,7 +1310,7 @@ describe('Player', function () {
         if (audioTracks.length) {
           player.getActiveTracks().audio.should.deep.equals(audioTracks[0]);
         }
-        player.selectTrack(player._tracks.find(track => track.language === 'fr'));
+        player.selectTrack(player.getTracks(TrackType.TEXT).find(track => track.language === 'fr'));
       });
       player.load();
     });

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -1141,7 +1141,8 @@ describe('Player', function () {
           video.textTracks[1].mode.should.be.equal('disabled');
           tracks[0].active.should.be.true;
           tracks[1].active.should.be.false;
-          player.selectTrack(new TextTrack({language: 'fr', kind: 'subtitles', index: 1}));
+          const track = player._tracks.find(track => track.language === 'fr');
+          player.selectTrack({...track, kind: 'subtitles'});
         })
         .catch(e => {
           done(e);
@@ -1151,25 +1152,31 @@ describe('Player', function () {
 
     it('should select a new captions track', done => {
       player.load();
-      player.ready().then(() => {
-        player.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, event => {
-          (event.payload.selectedTextTrack instanceof TextTrack).should.be.true;
-          event.payload.selectedTextTrack.index.should.equal(1);
-          video.textTracks[0].mode.should.be.equal('disabled');
-          video.textTracks[1].mode.should.be.equal('hidden');
-          tracks[0].active.should.be.false;
-          tracks[1].active.should.be.true;
-          done();
+      player
+        .ready()
+        .then(() => {
+          player.addEventListener(CustomEventType.TEXT_TRACK_CHANGED, event => {
+            (event.payload.selectedTextTrack instanceof TextTrack).should.be.true;
+            event.payload.selectedTextTrack.index.should.equal(1);
+            video.textTracks[0].mode.should.be.equal('disabled');
+            video.textTracks[1].mode.should.be.equal('hidden');
+            tracks[0].active.should.be.false;
+            tracks[1].active.should.be.true;
+            done();
+          });
+          let tracks = player._tracks.filter(track => {
+            return track instanceof TextTrack;
+          });
+          video.textTracks[0].mode.should.be.equal('hidden');
+          video.textTracks[1].mode.should.be.equal('disabled');
+          tracks[0].active.should.be.true;
+          tracks[1].active.should.be.false;
+          const track = player._tracks.find(track => track.language === 'fr');
+          player.selectTrack({...track, kind: 'captions'});
+        })
+        .catch(e => {
+          done(e);
         });
-        let tracks = player._tracks.filter(track => {
-          return track instanceof TextTrack;
-        });
-        video.textTracks[0].mode.should.be.equal('hidden');
-        video.textTracks[1].mode.should.be.equal('disabled');
-        tracks[0].active.should.be.true;
-        tracks[1].active.should.be.false;
-        player.selectTrack(new TextTrack({index: 1, kind: 'captions', language: 'fr'}));
-      });
     });
 
     it('should not change the selected text track', done => {
@@ -1181,7 +1188,7 @@ describe('Player', function () {
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
         tracks[1].active.should.be.false;
-        player.selectTrack(new TextTrack({index: 0, kind: 'subtitles'}));
+        player.selectTrack(player._tracks.find(track => track.language === 'en'));
         video.textTracks[0].mode.should.be.equal('hidden');
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
@@ -1201,7 +1208,7 @@ describe('Player', function () {
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
         tracks[1].active.should.be.false;
-        player.selectTrack(new TextTrack({index: 3, kind: 'subtitles'}));
+        player.selectTrack(new TextTrack({language: 'asp'}));
         video.textTracks[0].mode.should.be.equal('hidden');
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
@@ -1219,7 +1226,8 @@ describe('Player', function () {
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
         tracks[1].active.should.be.false;
-        player.selectTrack(new TextTrack({index: 1, kind: 'metadata'}));
+        // player.selectTrack(new TextTrack({index: 1, kind: 'metadata'}));
+        player.selectTrack(new TextTrack({...player._tracks.find(track => track.language === 'fr'), kind: 'metadata'}));
         video.textTracks[0].mode.should.be.equal('hidden');
         video.textTracks[1].mode.should.be.equal('disabled');
         tracks[0].active.should.be.true;
@@ -1297,7 +1305,7 @@ describe('Player', function () {
         if (audioTracks.length) {
           player.getActiveTracks().audio.should.deep.equals(audioTracks[0]);
         }
-        player.selectTrack(new TextTrack({index: 1, kind: 'subtitles'}));
+        player.selectTrack(player._tracks.find(track => track.language === 'fr'));
       });
       player.load();
     });


### PR DESCRIPTION
### Description of the Changes

**issue:** the create _addTextTrackOffOption method of the player creates duplicated indexes every time duplicated languages are detected (and warning created);
**fix:** right now the index property of TextTrack is used as a unique identifier but in the other hand we don't mange it as such (the index is created in different places), so , the index management all moved to one place under the TextTrack class

related pr:

https://github.com/kaltura/playkit-js-dash/pull/182
https://github.com/kaltura/playkit-js-hls/pull/161

solves: FEC-11697  & FEC-11893 & FEC-11973


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
