### PR TITLE
fix(FEC-13217) - add protection for DOM Exception IndexSizeError

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -1214,7 +1214,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
    * @private
    */
   _calculateSegmentDuration() {
-    if (this._videoElement.seekable.start(0) === 0) {
+    if (this._videoElement.seekable.length > 0 && this._videoElement.seekable.start(0) === 0) {
       const {buffered, seekable} = this._videoElement;
       if (buffered.length && seekable.length) {
         this._segmentDuration = (buffered.end(buffered.length - 1) - seekable.end(seekable.length - 1)) / SAFARI_BUFFERED_SEGMENTS_COUNT;


### PR DESCRIPTION
### Description of the Changes

FEC-13217 - avoid accessing the this._videoElement.seekable.start(0) if 
this._videoElement.seekable.length <= 0 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
