### PR TITLE
feat(FEC-13462): handle the playback rate after medialoaded event

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1831,6 +1831,8 @@ export default class Player extends FakeEventTarget {
     this._readyPromise = new Promise((resolve, reject) => {
       this._eventManager.listenOnce(this, CustomEventType.TRACKS_CHANGED, () => {
         this.dispatchEvent(new FakeEvent(CustomEventType.MEDIA_LOADED));
+        // handle playback rate after media loaded, to avoid race condition, so it won't be overwritten
+        this._handlePlaybackRate();
         resolve();
       });
       this._eventManager.listen(this, Html5EventType.ERROR, (event: FakeEvent) => {
@@ -1841,6 +1843,19 @@ export default class Player extends FakeEventTarget {
     }).catch(() => {
       // silence the promise rejection, error is handled by the error event
     });
+  }
+
+  /**
+   * Handles the playback rate.
+   * @private
+   * @returns {void}
+   */
+  _handlePlaybackRate(): void {
+    if (typeof this._playbackAttributesState.rate === 'number') {
+      this.playbackRate = this._playbackAttributesState.rate;
+    } else if (typeof this._config.playback.playbackRate === 'number') {
+      this.playbackRate = this._config.playback.playbackRate;
+    }
   }
 
   /**
@@ -2079,11 +2094,6 @@ export default class Player extends FakeEventTarget {
     }
     if (typeof this._config.playback.crossOrigin === 'string') {
       this.crossOrigin = this._config.playback.crossOrigin;
-    }
-    if (typeof this._playbackAttributesState.rate === 'number') {
-      this.playbackRate = this._playbackAttributesState.rate;
-    } else if (typeof this._config.playback.playbackRate === 'number') {
-      this.playbackRate = this._config.playback.playbackRate;
     }
     if (Array.isArray(this._config.playback.playbackRates)) {
       const validPlaybackRates = this._config.playback.playbackRates


### PR DESCRIPTION
### Description of the Changes

- handle the `playbackRate` after `medialoaded` event, in order to overcome race condition, where the playbackRate is being overwritten; the engine is re-initializing the playbackRate after the media is loaded.

Solves FEC-13462

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
