### PR TITLE
fix(FEC-10833): captions not auto selected from the user preferences

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2587,11 +2587,14 @@ export default class Player extends FakeEventTarget {
     const activeTracks = this.getActiveTracks();
     const playbackConfig = this.config.playback;
     const offTextTrack: ?Track = this._getTextTracks().find(track => TextTrack.langComparer(OFF, track.language));
-    const configuredTextLang = this._getLanguage<TextTrack>(this._getTextTracks(), playbackConfig.textLanguage, activeTracks.text);
+    const currentOrConfiguredTextLang =
+      window.localStorage.getItem('kaltura-player-js_textLanguage') ||
+      this._playbackAttributesState.textLanguage ||
+      this._getLanguage<TextTrack>(this._getTextTracks(), playbackConfig.textLanguage, activeTracks.text);
     const currentOrConfiguredAudioLang =
       this._playbackAttributesState.audioLanguage ||
       this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
-    this._setDefaultTrack<TextTrack>(this._getTextTracks(), configuredTextLang, offTextTrack);
+    this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
     this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
     this._setDefaultVideoTrack();
   }

--- a/src/player.js
+++ b/src/player.js
@@ -2587,13 +2587,11 @@ export default class Player extends FakeEventTarget {
     const activeTracks = this.getActiveTracks();
     const playbackConfig = this.config.playback;
     const offTextTrack: ?Track = this._getTextTracks().find(track => TextTrack.langComparer(OFF, track.language));
-    const currentOrConfiguredTextLang =
-      this._playbackAttributesState.textLanguage ||
-      this._getLanguage<TextTrack>(this._getTextTracks(), playbackConfig.textLanguage, activeTracks.text);
+    const configuredTextLang = this._getLanguage<TextTrack>(this._getTextTracks(), playbackConfig.textLanguage, activeTracks.text);
     const currentOrConfiguredAudioLang =
       this._playbackAttributesState.audioLanguage ||
       this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
-    this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
+    this._setDefaultTrack<TextTrack>(this._getTextTracks(), configuredTextLang, offTextTrack);
     this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
     this._setDefaultVideoTrack();
   }


### PR DESCRIPTION
**the issue:**
when playing a video with 608 captions and switching to a certain language, after refreshing, the default is "off" instead of the language that was chosen (and that was saved to local storage).

**root cause:**
608 captions are loaded one after another (unlike from the manifest which loaded all together). So if the desired textLanguage is not arriving at the first captions load, the player [selects the ‘off’ and saves it](https://github.com/kaltura/playkit-js/blob/d87e7b13fc204157b9615c67949135f45efd17ae/src/player.js#L1194). then, when the captions file with the desired textLanguage is being loaded, the player ignores it.

**solution:**
since setDefaultTracks is being called every time a 608 caption is loaded, need to set the default text track also by the value that is stored in the local storage, if exists.

### Description of the Changes

first check the value of kaltura-player-js_textLanguage in local storage, when setting the default text track.
Note - currently playkit.js does not have access to storageManager in kaltura-player-js.

Solves FEC-10833

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
