### PR TITLE
fix(FEC-13108): Start time can't be set to 0 in loadMedia for live with dvr

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -507,7 +507,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   }
 
   _setStartTime(startTime: ?number) {
-    if (startTime > -1) {
+    if (typeof startTime === 'number' && startTime > -1) {
       this._videoElement.currentTime = startTime;
     }
     this._wasCurrentTimeSetSuccessfully = true;

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -507,7 +507,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   }
 
   _setStartTime(startTime: ?number) {
-    if (startTime && startTime > -1) {
+    if (startTime > -1) {
       this._videoElement.currentTime = startTime;
     }
     this._wasCurrentTimeSetSuccessfully = true;


### PR DESCRIPTION
### Description of the Changes

Support setting startTime 0.
Resolves FEC-13108.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
