### PR TITLE
fix(FEC-12479): [Dash] - Subtitles are too small and not centered

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -50,6 +50,7 @@
   right: 0;
   left: 0;
   pointer-events: none;
+  margin-bottom: 5px;
 }
 
 .playkit-black-cover {


### PR DESCRIPTION
### Description of the Changes

solves: FEC-12479

related pr: https://github.com/kaltura/playkit-js-dash/pull/204

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
