### PR TITLE
feat(FEC-11964): Allow configuring player to auto-select audio track according to browser locale

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -755,7 +755,7 @@ var config = {
 > >
 > > The player will choose the default captions language using the following logic:
 > >
-> > 1.  **Locale language** - If there are captions in the user's system language then this language will be selected.
+> > 1.  **Locale language** - If there is a text track with the same language as the user's system locale language, this text track will be selected.
 > > 2.  **Manifest default language** - If a default language is specified in the manifest file then this language will be selected.
 > > 3.  **First language in manifest** - The first language specified in the manifest file will be selected.
 > > 4.  If none of the above conditions have taken place, do not display captions.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -719,10 +719,7 @@ var config = {
 > > };
 > > ```
 > >
-> > The player will choose the default audio language using the following logic:
-> >
-> > 1.  **Locale language** - If there is an audio track in the user's system language then this language will be selected.
-> > 2.  **Manifest default language** - If a default language is specified in the manifest file then this language will be selected.
+> > If there is an audio track in the user's system language then this language will be selected.
 >
 > ##
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -691,7 +691,7 @@ var config = {
 >
 > > ### config.playback.audioLanguage
 > >
-> > ##### Type: `string`
+> > ##### Type: `string || "auto"`
 > >
 > > ##### Default: `""`
 > >
@@ -708,6 +708,21 @@ var config = {
 > >   }
 > > };
 > > ```
+> >
+> > If the value `"auto"` is set, i.e:
+> >
+> > ```js
+> > var config = {
+> >   playback: {
+> >     audioLanguage: 'auto'
+> >   }
+> > };
+> > ```
+> >
+> > The player will choose the default audio language using the following logic:
+> >
+> > 1.  **Locale language** - If there is an audio track in the user's system language then this language will be selected.
+> > 2.  **Manifest default language** - If a default language is specified in the manifest file then this language will be selected.
 >
 > ##
 >

--- a/src/player.js
+++ b/src/player.js
@@ -2548,9 +2548,12 @@ export default class Player extends FakeEventTarget {
     const activeTracks = this.getActiveTracks();
     const playbackConfig = this.config.playback;
     const offTextTrack: ?Track = this._getTextTracks().find(track => TextTrack.langComparer(OFF, track.language));
-    let currentOrConfiguredTextLang = this._playbackAttributesState.textLanguage || this._getLanguage(playbackConfig.textLanguage, activeTracks.text);
+    let currentOrConfiguredTextLang =
+      this._playbackAttributesState.textLanguage ||
+      this._getLanguage<TextTrack>(this._getTextTracks(), playbackConfig.textLanguage, activeTracks.text);
     let currentOrConfiguredAudioLang =
-      this._playbackAttributesState.audioLanguage || this._getLanguage(playbackConfig.audioLanguage, activeTracks.audio);
+      this._playbackAttributesState.audioLanguage ||
+      this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
     this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
     this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
     this._setDefaultVideoTrack();
@@ -2558,15 +2561,15 @@ export default class Player extends FakeEventTarget {
 
   /**
    * Gets the track language that should be set by default.
+   * @param {Array<T>} tracks - the audio or text tracks.
    * @param {string} configuredLanguage - The configured language (can be also "auto").
    * @param {?(TextTrack|AudioTrack)} defaultTrack - The default track.
    * @private
    * @returns {string} - The track language to set by default.
    */
-  _getLanguage(configuredLanguage: string, defaultTrack: ?(TextTrack | AudioTrack)): string {
+  _getLanguage<T: TextTrack | AudioTrack>(tracks: Array<T>, configuredLanguage: string, defaultTrack: ?(TextTrack | AudioTrack)): string {
     let language = configuredLanguage;
     if (language === AUTO) {
-      const tracks = defaultTrack instanceof AudioTrack ? this._getAudioTracks() : this._getTextTracks();
       const localeTrack: ?(TextTrack | AudioTrack) = tracks.find(track => Track.langComparer(Locale.language, track.language));
       if (localeTrack) {
         language = localeTrack.language;

--- a/src/player.js
+++ b/src/player.js
@@ -2549,7 +2549,8 @@ export default class Player extends FakeEventTarget {
     const playbackConfig = this.config.playback;
     const offTextTrack: ?Track = this._getTextTracks().find(track => TextTrack.langComparer(OFF, track.language));
     let currentOrConfiguredTextLang = this._playbackAttributesState.textLanguage || this._getLanguage(playbackConfig.textLanguage, activeTracks.text);
-    let currentOrConfiguredAudioLang = this._playbackAttributesState.audioLanguage || playbackConfig.audioLanguage;
+    let currentOrConfiguredAudioLang =
+      this._playbackAttributesState.audioLanguage || this._getLanguage(playbackConfig.audioLanguage, activeTracks.audio);
     this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
     this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
     this._setDefaultVideoTrack();
@@ -2558,15 +2559,15 @@ export default class Player extends FakeEventTarget {
   /**
    * Gets the track language that should be set by default.
    * @param {string} configuredLanguage - The configured language (can be also "auto").
-   * @param {?TextTrack} defaultTrack - The default track.
+   * @param {?(TextTrack|AudioTrack)} defaultTrack - The default track.
    * @private
    * @returns {string} - The track language to set by default.
    */
-  _getLanguage(configuredLanguage: string, defaultTrack: ?TextTrack): string {
+  _getLanguage(configuredLanguage: string, defaultTrack: ?(TextTrack | AudioTrack)): string {
     let language = configuredLanguage;
     if (language === AUTO) {
-      const tracks = this._getTextTracks();
-      const localeTrack: ?TextTrack = tracks.find(track => Track.langComparer(Locale.language, track.language));
+      const tracks = defaultTrack instanceof AudioTrack ? this._getAudioTracks() : this._getTextTracks();
+      const localeTrack: ?(TextTrack | AudioTrack) = tracks.find(track => Track.langComparer(Locale.language, track.language));
       if (localeTrack) {
         language = localeTrack.language;
       } else if (defaultTrack && defaultTrack.language !== OFF) {

--- a/src/player.js
+++ b/src/player.js
@@ -2563,11 +2563,11 @@ export default class Player extends FakeEventTarget {
    * Gets the track language that should be set by default.
    * @param {Array<T>} tracks - the audio or text tracks.
    * @param {string} configuredLanguage - The configured language (can be also "auto").
-   * @param {?(TextTrack|AudioTrack)} defaultTrack - The default track.
+   * @param {?T} defaultTrack - The default track.
    * @private
    * @returns {string} - The track language to set by default.
    */
-  _getLanguage<T: TextTrack | AudioTrack>(tracks: Array<T>, configuredLanguage: string, defaultTrack: ?(TextTrack | AudioTrack)): string {
+  _getLanguage<T: TextTrack | AudioTrack>(tracks: Array<T>, configuredLanguage: string, defaultTrack: ?T): string {
     let language = configuredLanguage;
     if (language === AUTO) {
       const localeTrack: ?(TextTrack | AudioTrack) = tracks.find(track => Track.langComparer(Locale.language, track.language));

--- a/src/player.js
+++ b/src/player.js
@@ -2548,10 +2548,10 @@ export default class Player extends FakeEventTarget {
     const activeTracks = this.getActiveTracks();
     const playbackConfig = this.config.playback;
     const offTextTrack: ?Track = this._getTextTracks().find(track => TextTrack.langComparer(OFF, track.language));
-    let currentOrConfiguredTextLang =
+    const currentOrConfiguredTextLang =
       this._playbackAttributesState.textLanguage ||
       this._getLanguage<TextTrack>(this._getTextTracks(), playbackConfig.textLanguage, activeTracks.text);
-    let currentOrConfiguredAudioLang =
+    const currentOrConfiguredAudioLang =
       this._playbackAttributesState.audioLanguage ||
       this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
     this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);

--- a/src/player.js
+++ b/src/player.js
@@ -2570,7 +2570,7 @@ export default class Player extends FakeEventTarget {
   _getLanguage<T: TextTrack | AudioTrack>(tracks: Array<T>, configuredLanguage: string, defaultTrack: ?T): string {
     let language = configuredLanguage;
     if (language === AUTO) {
-      const localeTrack: ?(TextTrack | AudioTrack) = tracks.find(track => Track.langComparer(Locale.language, track.language));
+      const localeTrack: ?T = tracks.find(track => Track.langComparer(Locale.language, track.language));
       if (localeTrack) {
         language = localeTrack.language;
       } else if (defaultTrack && defaultTrack.language !== OFF) {

--- a/test/src/player.spec.js
+++ b/test/src/player.spec.js
@@ -3349,7 +3349,7 @@ describe('Player', function () {
 
     it('should return the configured language', () => {
       let configuredLanguage = 'ita';
-      player._getLanguage(configuredLanguage, new TextTrack({}), 'text').should.equals(configuredLanguage);
+      player._getLanguage(player.getTracks('text'), configuredLanguage, new TextTrack({}), 'text').should.equals(configuredLanguage);
     });
 
     it('should return the locale language', () => {
@@ -3366,7 +3366,7 @@ describe('Player', function () {
         return [engTrack];
       });
 
-      let resultLang = player._getLanguage(configuredLanguage, engTrack, 'text');
+      let resultLang = player._getLanguage(player.getTracks('text'), configuredLanguage, engTrack, 'text');
       Track.langComparer(resultLang, Locale.language).should.be.true;
     });
 
@@ -3384,7 +3384,7 @@ describe('Player', function () {
         return [gerTrack];
       });
 
-      player._getLanguage(configuredLanguage, gerTrack, 'text').should.equals(gerTrack.language);
+      player._getLanguage(player.getTracks('text'), configuredLanguage, gerTrack, 'text').should.equals(gerTrack.language);
     });
 
     it('should return the first track language ', () => {
@@ -3401,7 +3401,7 @@ describe('Player', function () {
         return [gerTrack];
       });
 
-      player._getLanguage(configuredLanguage, null, 'text').should.equals(gerTrack.language);
+      player._getLanguage(player.getTracks('text'), configuredLanguage, null, 'text').should.equals(gerTrack.language);
     });
 
     it('should return the first track language even if off track sent as default ', () => {
@@ -3424,7 +3424,7 @@ describe('Player', function () {
         return [gerTrack, offTrack];
       });
 
-      player._getLanguage(configuredLanguage, offTrack, 'text').should.equals(gerTrack.language);
+      player._getLanguage(player.getTracks('text'), configuredLanguage, offTrack, 'text').should.equals(gerTrack.language);
     });
   });
 


### PR DESCRIPTION
### Description of the Changes

add the option to set `playback.audioLanguage: 'auto'` and compare with the locale then 

Solves FEC-11964

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [x] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
