### PR TITLE
FEC-12736 - fix regression where fontSize in % is not working

### DIFF
--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -105,32 +105,26 @@ class TextStyle {
   static FontSizes: Array<Object> = [
     {
       value: -2,
-      px: '8px',
       label: '50%'
     },
     {
       value: -1,
-      px: '12px',
       label: '75%'
     },
     {
       value: 0,
-      px: '16px',
       label: '100%'
     },
     {
       value: 2,
-      px: '32px',
       label: '200%'
     },
     {
       value: 3,
-      px: '48px',
       label: '300%'
     },
     {
       value: 4,
-      px: '64px',
       label: '400%'
     }
   ];
@@ -190,12 +184,6 @@ class TextStyle {
    */
   get fontSize() {
     return TextStyle.FontSizes[this._fontSizeIndex].label;
-  }
-  /**
-   * px string matching a FontSizes in px instead of  %
-   */
-  get fontSizePx() {
-    return TextStyle.FontSizes[this._fontSizeIndex].px;
   }
 
   set fontScale(fontScale: number) {
@@ -269,7 +257,6 @@ class TextStyle {
     attributes.push('color: ' + TextStyle.toRGBA(this.fontColor, this.fontOpacity));
     attributes.push('background-color: ' + TextStyle.toRGBA(this.backgroundColor, this.backgroundOpacity));
     attributes.push('text-shadow: ' + this.getTextShadow());
-    attributes.push('font-size: ' + this.fontSizePx);
     return attributes.join('!important; ');
   }
 

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -105,26 +105,32 @@ class TextStyle {
   static FontSizes: Array<Object> = [
     {
       value: -2,
+      px: '8px',
       label: '50%'
     },
     {
       value: -1,
+      px: '12px',
       label: '75%'
     },
     {
       value: 0,
+      px: '16px',
       label: '100%'
     },
     {
       value: 2,
+      px: '32px',
       label: '200%'
     },
     {
       value: 3,
+      px: '48px',
       label: '300%'
     },
     {
       value: 4,
+      px: '64px',
       label: '400%'
     }
   ];
@@ -184,6 +190,12 @@ class TextStyle {
    */
   get fontSize() {
     return TextStyle.FontSizes[this._fontSizeIndex].label;
+  }
+  /**
+   * px string matching a FontSizes in px instead of  %
+   */
+  get fontSizePx() {
+    return TextStyle.FontSizes[this._fontSizeIndex].px;
   }
 
   set fontScale(fontScale: number) {
@@ -257,7 +269,8 @@ class TextStyle {
     attributes.push('color: ' + TextStyle.toRGBA(this.fontColor, this.fontOpacity));
     attributes.push('background-color: ' + TextStyle.toRGBA(this.backgroundColor, this.backgroundOpacity));
     attributes.push('text-shadow: ' + this.getTextShadow());
-    attributes.push('font-size: ' + this.fontSize);
+    attributes.push('font-size: ' + this.fontSizePx);
+
     return attributes.join('!important; ');
   }
 

--- a/src/track/text-style.js
+++ b/src/track/text-style.js
@@ -270,7 +270,6 @@ class TextStyle {
     attributes.push('background-color: ' + TextStyle.toRGBA(this.backgroundColor, this.backgroundOpacity));
     attributes.push('text-shadow: ' + this.getTextShadow());
     attributes.push('font-size: ' + this.fontSizePx);
-
     return attributes.join('!important; ');
   }
 


### PR DESCRIPTION
### Description of the Changes

solves FEC-12736

Regression of https://github.com/kaltura/playkit-js/pull/669/

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated