### PR TITLE
fix(FEC-12615): add configuration to toggle emsg listener

### DIFF
--- a/flow-typed/types/streaming-config.js
+++ b/flow-typed/types/streaming-config.js
@@ -1,5 +1,6 @@
 // @flow
 declare type PKStreamingConfigObject = {
   forceBreakStall: boolean,
-  lowLatencyMode: boolean
+  lowLatencyMode: boolean,
+  trackEmsgEvents: boolean
 };


### PR DESCRIPTION
### Description of the Changes

add configuration option to toggle off dash emsg listener

related PR: https://github.com/kaltura/playkit-js-dash/pull/212

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
