### PR TITLE
fix(ADA-82): Caption Texts are Not Showing when Moving Cursor in Time Bar

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1941,12 +1941,6 @@ export default class Player extends FakeEventTarget {
           this._isOnLiveEdge = this.duration && this.currentTime ? this.currentTime >= this.duration - LIVE_EDGE_THRESHOLD && !this.paused : false;
         }
       });
-      this._eventManager.listen(this._engine, Html5EventType.SEEKED, () => {
-        const browser = this._env.browser.name;
-        if (browser === 'Edge' || browser === 'IE') {
-          this._removeTextCuePatch();
-        }
-      });
       this._eventManager.listen(this._engine, CustomEventType.MEDIA_RECOVERED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.IMAGE_TRACK_CHANGED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.TEXT_TRACK_ADDED, (event: FakeEvent) => this.dispatchEvent(event));
@@ -2052,24 +2046,6 @@ export default class Player extends FakeEventTarget {
       this._activeTextCues[i].hasBeenReset = true;
     }
     this._updateTextDisplay(this._activeTextCues);
-  }
-
-  /**
-   * Handles the cue text removal issue, when seeking to a time without captions in IE \ edge the previous captions
-   * are not removed
-   * @returns {void}
-   * @private
-   */
-  _removeTextCuePatch(): void {
-    let filteredActiveTextCues = this._activeTextCues.filter(textCue => {
-      const cueEndTime = textCue._endTime;
-      const cueStartTime = textCue._startTime;
-      const currTime = this.currentTime;
-      if (currTime < cueEndTime && currTime > cueStartTime) {
-        return textCue;
-      }
-    });
-    this._updateTextDisplay(filteredActiveTextCues);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

**issue:**
In Edge browser when video is paused and captions enabled, when seeking in seekbar the caption are not displayed on the player.

**solution:**
The issue is caused by old fix made here - https://github.com/kaltura/playkit-js/pull/147 The original issue no longer reproducible so removed the old patch.

solves [ADA-82](https://kaltura.atlassian.net/browse/ADA-82)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-82]: https://kaltura.atlassian.net/browse/ADA-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ