### PR TITLE
fix(FEC-11619):  Player failed to change speed rate to 4

### DIFF
--- a/src/engines/html5/html5.js
+++ b/src/engines/html5/html5.js
@@ -181,7 +181,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * The player playback rates.
    * @type {Array<number>}
    */
-  static PLAYBACK_RATES: Array<number> = [0.5, 1, 2, 4];
+  static PLAYBACK_RATES: Array<number> = [0.5, 1, 1.5, 2];
 
   /**
    * @constructor


### PR DESCRIPTION
### Description of the Changes

4 is too high and breaks the player

Solves FEC-11619