### PR TITLE
fix(FEC-12679): ISO Code for Chinese and Spanish in Multi Audio

### DIFF
--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -2,6 +2,8 @@
 declare type PKPlaybackConfigObject = {
   audioLanguage: string,
   textLanguage: string,
+  extensionAudioLanguage: string,
+  extensionTextLanguage: string,
   volume: number,
   playsinline: boolean,
   crossOrigin: string,

--- a/flow-typed/types/playback-config.js
+++ b/flow-typed/types/playback-config.js
@@ -2,8 +2,8 @@
 declare type PKPlaybackConfigObject = {
   audioLanguage: string,
   textLanguage: string,
-  extensionAudioLanguage: string,
-  extensionTextLanguage: string,
+  additionalAudioLanguage: string,
+  additionalTextLanguage: string,
   volume: number,
   playsinline: boolean,
   crossOrigin: string,

--- a/src/player.js
+++ b/src/player.js
@@ -2599,14 +2599,14 @@ export default class Player extends FakeEventTarget {
       this._playbackAttributesState.audioLanguage ||
       this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
     currentOrConfiguredTextLang === playbackConfig.textLanguage
-      ? this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack, playbackConfig.extensionTextLanguage)
+      ? this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack, playbackConfig.additionalTextLanguage)
       : this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
     currentOrConfiguredAudioLang === playbackConfig.audioLanguage
       ? this._setDefaultTrack<AudioTrack>(
           this._getAudioTracks(),
           currentOrConfiguredAudioLang,
           activeTracks.audio,
-          playbackConfig.extensionAudioLanguage
+          playbackConfig.additionalAudioLanguage
         )
       : this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
     this._setDefaultVideoTrack();
@@ -2641,20 +2641,20 @@ export default class Player extends FakeEventTarget {
    * @param {Array<T>} tracks - the audio or text tracks.
    * @param {string} language - The track language.
    * @param {Track} defaultTrack - The default track to set in case there is no language configured.
-   * @param {string} extensionLanguage - extension track language.
+   * @param {string} additionalLanguage - additional track language.
    * @returns {void}
    * @private
    */
-  _setDefaultTrack<T: TextTrack | AudioTrack>(tracks: Array<T>, language: string, defaultTrack: ?Track, extensionLanguage: ?string): void {
+  _setDefaultTrack<T: TextTrack | AudioTrack>(tracks: Array<T>, language: string, defaultTrack: ?Track, additionalLanguage: ?string): void {
     const updateTrack = track => {
       this.selectTrack(track);
       this._markActiveTrack(track);
     };
-    const sameTrack: ?T = tracks.find(track => Track.langComparer(language, track.language, extensionLanguage, true));
+    const sameTrack: ?T = tracks.find(track => Track.langComparer(language, track.language, additionalLanguage, true));
     if (sameTrack) {
       updateTrack(sameTrack);
     } else {
-      const track: ?T = tracks.find(track => Track.langComparer(language, track.language, extensionLanguage, false));
+      const track: ?T = tracks.find(track => Track.langComparer(language, track.language, additionalLanguage, false));
       if (track) {
         updateTrack(track);
       } else if (defaultTrack && !defaultTrack.active) {

--- a/src/player.js
+++ b/src/player.js
@@ -2598,8 +2598,17 @@ export default class Player extends FakeEventTarget {
     const currentOrConfiguredAudioLang =
       this._playbackAttributesState.audioLanguage ||
       this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
-    this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
-    this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
+    currentOrConfiguredTextLang === playbackConfig.textLanguage
+      ? this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack, playbackConfig.extensionTextLanguage)
+      : this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
+    currentOrConfiguredAudioLang === playbackConfig.audioLanguage
+      ? this._setDefaultTrack<AudioTrack>(
+          this._getAudioTracks(),
+          currentOrConfiguredAudioLang,
+          activeTracks.audio,
+          playbackConfig.extensionAudioLanguage
+        )
+      : this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
     this._setDefaultVideoTrack();
   }
 
@@ -2632,19 +2641,20 @@ export default class Player extends FakeEventTarget {
    * @param {Array<T>} tracks - the audio or text tracks.
    * @param {string} language - The track language.
    * @param {Track} defaultTrack - The default track to set in case there is no language configured.
+   * @param {string} extensionLanguage - extension track language.
    * @returns {void}
    * @private
    */
-  _setDefaultTrack<T: TextTrack | AudioTrack>(tracks: Array<T>, language: string, defaultTrack: ?Track): void {
+  _setDefaultTrack<T: TextTrack | AudioTrack>(tracks: Array<T>, language: string, defaultTrack: ?Track, extensionLanguage: ?string): void {
     const updateTrack = track => {
       this.selectTrack(track);
       this._markActiveTrack(track);
     };
-    const sameTrack: ?T = tracks.find(track => Track.langComparer(language, track.language, true));
+    const sameTrack: ?T = tracks.find(track => Track.langComparer(language, track.language, extensionLanguage, true));
     if (sameTrack) {
       updateTrack(sameTrack);
     } else {
-      const track: ?T = tracks.find(track => Track.langComparer(language, track.language, false));
+      const track: ?T = tracks.find(track => Track.langComparer(language, track.language, extensionLanguage, false));
       if (track) {
         updateTrack(track);
       } else if (defaultTrack && !defaultTrack.active) {

--- a/src/player.js
+++ b/src/player.js
@@ -2598,17 +2598,21 @@ export default class Player extends FakeEventTarget {
     const currentOrConfiguredAudioLang =
       this._playbackAttributesState.audioLanguage ||
       this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
-    currentOrConfiguredTextLang === playbackConfig.textLanguage
-      ? this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack, playbackConfig.additionalTextLanguage)
-      : this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
-    currentOrConfiguredAudioLang === playbackConfig.audioLanguage
-      ? this._setDefaultTrack<AudioTrack>(
-          this._getAudioTracks(),
-          currentOrConfiguredAudioLang,
-          activeTracks.audio,
-          playbackConfig.additionalAudioLanguage
-        )
-      : this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
+    if (currentOrConfiguredTextLang === playbackConfig.textLanguage) {
+      this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack, playbackConfig.additionalTextLanguage);
+    } else {
+      this._setDefaultTrack<TextTrack>(this._getTextTracks(), currentOrConfiguredTextLang, offTextTrack);
+    }
+    if (currentOrConfiguredAudioLang === playbackConfig.audioLanguage) {
+      this._setDefaultTrack<AudioTrack>(
+        this._getAudioTracks(),
+        currentOrConfiguredAudioLang,
+        activeTracks.audio,
+        playbackConfig.additionalAudioLanguage
+      );
+    } else {
+      this._setDefaultTrack<AudioTrack>(this._getAudioTracks(), currentOrConfiguredAudioLang, activeTracks.audio);
+    }
     this._setDefaultVideoTrack();
   }
 

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -9,19 +9,19 @@ export default class Track {
    * Comparing language strings.
    * @param {string} inputLang - The configured language.
    * @param {string} trackLang - The default track language.
-   * @param {string} extensionLanguage -  Additional configured language.
+   * @param {string} additionalLanguage -  Additional configured language.
    * @param {boolean} equal - Optional flag to check for matching languages.
    * @returns {boolean} - Whether the strings are equal or starts with the same substring.
    */
-  static langComparer(inputLang: string, trackLang: string, extensionLanguage: ?string, equal: ?boolean): boolean {
+  static langComparer(inputLang: string, trackLang: string, additionalLanguage: ?string, equal: ?boolean): boolean {
     try {
       inputLang = inputLang.toLowerCase();
       trackLang = trackLang.toLowerCase();
-      extensionLanguage ? (extensionLanguage = extensionLanguage.toLowerCase()) : extensionLanguage;
+      additionalLanguage ? (additionalLanguage = additionalLanguage.toLowerCase()) : additionalLanguage;
       if (equal) {
-        if (inputLang && inputLang === trackLang) {
+        if (inputLang === trackLang) {
           return true;
-        } else if (extensionLanguage && extensionLanguage === trackLang) {
+        } else if (additionalLanguage === trackLang) {
           return true;
         } else return false;
       } else {

--- a/src/track/track.js
+++ b/src/track/track.js
@@ -9,15 +9,21 @@ export default class Track {
    * Comparing language strings.
    * @param {string} inputLang - The configured language.
    * @param {string} trackLang - The default track language.
+   * @param {string} extensionLanguage -  Additional configured language.
    * @param {boolean} equal - Optional flag to check for matching languages.
    * @returns {boolean} - Whether the strings are equal or starts with the same substring.
    */
-  static langComparer(inputLang: string, trackLang: string, equal: ?boolean): boolean {
+  static langComparer(inputLang: string, trackLang: string, extensionLanguage: ?string, equal: ?boolean): boolean {
     try {
       inputLang = inputLang.toLowerCase();
       trackLang = trackLang.toLowerCase();
+      extensionLanguage ? (extensionLanguage = extensionLanguage.toLowerCase()) : extensionLanguage;
       if (equal) {
-        return inputLang ? inputLang === trackLang : false;
+        if (inputLang && inputLang === trackLang) {
+          return true;
+        } else if (extensionLanguage && extensionLanguage === trackLang) {
+          return true;
+        } else return false;
       } else {
         return inputLang ? inputLang.startsWith(trackLang) || trackLang.startsWith(inputLang) : false;
       }

--- a/test/src/track/track.spec.js
+++ b/test/src/track/track.spec.js
@@ -21,9 +21,15 @@ describe('Track', () => {
     });
 
     it('should compare languages using equality flag', () => {
-      Track.langComparer('zh', 'zh', true).should.be.true;
-      Track.langComparer('zh_tw', 'zh', true).should.be.false;
-      Track.langComparer('zh_tw', 'zh', false).should.be.true;
+      Track.langComparer('zh', 'zh', undefined, true).should.be.true;
+      Track.langComparer('zh_tw', 'zh', undefined, true).should.be.false;
+      Track.langComparer('zh_tw', 'zh', undefined, false).should.be.true;
+    });
+
+    it('should compare languages also with the additionalLanguage from the configuration', () => {
+      Track.langComparer('zh', 'chi', 'chi', true).should.be.true;
+      Track.langComparer('es', 'spa', 'spa', true).should.be.true;
+      Track.langComparer('es', 'zh', 'spa', true).should.be.false;
     });
   });
 });


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when the language track is 639-2 iso code and it's not the 639-1 + additional latter.
(for example: Spanish, 639-1: "es" 639-2: "spa")
the player doesn't recognize the language and it doesn't do the match between codes.

**the solution:**
add fields of extensionAudioLanguage and extensionTextLanguage to the configuration
in order to add additional checking in case the 639-2 iso code is totally different from the 639-1 iso code.

solves FEC-12679

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
