### PR TITLE
fix(FEC-11904): Player_Web_Mac - The spinner appears when unmute the show

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -1156,7 +1156,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       if (!playing) {
         this.dispatchEvent(new FakeEvent(Html5EventType.WAITING));
       }
-      playing = false;
     }, SHORT_BUFFERING_TIMEOUT);
   }
 

--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -17,6 +17,8 @@ import getLogger from '../../utils/logger';
 import {DroppedFramesWatcher} from '../dropped-frames-watcher';
 import {ThumbnailInfo} from '../../thumbnail/thumbnail-info';
 
+const SHORT_BUFFERING_TIMEOUT: number = 200;
+
 /**
  * Html5 engine for playback.
  * @classdesc
@@ -295,13 +297,14 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   attach(): void {
     Object.keys(Html5EventType).forEach(html5Event => {
-      if (Html5EventType[html5Event] !== Html5EventType.ERROR) {
+      if (![Html5EventType.ERROR, Html5EventType.WAITING].includes(Html5EventType[html5Event])) {
         this._eventManager.listen(this._el, Html5EventType[html5Event], () => {
           return this.dispatchEvent(new FakeEvent(Html5EventType[html5Event]));
         });
       }
     });
     this._eventManager.listen(this._el, Html5EventType.ERROR, () => this._handleVideoError());
+    this._eventManager.listen(this._el, Html5EventType.WAITING, () => this._handleWaiting());
     this._handleMetadataTrackEvents();
     this._eventManager.listen(this._el.textTracks, 'addtrack', (event: any) => {
       if (PKTextTrack.isNativeTextTrack(event.track)) {
@@ -1143,6 +1146,18 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       });
       this.dispatchEvent(new FakeEvent(Html5EventType.ERROR, error));
     }
+  }
+
+  _handleWaiting(): void {
+    let playing = false;
+    this._eventManager.listenOnce(this._el, Html5EventType.PLAYING, () => (playing = true));
+    setTimeout(() => {
+      // prevent sending waiting event for too short buffering
+      if (!playing) {
+        this.dispatchEvent(new FakeEvent(Html5EventType.WAITING));
+      }
+      playing = false;
+    }, SHORT_BUFFERING_TIMEOUT);
   }
 
   /**

--- a/test/src/engines/html5/html5.spec.js
+++ b/test/src/engines/html5/html5.spec.js
@@ -2,6 +2,7 @@ import Html5 from '../../../../src/engines/html5/html5';
 import BaseMediaSourceAdapter from '../../../../src/engines/html5/media-source/base-media-source-adapter';
 import sourcesConfig from '../../configs/sources.json';
 import {DroppedFramesWatcher} from '../../../../src/engines/dropped-frames-watcher';
+import {Html5EventType} from '../../../../src/event/event-type';
 
 describe('Html5', () => {
   let sandbox;
@@ -29,6 +30,20 @@ describe('Html5', () => {
     engine._config.should.deep.equal(config);
     engine._mediaSourceAdapter.should.be.instanceof(BaseMediaSourceAdapter);
     engine._el.should.be.a('HTMLVideoElement');
+  });
+
+  it('should prevent too short buffering event', done => {
+    const progressiveSource = sourcesConfig.Mp4.progressive[0];
+    const engine = Html5.createEngine(progressiveSource);
+    engine._eventManager.listen(engine, Html5EventType.WAITING, () => {
+      done();
+    });
+    engine._el.dispatchEvent(new window.Event(Html5EventType.WAITING));
+    engine._el.dispatchEvent(new window.Event(Html5EventType.PLAYING));
+    engine._el.dispatchEvent(new window.Event(Html5EventType.WAITING));
+    setTimeout(() => {
+      engine._el.dispatchEvent(new window.Event(Html5EventType.PLAYING));
+    }, 300);
   });
 
   it('should restore html5 engine', () => {


### PR DESCRIPTION
### Description of the Changes

Safari fires WAITING event once unmuting and immediately sends PLAYING
so prevent sending waiting event for too short buffering

Solves FEC-11904

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
