### PR TITLE
fix(FEC-12431): [WEB] - [O2CZ] Player_Web_MAC_Safari - The progress bar jumps front and back when seek

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -1213,7 +1213,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
       }
     } else {
       const liveEdge = this._getLiveEdge();
-      if (this._liveEdge !== liveEdge) {
+      if (this._liveEdge && this._liveEdge !== liveEdge) {
         this._segmentDuration = liveEdge - this._liveEdge;
       }
     }


### PR DESCRIPTION
### Description of the Changes

Handle a scenario of this._liveEdge (in native-adapter) being 0 in a live stream, which caused isOnLiveEdge to be true when it shouldn't be.

Resolves FEC-12431.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
