### PR TITLE
fix(FEC-12991): Left-positioned captions are centered on Firefox

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -580,7 +580,7 @@ var config = {
 >   lineAlign: string, // ['start', 'center', 'end']
 >   align: string, // ['start', 'center', 'end', 'left', 'right']
 >   position: number, //[0 .. 100]
->   positionAlign: string, // ['start', 'center', 'end']
+>   positionAlign: string, // ['line-left', 'center', 'line-right']
 >   snapToLines: boolean, // [true, false]
 >   vertical: string, //['', 'lr', 'rl']
 >   size: number //[0 .. 100]

--- a/src/track/text-track-display.js
+++ b/src/track/text-track-display.js
@@ -664,6 +664,7 @@ class CueStyleBox extends StyleBox {
     switch (align) {
       case 'start':
       case 'left':
+      case 'line-left':
         textPos = cue.position;
         break;
       case 'center':
@@ -671,6 +672,7 @@ class CueStyleBox extends StyleBox {
         break;
       case 'end':
       case 'right':
+      case 'line-right':
         textPos = cue.position - cue.size;
         break;
     }


### PR DESCRIPTION
### Description of the Changes

**issue:** we override the [positionAlign](https://developer.mozilla.org/en-US/docs/Web/API/VTTCue/positionAlign) on [VTTCue](https://developer.mozilla.org/en-US/docs/Web/API/VTTCue) with no [excepted values](https://developer.mozilla.org/en-US/docs/Web/API/VTTCue/positionAlign#value), so Firefox ignores other values and keep its default value - 'auto'
**fix:** changed the configuration to use the [excepted values](https://developer.mozilla.org/en-US/docs/Web/API/VTTCue/positionAlign#value), (and keep the old ones for backward  compatibility)

solves: FEC-12991

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [x] Docs have been updated
