### PR TITLE
fix(FEC-13594): playlist with youtube blocks interaction with player

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -608,6 +608,17 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
+   * Disable native picture-in-picture for Firefox browser.
+   * @returns {void}
+   * @public
+   */
+  public disableNativePiPInFF(): void {
+    if (Env.browser.name === 'Firefox') {
+      this._el.setAttribute('disablePictureInPicture', 'true');
+    }
+  }
+
+  /**
    * Gets the view of the player (i.e the dom container object).
    * @return {HTMLElement} - The dom container.
    * @public
@@ -1792,6 +1803,9 @@ export default class Player extends FakeEventTarget {
       Utils.Dom.prependTo(engineEl, this._el);
       if (this._engine.id === 'youtube') {
         this._el.style.zIndex = '1';
+      } else if (this._el.style.zIndex) {
+        // in case the engine is not yt, need to remove the z-index value if exists
+        this._el.style.zIndex = '';
       }
     }
   }

--- a/src/player.ts
+++ b/src/player.ts
@@ -608,17 +608,6 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
-   * Disable native picture-in-picture for Firefox browser.
-   * @returns {void}
-   * @public
-   */
-  public disableNativePiPInFF(): void {
-    if (Env.browser.name === 'Firefox') {
-      this._el.setAttribute('disablePictureInPicture', 'true');
-    }
-  }
-
-  /**
    * Gets the view of the player (i.e the dom container object).
    * @return {HTMLElement} - The dom container.
    * @public


### PR DESCRIPTION
### Description of the Changes

- bug fix.

**the issue:**
when loading a playlist with youtube entry and media that has dualscreen, and playing the dualscreen media- the dualscreen player is not clickable. in addition, the interaction with the player gui area is also "blocked".

**root cause:**
we are adding `z-index = 1` to the engine element in case it is a youtube engine. when switching to the dual media (or just not a YT entry), it is blocking the interaction with the player in the gui area (play/pause), which includes blocking interaction with the secondary player (aka the dualscreen).

**solution:**
remove the value of `z-index` in case the engine is not youtube.

Solves FEC-13594

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
