### PR TITLE
feat: support full webOS mediaOption object

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -467,13 +467,25 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           source.setAttribute('type', mimetype);
 
           if (this._config.useMediaOptionAttribute) {
-            const options = {};
-            options.option = {};
+            let options = {};
+            // https://webostv.developer.lge.com/develop/guides/mediaoption-parameter
+            if (this._config.mediaOptionAttribute) {
+              /**
+               * Undocumented option.
+               * Usage example:
+               * var video = document.querySelector('video');
+               * video.addEventListener("umsmediainfo", function(e) {
+               *     console.log(JSON.parse(e.detail));
+               * });
+               * {
+               *   useUMSMediaInfo: true
+               * }
+               **/
+              options = this._config.mediaOptionAttribute;
+            }
             if (this._config.abrEwmaDefaultEstimate) {
-              options.option.adaptiveStreaming = {};
-              options.option.adaptiveStreaming.bps = {
-                start: this._config.abrEwmaDefaultEstimate
-              };
+              const bps = {start: this._config.abrEwmaDefaultEstimate};
+              Utils.Object.createPropertyPath(options, 'option.adaptiveStreaming.bps', bps);
             }
             NativeAdapter._logger.debug('Setting mediaOption -', options);
             const mediaOption = encodeURI(JSON.stringify(options));


### PR DESCRIPTION
### Description of the Changes

if useMediaOptionAttribute is true then first take all mediaOptionAttribute which is an object that passes as is the webLG options as defined in https://webostv.developer.lge.com/develop/guides/mediaoption-parameter If abrEwmaDefaultEstimate is defined so it passes it as override on top of the mediaOption in the 'option.adaptiveStreaming.bps' object

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
