### PR TITLE
fix(FEC-13227): video starts unmuted in playlist after playing YT entry

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2122,11 +2122,11 @@ export default class Player extends FakeEventTarget {
 
     const isMuted = () => {
       Player._logger.debug('Checking muted value');
-      // at this point it is possible that the engine hasn't loaded yet, so this.muted is not reflecting the actual state.
+      // at this point it is possible that the engine hasn't loaded yet (like youtube), so this.muted is not reflecting the actual state.
       // first, check if someone set a value in muted; if not, then check the config; lastly, check the engine.
       const muted =
         (typeof this._playbackAttributesState.muted === 'boolean' && this._playbackAttributesState.muted) ||
-        this._config.playback.muted ||
+        (typeof this._config.playback.muted === 'boolean' && this._config.playback.muted) ||
         this.muted;
       Player._logger.debug('Muted value is:', muted);
       return muted;

--- a/src/player.js
+++ b/src/player.js
@@ -2122,13 +2122,13 @@ export default class Player extends FakeEventTarget {
 
     const isMuted = () => {
       Player._logger.debug('Checking muted value');
-      // at this point it is possible that the engine hasn't loaded yet, so this.muted is not refelcting the actual state.
+      // at this point it is possible that the engine hasn't loaded yet, so this.muted is not reflecting the actual state.
       // first, check if someone set a value in muted; if not, then check the config; lastly, check the engine.
       const muted =
         (typeof this._playbackAttributesState.muted === 'boolean' && this._playbackAttributesState.muted) ||
         this._config.playback.muted ||
         this.muted;
-      Player._logger.debug(`Muted value is ${muted}`);
+      Player._logger.debug('Muted value is:', muted);
       return muted;
     };
 

--- a/src/player.js
+++ b/src/player.js
@@ -1963,8 +1963,8 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this, Html5EventType.PAUSE, this._onPause.bind(this));
       this._eventManager.listen(this, Html5EventType.PLAYING, this._onPlaying.bind(this));
       this._eventManager.listen(this, Html5EventType.ENDED, this._onEnded.bind(this));
-      this._eventManager.listen(this, CustomEventType.MUTE_CHANGE, () => {
-        this._playbackAttributesState.muted = this.muted;
+      this._eventManager.listen(this, CustomEventType.MUTE_CHANGE, (event: FakeEvent) => {
+        this._playbackAttributesState.muted = event.payload?.mute || this.muted;
       });
       this._eventManager.listen(this, Html5EventType.VOLUME_CHANGE, () => {
         this._playbackAttributesState.volume = this.volume;
@@ -2107,7 +2107,7 @@ export default class Player extends FakeEventTarget {
         onAutoPlay();
       } else {
         if (capabilities.mutedAutoPlay) {
-          if (this.muted && !this._fallbackToMutedAutoPlay) {
+          if (isMuted() && !this._fallbackToMutedAutoPlay) {
             onMutedAutoPlay();
           } else if (allowMutedAutoPlay) {
             onFallbackToMutedAutoPlay();
@@ -2119,6 +2119,18 @@ export default class Player extends FakeEventTarget {
         }
       }
     });
+
+    const isMuted = () => {
+      Player._logger.debug('Checking muted value');
+      // at this point it is possible that the engine hasn't loaded yet, so this.muted is not refelcting the actual state.
+      // first, check if someone set a value in muted; if not, then check the config; lastly, check the engine.
+      const muted =
+        (typeof this._playbackAttributesState.muted === 'boolean' && this._playbackAttributesState.muted) ||
+        this._config.playback.muted ||
+        this.muted;
+      Player._logger.debug(`Muted value is ${muted}`);
+      return muted;
+    };
 
     const onAutoPlay = () => {
       Player._logger.debug('Start autoplay');


### PR DESCRIPTION
### Description of the Changes

- bug fix

**the issue:**
when playing a playlist and the audio should be muted- after playing a YT entry, the player is becoming unmuted for the next entry.

**root cause:**
it seems that the playkit is checking the YT engine's `muted` value, while the youtube engine hasn't even loaded yet. Because of that, the autoplay handler is executing `onFallbackMutedAutoPlay` function instead of `onMutedAutoPlay` function. As a result, when playing a different entry after playing the YT one, the UI is unmuting the player- because of the `fallbackMutedAutoPlay` state.

**solution:**
at the point when we're checking the `muted` value, it is possible that the engine hasn't loaded yet (like in our case), so the muted value that we get is not reflecting the actual state of muted; the engine is returning false by default.
to handle this case, we need to check the muted value also in `_playbackAttributesState` and in the config itself, prior to checking the engine.

Solves FEC-13227

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
