### PR TITLE
fix(FEC-12122):[WEB][Youtube media][iOS][Safari][iPhone] - Full screen UI is not responsive for clicks

### DIFF
--- a/src/engines/engine-type.js
+++ b/src/engines/engine-type.js
@@ -3,7 +3,8 @@ const EngineType: PKEngineTypes = {
   HTML5: 'html5',
   FLASH: 'flash',
   SILVERLIGHT: 'silverlight',
-  CAST: 'cast'
+  CAST: 'cast',
+  YOUTUBE: 'youtube'
 };
 
 export {EngineType};

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -4,6 +4,7 @@ import Player from '../player';
 import FakeEvent from '../event/fake-event';
 import * as Utils from '../utils/util';
 import {ScreenOrientationType} from '../enums/screen-orientation-type';
+import {EngineType} from '../engines/engine-type';
 
 /**
  * The IOS fullscreen class name.
@@ -100,7 +101,7 @@ class FullscreenController {
         fullScreenElement = this._player.getView();
       }
       if (this._player.env.os.name === 'iOS') {
-        if ((playbackConfig.inBrowserFullscreen && playbackConfig.playsinline) || this._player._engineType === 'youtube') {
+        if ((playbackConfig.inBrowserFullscreen && playbackConfig.playsinline) || this._player._engineType === EngineType.YOUTUBE) {
           this._enterInBrowserFullscreen(fullScreenElement);
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();
@@ -130,7 +131,7 @@ class FullscreenController {
     if (this.isFullscreen()) {
       if (this._player.env.os.name === 'iOS') {
         // player will be in full screen with this flag or otherwise will be natively full screen
-        if (this._isInBrowserFullscreen || this._player._engineType === 'youtube') {
+        if (this._isInBrowserFullscreen || this._player._engineType === EngineType.YOUTUBE) {
           this._exitInBrowserFullscreen();
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();

--- a/src/fullscreen/fullscreen-controller.js
+++ b/src/fullscreen/fullscreen-controller.js
@@ -100,7 +100,7 @@ class FullscreenController {
         fullScreenElement = this._player.getView();
       }
       if (this._player.env.os.name === 'iOS') {
-        if (playbackConfig.inBrowserFullscreen && playbackConfig.playsinline) {
+        if ((playbackConfig.inBrowserFullscreen && playbackConfig.playsinline) || this._player._engineType === 'youtube') {
           this._enterInBrowserFullscreen(fullScreenElement);
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();
@@ -130,7 +130,7 @@ class FullscreenController {
     if (this.isFullscreen()) {
       if (this._player.env.os.name === 'iOS') {
         // player will be in full screen with this flag or otherwise will be natively full screen
-        if (this._isInBrowserFullscreen) {
+        if (this._isInBrowserFullscreen || this._player._engineType === 'youtube') {
           this._exitInBrowserFullscreen();
         } else {
           const videoElement: ?HTMLVideoElement = this._player.getVideoElement();


### PR DESCRIPTION
### Description of the Changes

**the issue:**
full screen button is not responsive for clicks in youtube media on ios devices.

**the root cause:**
in case of ios deivces the full screen is the native full screen. 
the webkitEnterFullScreen function works only on the video element.
we tried to call the function on the element that wrapped the youtube iframe.

**the solution:**
in case of youtube media on ios devices we always call the enterInBrowserFullscreen function since we can't call the webkitEnterFullScreen. 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
