### PR TITLE
fix(FEC-12727):Remove aria-live region from the captions

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1817,7 +1817,6 @@ export default class Player extends FakeEventTarget {
     Utils.Dom.appendChild(this._el, el);
     // Append playkit-subtitles
     this._textDisplayEl = Utils.Dom.createElement('div');
-    Utils.Dom.setAttribute(this._textDisplayEl, 'aria-live', 'polite');
     Utils.Dom.addClassName(this._textDisplayEl, SUBTITLES_CLASS_NAME);
     Utils.Dom.appendChild(this._el, this._textDisplayEl);
   }


### PR DESCRIPTION
### Description of the Changes

**the issue:**
Captions are read aloud by the screen reader. 
Since captions are intended for users who are blind or have visual impairments, the audio of the video is sufficient.

**the solution:**
Remove aria-live attribute from the captions element. 

solves FEC-12727

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
