### PR TITLE
feat(FEC-13420): support start and end time of video

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,8 @@ var config = {
 >  captions?: Array<PKExternalCaptionObject>,
 >  thumbnails?: PKExternalThumbnailsConfig,
 >  startTime?: number
+>  seekFrom?: number
+>  clipTo?: number
 > }
 > ```
 >
@@ -505,6 +507,32 @@ var config = {
 > > > Note. `startTime` affects the ad playback, e.g. `startTime: 10` will skip ads scheduled until 10.
 > > > <br>To force playing ads scheduled before `startTime`, need to configure the ads plugin.
 > > > <br>For example with [IMA](https://github.com/kaltura/playkit-js-ima/blob/master/docs/api.md) plugin, set `adsRenderingSettings: {playAdsAfterTime: -1}`.
+> >
+> > ##
+> >
+> > ### sources.seekFrom
+> >
+> > ##### Type: `number`
+> >
+> > ##### Default: `-`
+> >
+> > ##### Description: Optional time, in seconds, to start the playback from, by cutting the video.
+> >
+> > Unlike `startTime`, this configuration will cut and omit the part of the video that is before the configured `seekFrom` value and will start from there.
+> > This will affect the duration of the video.
+> >
+> > ##
+> >
+> > ### sources.clipTo
+> >
+> > ##### Type: `number`
+> >
+> > ##### Default: `-`
+> >
+> > ##### Description: Optional time, in seconds, to end the playback, by cutting the video.
+> >
+> > `clipTo` will cut and omit the part of the video that is after the configured value, and will end at this position.
+> > This will affect the duration of the video.
 >
 > ##
 >

--- a/flow-typed/types/sources-config.js
+++ b/flow-typed/types/sources-config.js
@@ -15,5 +15,7 @@ declare type PKSourcesConfigObject = {
   duration?: number,
   startTime?: number,
   vr: ?Object,
-  imageSourceOptions?: ImageSourceOptions
+  imageSourceOptions?: ImageSourceOptions,
+  seekFrom?: number,
+  clipTo?: number
 };


### PR DESCRIPTION
### Description of the Changes

add new configurations under `PKSourcesConfigObject` object:
- `seekFrom` - optional, number, in sec
- `clipTo` - optional, number, in sec

if configured, the above will be chained to the `playManifest` request and as a result, the video will play from the seekFrom position to the clipTo position.

**For example:**
configuring the following: `seekFrom=10`, `clipTo=20`, where the video duration is 40 sec.
the duration of the video that will be played as a result, would be 10 sec long, where the first frame will be the same as the frame of the original video at position 10; and the end frame will be the same as the frame of the original video at position 20.

**related PR-** https://github.com/kaltura/kaltura-player-js/pull/658

Solves FEC-13420

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
