### PR TITLE
fix(FEC-12351): cc button changed to enable during change media

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1337,6 +1337,7 @@ export default class Player extends FakeEventTarget {
         textTrack.active = true;
         this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_TRACK_CHANGED, {selectedTextTrack: textTrack}));
       }
+      this._playbackAttributesState.textLanguage = OFF;
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

**the issue:** 
when click on the cc button to disable caption and then occur the "change media" functionality the new video start with cc enabled.

**root cause:**
when turn off the caption from the cc button the previous language variable not change to off and still storing the previous language.

**the solution:**
the previous language viarable will be changed to off also when clicking cc button and not only when clicking "off" in the language button.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
