### PR TITLE
fix: remove source tag before config is reset

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -630,7 +630,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
     NativeAdapter._logger.debug('destroy');
     return new Promise((resolve, reject) => {
       //must be called before super config cause it requires config which is reset in super destroy
-      this._removeSourceTag();
+      this._maybeRemoveSourceTag();
       super.destroy().then(
         () => {
           this._drmHandler && this._drmHandler.destroy();
@@ -659,11 +659,11 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
 
   /**
    * remove source tag
-   * @function _removeSourceTag
+   * @function _maybeRemoveSourceTag
    * @returns {void}
    * @private
    */
-  _removeSourceTag(): void {
+  _maybeRemoveSourceTag(): void {
     if (this._config.useSourceTag && this._videoElement) {
       const source = this._videoElement.firstChild;
       if (source) {

--- a/src/engines/html5/media-source/adapters/native-adapter.js
+++ b/src/engines/html5/media-source/adapters/native-adapter.js
@@ -629,20 +629,14 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
   destroy(): Promise<*> {
     NativeAdapter._logger.debug('destroy');
     return new Promise((resolve, reject) => {
+      //must be called before super config cause it requires config which is reset in super destroy
+      this._removeSourceTag();
       super.destroy().then(
         () => {
           this._drmHandler && this._drmHandler.destroy();
           this._waitingEventTriggered = false;
           this._progressiveSources = [];
           this._loadPromise = null;
-          if (this._config['useSourceTag'] && this._videoElement) {
-            const source = this._videoElement.firstChild;
-            if (source) {
-              Utils.Dom.setAttribute(source, 'src', '');
-              Utils.Dom.removeAttribute(source, 'src');
-              Utils.Dom.removeChild(this._videoElement, source);
-            }
-          }
           this._nativeTextTracksMap = {};
           this._loadPromiseReject = null;
           this._liveEdge = 0;
@@ -661,6 +655,23 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         () => reject
       );
     });
+  }
+
+  /**
+   * remove source tag
+   * @function _removeSourceTag
+   * @returns {void}
+   * @private
+   */
+  _removeSourceTag(): void {
+    if (this._config.useSourceTag && this._videoElement) {
+      const source = this._videoElement.firstChild;
+      if (source) {
+        Utils.Dom.setAttribute(source, 'src', '');
+        Utils.Dom.removeAttribute(source, 'src');
+        Utils.Dom.removeChild(this._videoElement, source);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

the logic of removing source tag depends on config which is reset in the super destroy method so need to run it before

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
