### PR TITLE
fix(FEC-12691): Shaka Text Track Displayer does not work unless  useNativeTextTrack set to true

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2557,7 +2557,7 @@ export default class Player extends FakeEventTarget {
    * @returns {void}
    */
   _updateTextDisplay(cues: Array<Cue>): void {
-    if (!this._config.text.useNativeTextTrack) {
+    if (!this._config.text.useNativeTextTrack && !this._config.text.useShakaTextTrackDisplay) {
       processCues(window, cues, this._textDisplayEl, this._textStyle);
     }
   }


### PR DESCRIPTION
### Description of the Changes

shaka Text Track Displayer does not work unless  useNativeTextTrack set to true

solves: FEC-12691

related pr: 
https://github.com/kaltura/playkit-js-dash/pull/215,
https://github.com/kaltura/kaltura-player-js/pull/586

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
