### PR TITLE
fix(FEC-12679): ISO Code for Chinese and Spanish in Multi Audio

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2614,13 +2614,18 @@ export default class Player extends FakeEventTarget {
   _getLanguage<T: TextTrack | AudioTrack>(tracks: Array<T>, configuredLanguage: string, defaultTrack: ?T): string {
     let language = configuredLanguage;
     if (language === AUTO) {
-      const localeTrack: ?T = tracks.find(track => Track.langComparer(Locale.language, track.language));
-      if (localeTrack) {
-        language = localeTrack.language;
-      } else if (defaultTrack && defaultTrack.language !== OFF) {
-        language = defaultTrack.language;
-      } else if (tracks && tracks.length > 0) {
-        language = tracks[0].language;
+      const localeSameTrack: ?T = tracks.find(track => Track.langComparer(Locale.language, track.language, true));
+      if (localeSameTrack) {
+        language = localeSameTrack.language;
+      } else {
+        const localeTrack: ?T = tracks.find(track => Track.langComparer(Locale.language, track.language, false));
+        if (localeTrack) {
+          language = localeTrack.language;
+        } else if (defaultTrack && defaultTrack.language !== OFF) {
+          language = defaultTrack.language;
+        } else if (tracks && tracks.length > 0) {
+          language = tracks[0].language;
+        }
       }
     }
     return language;

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -147,7 +147,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @private
    */
   _maybeAddTrack(track: TextTrack, caption: PKExternalCaptionObject, playerTextTracks: Array<Track>, newTextTracks: Array<TextTrack>): void {
-    const sameLangTrack = playerTextTracks.find(textTrack => textTrack.available && Track.langComparer(caption.language, textTrack.language));
+    const sameLangTrack = playerTextTracks.find(textTrack => textTrack.available && Track.langComparer(caption.language, textTrack.language, true));
     if (!sameLangTrack) {
       newTextTracks.push(track);
       this._updateTextTracksModel(caption);

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -12,12 +12,22 @@ export default class Track {
    * @param {boolean} equal - Optional flag to check for matching languages.
    * @returns {boolean} - Whether the strings are equal or starts with the same substring.
    */
+
   static langComparer(inputLang: string, trackLang: string, equal: ?boolean): boolean {
     try {
       inputLang = inputLang.toLowerCase();
       trackLang = trackLang.toLowerCase();
-      if (equal) {
-        return inputLang ? inputLang === trackLang : false;
+      if (equal && inputLang) {
+        if (inputLang === trackLang) {
+          return true;
+        } else {
+          const languageNames = new Intl.DisplayNames(['en'], {
+            type: 'language'
+          });
+          inputLang = inputLang.replace('_', '-');
+          trackLang = trackLang.replace('_', '-');
+          return languageNames.of(trackLang) === languageNames.of(inputLang);
+        }
       } else {
         return inputLang ? inputLang.startsWith(trackLang) || trackLang.startsWith(inputLang) : false;
       }


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when the language text track is 639-2 iso code and it not the 639-1 + additional latter 
(for example: Spanish, 639-1: "es" 639-2: "spa") 
the player doesn't recognize the language and it doesn't do the match between codes.

**the solution:**
checking in the lanfcomparer function if the iso code (both 639-1 and 639-2) is the same language.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated

solves FEC-12679