### PR TITLE
fix(FEC-12350): external captions shown while cc button disabled

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1331,6 +1331,10 @@ export default class Player extends FakeEventTarget {
       this._engine.hideTextTrack();
       this._resetTextDisplay();
       const textTracks = this._getTextTracks();
+      const activeTextTrack = textTracks.find(track => track.active === true);
+      if (activeTextTrack && activeTextTrack.external) {
+        this._externalCaptionsHandler.hideTextTrack();
+      }
       textTracks.map(track => (track.active = false));
       const textTrack = textTracks.find(track => track.language === OFF);
       if (textTrack) {


### PR DESCRIPTION
**the issue:**
when captions are external and disabling cc button, captions are still shown on player.

**root cause:**
player's API hideTextTrack() does not handle external captions.

### Description of the Changes

- check if active text track is external and use hideTextTrack() API of externalCaptionsHandler

Solves FEC-12350

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
