### PR TITLE
fix(SUP-40028): The playlist player freezes during the playback

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1498,7 +1498,7 @@ export default class Player extends FakeEventTarget {
   getThumbnail(time: number): ?ThumbnailInfo {
     if (this._externalThumbnailsHandler.isUsingVttThumbnails()) {
       return this._externalThumbnailsHandler.getThumbnail(time);
-    } else if (this._engine) {
+    } else if (this._engine && typeof this._engine.getThumbnail === 'function') {
       return this._engine.getThumbnail(time);
     }
     return null;


### PR DESCRIPTION
### Description of the Changes

**issue:**
the playlist player freezes when moving to youtube entry (when timeline plugin is loaded).

**solution:**
youtube doesn't have getThumbnail function, adding validation.

solves [SUP-40028](https://kaltura.atlassian.net/browse/SUP-40028)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-40028]: https://kaltura.atlassian.net/browse/SUP-40028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ