### PR TITLE
fix(FEC-12983): fix regression external captions are not displayed after seek back

### DIFF
--- a/src/track/external-captions-handler.js
+++ b/src/track/external-captions-handler.js
@@ -494,6 +494,7 @@ class ExternalCaptionsHandler extends FakeEventTarget {
           break;
         }
       }
+      this._externalCueIndex = i;
       return true;
     }
     return false;


### PR DESCRIPTION
### Description of the Changes

FEC-12983 - fix cue index after seek back

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
