### PR TITLE
fix(FEC-12686): Web - When changing the caption from RUS to JAP in the middle of the video, all of the past caption are shown at once

### DIFF
--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -574,9 +574,9 @@ class ExternalCaptionsHandler extends FakeEventTarget {
       this._isTextTrackActive = true;
       ExternalCaptionsHandler._logger.debug('External text track changed', textTrack);
       this._activeTextCues = [];
+      this._externalCueIndex = 0;
       this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_CUE_CHANGED, {cues: this._activeTextCues}));
       this._eventManager.listen(this._player, Html5EventType.TIME_UPDATE, () => this._handleCaptionOnTimeUpdate(textTrack));
-      this._externalCueIndex = 0;
     }
   }
 }

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -416,8 +416,8 @@ class ExternalCaptionsHandler extends FakeEventTarget {
         this._activeTextCues = [];
         cueIndexUpdated = this._maybeSetExternalCueIndex();
       }
-      const activeCuesRemoved = this._maybeRemoveActiveCues();
       const activeCuesAdded = this._maybeAddToActiveCues(track);
+      const activeCuesRemoved = this._maybeRemoveActiveCues();
 
       if (cueIndexUpdated || activeCuesAdded || activeCuesRemoved) {
         this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_CUE_CHANGED, {cues: this._activeTextCues}));
@@ -445,14 +445,11 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     if (!currentTime) {
       return false;
     }
-    let hadRemoved = false;
-    for (let activeTextCuesIndex = 0; activeTextCuesIndex < this._activeTextCues.length; activeTextCuesIndex++) {
-      const cue = this._activeTextCues[activeTextCuesIndex];
-      if (currentTime < cue.startTime || cue.endTime < currentTime) {
-        this._activeTextCues.splice(activeTextCuesIndex, 1);
-        hadRemoved = true;
-      }
-    }
+
+    const updatedActiveTextCues = this._activeTextCues.filter(cue => cue.startTime < currentTime && currentTime < cue.endTime);
+    const hadRemoved = this._activeTextCues.length !== updatedActiveTextCues.length;
+    this._activeTextCues = updatedActiveTextCues;
+
     return hadRemoved;
   }
 

--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -416,8 +416,8 @@ class ExternalCaptionsHandler extends FakeEventTarget {
         this._activeTextCues = [];
         cueIndexUpdated = this._maybeSetExternalCueIndex();
       }
-      const activeCuesAdded = this._maybeAddToActiveCues(track);
       const activeCuesRemoved = this._maybeRemoveActiveCues();
+      const activeCuesAdded = this._maybeAddToActiveCues(track);
 
       if (cueIndexUpdated || activeCuesAdded || activeCuesRemoved) {
         this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_CUE_CHANGED, {cues: this._activeTextCues}));
@@ -466,7 +466,9 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     let hadAdded = false;
     const cues = this._textTrackModel[track.language].cues;
     while (this._externalCueIndex < cues.length && currentTime > cues[this._externalCueIndex].startTime) {
-      this._activeTextCues.push(cues[this._externalCueIndex]);
+      if (currentTime < cues[this._externalCueIndex].endTime) {
+        this._activeTextCues.push(cues[this._externalCueIndex]);
+      }
       this._externalCueIndex++;
       hadAdded = true;
     }
@@ -492,7 +494,6 @@ class ExternalCaptionsHandler extends FakeEventTarget {
           break;
         }
       }
-      this._externalCueIndex = i;
       return true;
     }
     return false;
@@ -575,6 +576,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
       this._activeTextCues = [];
       this.dispatchEvent(new FakeEvent(CustomEventType.TEXT_CUE_CHANGED, {cues: this._activeTextCues}));
       this._eventManager.listen(this._player, Html5EventType.TIME_UPDATE, () => this._handleCaptionOnTimeUpdate(textTrack));
+      this._externalCueIndex = 0;
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

- When adding active cues - advance the cue index, but don't add active cues if they are are expired
- When removing active cues - use filter instead of splicing in a loop, which caused some cues to not be removed.
- Reset cue index on text track selection to force recalculation of the cue index

Resolves FEC-12686

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
