### PR TITLE
SUP-37895: CC setting is not persisting until refresh

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2593,9 +2593,7 @@ export default class Player extends FakeEventTarget {
     const offTextTrack: ?Track = this._getTextTracks().find(track => TextTrack.langComparer(OFF, track.language));
     const defaultLanguage = this._getLanguage<TextTrack>(this._getTextTracks(), playbackConfig.textLanguage, defaultStreamTrack);
     const currentOrConfiguredTextLang =
-      !this._playbackAttributesState.textLanguage || this._playbackAttributesState.textLanguage === OFF
-        ? defaultLanguage
-        : this._playbackAttributesState.textLanguage;
+      !this._playbackAttributesState.textLanguage || this.config.disableUserCache ? defaultLanguage : this._playbackAttributesState.textLanguage;
     const currentOrConfiguredAudioLang =
       this._playbackAttributesState.audioLanguage ||
       this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);


### PR DESCRIPTION
the issue:
when change captions to off and move to next entry captions changed back to be on.

the changes:
change in code if expression. remove if captions are off take the default so it will take what the user choose last, and add check is disable user cache then take the default. 
