### PR TITLE
fix(SUP-40695): [SmartTV][Cetin's bug] Player_SmartTV_Samsung - An in…

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2421,7 +2421,7 @@ export default class Player extends FakeEventTarget {
    */
   public _updateTracks(tracks: Array<Track>): void {
     Player._logger.debug('Tracks changed', tracks);
-    this._tracks = tracks.concat(this._externalCaptionsHandler.getExternalTracks(tracks));
+    this._tracks = tracks?.concat(this._externalCaptionsHandler.getExternalTracks(tracks));
     this._applyABRRestriction(this._config);
     this._addTextTrackOffOption();
     this._maybeSetTracksLabels();


### PR DESCRIPTION
issue:
on smart tv when switch between channels fast  "Cannot read properties of undefined" error occurred

solution:
add a check if the variable exist