### PR TITLE
fix(FEC-12121): youtube UI is not responsive for clicks

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1787,6 +1787,9 @@ export default class Player extends FakeEventTarget {
       const classNameWithId = `${ENGINE_CLASS_NAME}-${this._engine.id}`;
       Utils.Dom.addClassName(engineEl, classNameWithId);
       Utils.Dom.prependTo(engineEl, this._el);
+      if (this._engine.id === 'youtube') {
+        this._el.style.zIndex = 1;
+      }
     }
   }
 


### PR DESCRIPTION
### Description of the Changes

add z-index=1 when youtube engine element is loaded to the ui, to allow clicks on youtube's ui.

Solves FEC-12121

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
