### PR TITLE
fix(SUP-39574): Enable captions button is not working

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -2611,7 +2611,7 @@ export default class Player extends FakeEventTarget {
       this._playbackAttributesState.audioLanguage ||
       this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
     if (!playbackConfig.captionsDisplay) {
-      this._playbackAttributesState.textLanguage = playbackConfig.textLanguage;
+      this._playbackAttributesState.textLanguage = defaultLanguage;
       this._setDefaultTrack<TextTrack>(this._getTextTracks(), OFF, offTextTrack);
     } else {
       if (currentOrConfiguredTextLang === playbackConfig.textLanguage) {


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when the textLanguage config is defined to "auto" and there is no previous language in the localSession when clicking on enable caption button nothing happen.

**root cause:**
trying to find track with "auto" language and not real language 

**the solution:**
when "captionsDisplay" is disabled change the attribute state to defaultLanguage (the playbackConfig.textLanguage after set the language for "auto")

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
