### PR TITLE
feat(FEC-13664): Add the ability to configure default alignment of captions on the player #

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,6 @@ var config = {
   text: {
     enableCEA708Captions: true,
     useNativeTextTrack: false,
-    forceCenter: false,
     captionsTextTrack1Label: 'English',
     captionsTextTrack1LanguageCode: 'en',
     captionsTextTrack2Label: 'Spanish',
@@ -544,7 +543,6 @@ var config = {
 > {
 >  useNativeTextTrack: boolean,
 >  enableCEA708Captions: boolean,
->  forceCenter: boolean,
 >  textTrackDisplaySetting: PKTextTrackDisplaySettingObject,
 >  textStyle: TextStyle,
 >  captionsTextTrack1Label: string,
@@ -560,7 +558,6 @@ var config = {
 > {
 >  useNativeTextTrack: false,
 >  enableCEA708Captions: true,
->  forceCenter: false,
 >  captionsTextTrack1Label: "English",
 >  captionsTextTrack1LanguageCode: "en",
 >  captionsTextTrack2Label: "Spanish",
@@ -592,16 +589,6 @@ var config = {
 >
 > ##
 >
-> > ### config.text.forceCenter
-> >
-> > ##### Type: `Object`
-> >
-> > ##### Default: `false`
-> >
-> > ##### Description: set the forceCenter to true will override the position, align and size in textTrackDisplaySetting
->
-> ##
->
 > > ### config.text.textTrackDisplaySetting
 > >
 > > ##### Type: `PKTextTrackDisplaySettingObject`
@@ -616,7 +603,6 @@ var config = {
 > {
 >   line: string | number, // [-16 .. 16]
 >   lineAlign: string, // ['start', 'center', 'end']
->   align: string, // ['start', 'center', 'end', 'left', 'right']
 >   position: number, //[0 .. 100]
 >   positionAlign: string, // ['line-left', 'center', 'line-right']
 >   snapToLines: boolean, // [true, false]
@@ -632,10 +618,6 @@ var config = {
 > > ##### lineAlign
 > >
 > > An alignment for the cue box’s line, one of start/center/end alignment
-> >
-> > ##### align
-> >
-> > An alignment for all lines of text within the cue box, in the dimension of the writing direction
 > >
 > > ##### snapToLines
 > >
@@ -678,6 +660,7 @@ var config = {
 > > ```js
 > > {
 > >   fontSize?: '50%' | '75%' | '100%' | '200%' | '300%' | '400%'
+> >   textAlign?: string, // ['center', 'left', 'right']
 > >   fontScale?: -2 | -1 | 0 | 2 | 3 | 4
 > >   fontFamily?: string, // font family available in browser
 > >   fontColor?: [number, number, number], // RGB
@@ -692,6 +675,10 @@ var config = {
 > >   backgroundOpacity?: number // [0.0 .. 1.0]
 > > }
 > > ```
+> >
+> > ##### textAlign
+> >
+> > An alignment for all lines of text within the cue box, in the dimension of the writing direction
 > >
 > > ##### fontSize
 > >

--- a/flow-typed/types/text-config.js
+++ b/flow-typed/types/text-config.js
@@ -7,7 +7,6 @@ declare type PKTextConfigObject = {
   useNativeTextTrack: boolean,
   textTrackDisplaySetting: PKTextTrackDisplaySettingObject,
   textStyle: PKTextStyleObject,
-  forceCenter: boolean,
   captionsTextTrack1Label: string,
   captionsTextTrack1LanguageCode: string,
   captionsTextTrack2Label: string,

--- a/flow-typed/types/text-track-display-setting.js
+++ b/flow-typed/types/text-track-display-setting.js
@@ -2,7 +2,6 @@
 declare type PKTextTrackDisplaySettingObject = {
   line: string | number,
   lineAlign: string,
-  align: string,
   position: number,
   positionAlign: string,
   snapToLines: boolean,

--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -44,7 +44,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @type {?IMediaSourceAdapter}
    * @private
    */
-  _mediaSourceAdapter!: IMediaSourceAdapter | null;
+  private _mediaSourceAdapter!: IMediaSourceAdapter | null;
   /**
    * The player config object.
    * @type {Object}
@@ -260,6 +260,15 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       this._mediaSourceAdapter.destroy();
       this._mediaSourceAdapter = null;
     }
+  }
+
+  /**
+   * Get the engine mediaSourceAdapter
+   * @public
+   * @returns {IMediaSourceAdapter | null}
+   */
+  public get mediaSourceAdapter(): IMediaSourceAdapter | null {
+    return this._mediaSourceAdapter;
   }
 
   /**

--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -44,7 +44,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @type {?IMediaSourceAdapter}
    * @private
    */
-  private _mediaSourceAdapter!: IMediaSourceAdapter | null;
+  _mediaSourceAdapter!: IMediaSourceAdapter | null;
   /**
    * The player config object.
    * @type {Object}

--- a/src/engines/html5/media-source/base-media-source-adapter.ts
+++ b/src/engines/html5/media-source/base-media-source-adapter.ts
@@ -4,6 +4,7 @@ import Error from '../../../error/error';
 import { CustomEventType, Html5EventType } from '../../../event/event-type';
 import getLogger from '../../../utils/logger';
 import Track from '../../../track/track';
+import TextStyle from '../../../track/text-style';
 import VideoTrack from '../../../track/video-track';
 import AudioTrack from '../../../track/audio-track';
 import PKTextTrack from '../../../track/text-track';
@@ -175,6 +176,10 @@ export default class BaseMediaSourceAdapter extends FakeEventTarget implements I
   // eslint-disable-next-line
   public static canPlayType(mimeType: string, preferNative: boolean): boolean {
     return BaseMediaSourceAdapter._throwNotImplementedError('static canPlayType');
+  }
+
+  public applyTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName?: string): void {
+    return BaseMediaSourceAdapter._throwNotImplementedError('applyTextTrackStyles');
   }
 
   public load(): Promise<{ tracks: Track[] }> {

--- a/src/engines/html5/media-source/base-media-source-adapter.ts
+++ b/src/engines/html5/media-source/base-media-source-adapter.ts
@@ -178,6 +178,7 @@ export default class BaseMediaSourceAdapter extends FakeEventTarget implements I
     return BaseMediaSourceAdapter._throwNotImplementedError('static canPlayType');
   }
 
+  // eslint-disable-next-line
   public applyTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName?: string): void {
     return BaseMediaSourceAdapter._throwNotImplementedError('applyTextTrackStyles');
   }

--- a/src/player-config.js
+++ b/src/player-config.js
@@ -7,7 +7,6 @@ const DefaultConfig = {
   text: {
     enableCEA708Captions: true,
     useNativeTextTrack: false,
-    forceCenter: false,
     captionsTextTrack1Label: 'English',
     captionsTextTrack1LanguageCode: 'en',
     captionsTextTrack2Label: 'Spanish',

--- a/src/player.ts
+++ b/src/player.ts
@@ -120,6 +120,14 @@ const DURATION_OFFSET: number = 0.1;
  */
 const LIVE_EDGE_THRESHOLD: number = 1;
 
+// TODO: move custom subtitles styling into engines
+/**
+ *  Shaka player subtitles container class
+ *  @type {string}
+ *  @const
+ */
+const SHAKA_TEXT_CONTAINER_CLASSNAME = "shaka-text-container"
+
 /**
  * The HTML5 player class.
  * @classdesc
@@ -1482,6 +1490,10 @@ export default class Player extends FakeEventTarget {
         // align - backward compatibility || new caption alignment API || default value
         align: textTrackDisplaySetting?.align || textStyle?.textAlign || 'center'
       });
+      // backward compatibility for `text.forceCenter`
+      if (Utils.Object.getPropertyPath(this._config, 'text.forceCenter')) {
+        textDisplaySettings.align = 'center';
+      }
       this.setTextDisplaySettings(textDisplaySettings);
     }
     try {
@@ -1720,20 +1732,20 @@ export default class Player extends FakeEventTarget {
 
   private _applyCustomSubtitleStyles(): void {
     try {
-      const sheet = this._getSubtitleStyleSheet();
-
       if (this._config.text.useNativeTextTrack && !this._config.text.useShakaTextTrackDisplay) {
+        const sheet = this._getSubtitleStyleSheet();
         sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::-webkit-media-text-track-display { text-align: ${this._textStyle.textAlign}!important; }`, 0);
         sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::cue { ${this._textStyle.toCSS()} }`, 0);
       } else if (this._config.text.useShakaTextTrackDisplay) {
         this._resetCustomSubtitleStyles();
+        const sheet = this._getSubtitleStyleSheet();
         const flexAlignment = {
           left: 'flex-start',
           center: 'center',
           right: 'flex-end',
         }
-        sheet.insertRule(`#${this._playerId} .shaka-text-container { padding: 0px 16px; align-items: ${flexAlignment[this._textStyle.textAlign]}!important; }`, 0);
-        sheet.insertRule(`#${this._playerId} .shaka-text-container > * { ${this._textStyle.toCSS()} }`, 0);
+        sheet.insertRule(`#${this._playerId} .${SHAKA_TEXT_CONTAINER_CLASSNAME} { padding: 0px 16px; align-items: ${flexAlignment[this._textStyle.textAlign]}!important; }`, 0);
+        sheet.insertRule(`#${this._playerId} .${SHAKA_TEXT_CONTAINER_CLASSNAME} > * { ${this._textStyle.toCSS()} }`, 0);
       }
     } catch (e) {
       Player._logger.error(`Failed to add custom text style: ${e.message}`);

--- a/src/player.ts
+++ b/src/player.ts
@@ -1479,7 +1479,8 @@ export default class Player extends FakeEventTarget {
     if (textTrackDisplaySetting) {
       const textDisplaySettings: any = Utils.Object.mergeDeep({}, textTrackDisplaySetting, {
         position: 'auto',
-        align: textStyle?.textAlign || 'center' // overwrite cue align for if native text-tracks uses
+        // align - backward compatibility || new caption alignment API || default value
+        align: textTrackDisplaySetting?.align || textStyle?.textAlign || 'center'
       });
       this.setTextDisplaySettings(textDisplaySettings);
     }
@@ -1713,10 +1714,8 @@ export default class Player extends FakeEventTarget {
   }
 
   private _resetCustomSubtitleStyles(): void {
-    const sheet = this._getSubtitleStyleSheet();
-    while (sheet.cssRules.length) {
-      sheet.deleteRule(0);
-    }
+    const element = Utils.Dom.getElementBySelector(`.${this._playerId}.${SUBTITLES_STYLE_CLASS_NAME}`);
+    element?.remove();
   }
 
   private _applyCustomSubtitleStyles(): void {
@@ -1737,7 +1736,7 @@ export default class Player extends FakeEventTarget {
         sheet.insertRule(`#${this._playerId} .shaka-text-container > * { ${this._textStyle.toCSS()} }`, 0);
       }
     } catch (e) {
-      Player._logger.error(e.message);
+      Player._logger.error(`Failed to add custom text style: ${e.message}`);
     }
   }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -1724,7 +1724,7 @@ export default class Player extends FakeEventTarget {
 
   private _applyCustomSubtitleStyles(): void {
     // TODO: move custom subtitles styling into engines
-    const SHAKA_TEXT_CONTAINER_CLASSNAME = "shaka-text-container";
+    const SHAKA_TEXT_CONTAINER_CLASSNAME = 'shaka-text-container';
     try {
       const containerId = this._el?.parentElement?.id || this._playerId;
       if (this._config.text.useNativeTextTrack && !this._config.text.useShakaTextTrackDisplay) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -1723,7 +1723,7 @@ export default class Player extends FakeEventTarget {
     try {
       const sheet = this._getSubtitleStyleSheet();
 
-      if (this._config.text.useNativeTextTrack) {
+      if (this._config.text.useNativeTextTrack && !this._config.text.useShakaTextTrackDisplay) {
         sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::-webkit-media-text-track-display { text-align: ${this._textStyle.textAlign}!important; }`, 0);
         sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::cue { ${this._textStyle.toCSS()} }`, 0);
       } else if (this._config.text.useShakaTextTrackDisplay) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -471,7 +471,7 @@ export default class Player extends FakeEventTarget {
   public configure(config: any = {}): void {
     this._setConfigLogLevel(config);
     Utils.Object.mergeDeep(this._config, config);
-    this._applyTextTrackConfig(config);
+    this._applyTextTrackConfig();
     this._applyABRRestriction(config);
   }
 
@@ -1473,24 +1473,19 @@ export default class Player extends FakeEventTarget {
    * @param {Object} config - new config which configure for checking if it relevant config has changed
    * @private
    */
-  private _applyTextTrackConfig(config: any): void {
-    if (Utils.Object.hasPropertyPath(config, 'text.textTrackDisplaySetting') || Utils.Object.getPropertyPath(config, 'text.forceCenter')) {
-      let textDisplaySettings: any = {};
-      if (Utils.Object.hasPropertyPath(this._config, 'text.textTrackDisplaySetting')) {
-        textDisplaySettings = Utils.Object.mergeDeep(textDisplaySettings, this._config.text.textTrackDisplaySetting);
-      }
-      if (Utils.Object.getPropertyPath(this._config, 'text.forceCenter')) {
-        textDisplaySettings = Utils.Object.mergeDeep(textDisplaySettings, {
-          position: 'auto',
-          align: 'center',
-          size: '100'
-        });
-      }
+  private _applyTextTrackConfig(): void {
+    const textTrackDisplaySetting = Utils.Object.getPropertyPath(this._config, 'text.textTrackDisplaySetting');
+    const textStyle = Utils.Object.getPropertyPath(this._config, 'text.textStyle');
+    if (textTrackDisplaySetting) {
+      const textDisplaySettings: any = Utils.Object.mergeDeep({}, textTrackDisplaySetting, {
+        position: 'auto',
+        align: textStyle?.textAlign || 'center' // overwrite cue align for if native text-tracks uses
+      });
       this.setTextDisplaySettings(textDisplaySettings);
     }
     try {
-      if (Utils.Object.hasPropertyPath(config, 'text.textStyle')) {
-        this.textStyle = TextStyle.fromJson(this._config.text.textStyle);
+      if (textStyle) {
+        this.textStyle = TextStyle.fromJson(textStyle);
       }
     } catch (e) {
       Player._logger.warn(e);

--- a/src/player.ts
+++ b/src/player.ts
@@ -1708,7 +1708,7 @@ export default class Player extends FakeEventTarget {
       } else if (this._config.text.useShakaTextTrackDisplay) {
         resetSubtitleStyleSheet(this._playerId);
         const sheet = getSubtitleStyleSheet(this._playerId);
-        this._engine._mediaSourceAdapter?.applyTextTrackStyles?.(sheet, this._textStyle, containerId);
+        this._engine.mediaSourceAdapter?.applyTextTrackStyles?.(sheet, this._textStyle, containerId);
       }
     } catch (e) {
       Player._logger.error(`Failed to add custom text style: ${e.message}`);

--- a/src/player.ts
+++ b/src/player.ts
@@ -120,14 +120,6 @@ const DURATION_OFFSET: number = 0.1;
  */
 const LIVE_EDGE_THRESHOLD: number = 1;
 
-// TODO: move custom subtitles styling into engines
-/**
- *  Shaka player subtitles container class
- *  @type {string}
- *  @const
- */
-const SHAKA_TEXT_CONTAINER_CLASSNAME = "shaka-text-container"
-
 /**
  * The HTML5 player class.
  * @classdesc
@@ -1731,11 +1723,14 @@ export default class Player extends FakeEventTarget {
   }
 
   private _applyCustomSubtitleStyles(): void {
+    // TODO: move custom subtitles styling into engines
+    const SHAKA_TEXT_CONTAINER_CLASSNAME = "shaka-text-container";
     try {
+      const containerId = this._el?.parentElement?.id || this._playerId;
       if (this._config.text.useNativeTextTrack && !this._config.text.useShakaTextTrackDisplay) {
         const sheet = this._getSubtitleStyleSheet();
-        sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::-webkit-media-text-track-display { text-align: ${this._textStyle.textAlign}!important; }`, 0);
-        sheet.insertRule(`#${this._playerId} video.${ENGINE_CLASS_NAME}::cue { ${this._textStyle.toCSS()} }`, 0);
+        sheet.insertRule(`#${containerId} video.${ENGINE_CLASS_NAME}::-webkit-media-text-track-display { text-align: ${this._textStyle.textAlign}!important; }`, 0);
+        sheet.insertRule(`#${containerId} video.${ENGINE_CLASS_NAME}::cue { ${this._textStyle.toCSS()} }`, 0);
       } else if (this._config.text.useShakaTextTrackDisplay) {
         this._resetCustomSubtitleStyles();
         const sheet = this._getSubtitleStyleSheet();
@@ -1744,8 +1739,8 @@ export default class Player extends FakeEventTarget {
           center: 'center',
           right: 'flex-end',
         }
-        sheet.insertRule(`#${this._playerId} .${SHAKA_TEXT_CONTAINER_CLASSNAME} { padding: 0px 16px; align-items: ${flexAlignment[this._textStyle.textAlign]}!important; }`, 0);
-        sheet.insertRule(`#${this._playerId} .${SHAKA_TEXT_CONTAINER_CLASSNAME} > * { ${this._textStyle.toCSS()} }`, 0);
+        sheet.insertRule(`#${containerId} .${SHAKA_TEXT_CONTAINER_CLASSNAME} { padding: 0px 16px; align-items: ${flexAlignment[this._textStyle.textAlign]}!important; }`, 0);
+        sheet.insertRule(`#${containerId} .${SHAKA_TEXT_CONTAINER_CLASSNAME} > * { ${this._textStyle.toCSS()} }`, 0);
       }
     } catch (e) {
       Player._logger.error(`Failed to add custom text style: ${e.message}`);

--- a/src/player.ts
+++ b/src/player.ts
@@ -1708,8 +1708,6 @@ export default class Player extends FakeEventTarget {
       } else if (this._config.text.useShakaTextTrackDisplay) {
         resetSubtitleStyleSheet(this._playerId);
         const sheet = getSubtitleStyleSheet(this._playerId);
-        // eslint-disable-next-line  @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         this._engine._mediaSourceAdapter?.applyTextTrackStyles?.(sheet, this._textStyle, containerId);
       }
     } catch (e) {

--- a/src/track/external-captions-handler.ts
+++ b/src/track/external-captions-handler.ts
@@ -2,6 +2,7 @@ import Error from '../error/error';
 import * as Utils from '../utils/util';
 import {Parser, StringDecoder} from './text-track-display';
 import TextTrack, {getActiveCues} from './text-track';
+import TextStyle from './text-style';
 import Track from './track';
 import {CustomEventType, Html5EventType} from '../event/event-type';
 import { FakeEvent } from '../event/fake-event';
@@ -29,6 +30,12 @@ const SRT_POSTFIX: string = 'srt';
 const VTT_POSTFIX: string = 'vtt';
 
 class ExternalCaptionsHandler extends FakeEventTarget {
+
+  public static applyNativeTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName: string): void {
+    sheet.insertRule(`#${containerId} video.${engineClassName}::-webkit-media-text-track-display { text-align: ${styles.textAlign}!important; }`, 0);
+    sheet.insertRule(`#${containerId} video.${engineClassName}::cue { ${styles.toCSS()} }`, 0);
+  }
+
   /**
    * The external captions handler class logger.
    * @type {any}

--- a/src/track/text-style.ts
+++ b/src/track/text-style.ts
@@ -6,7 +6,7 @@
  * font size.
  * @type {number}
  */
-import {FontScaleOptions, FontSizeOptions, PKTextStyleObject} from '../types';
+import { FontScaleOptions, FontSizeOptions, PKTextStyleObject, FontAlignmentOptions } from '../types';
 
 const IMPLICIT_SCALE_PERCENTAGE: number = 0.25;
 
@@ -131,6 +131,24 @@ class TextStyle {
   ];
 
   /**
+   * Possible font alignments are left, center, right
+   */
+  public static FontAlignment: { label: string; value: FontAlignmentOptions }[] = [
+    {
+      label: 'Left',
+      value: 'left'
+    },
+    {
+      label: 'Center',
+      value: 'center'
+    },
+    {
+      label: 'Right',
+      value: 'right'
+    }
+  ];
+
+  /**
    * Creates a CSS RGBA sctring for a given color and opacity values
    * @param {TextStyle.StandardColors} color - color value in RGB
    * @param {TextStyle.StandardOpacities} opacity - opacity value
@@ -149,6 +167,7 @@ class TextStyle {
     const textStyle = new TextStyle();
     textStyle.fontEdge = getValue(setting.fontEdge, textStyle.fontEdge);
     textStyle.fontSize = getValue(setting.fontSize, textStyle.fontSize);
+    textStyle.textAlign = getValue(setting.textAlign, textStyle.textAlign);
     textStyle.fontScale = getValue(setting.fontScale, textStyle.fontScale);
     textStyle.fontColor = getValue(setting.fontColor, textStyle.fontColor);
     textStyle.fontOpacity = getValue(setting.fontOpacity, textStyle.fontOpacity);
@@ -162,6 +181,7 @@ class TextStyle {
     return {
       fontEdge: text.fontEdge,
       fontSize: text.fontSize,
+      textAlign: text.textAlign,
       fontScale: text.fontScale,
       fontColor: text.fontColor,
       fontOpacity: text.fontOpacity,
@@ -179,6 +199,8 @@ class TextStyle {
       this._fontSizeIndex = index;
     }
   }
+
+  public textAlign: FontAlignmentOptions = TextStyle.FontAlignment[1].value;
 
   /**
    * Percentage string matching a FontSizes entry
@@ -254,6 +276,7 @@ class TextStyle {
    */
   public toCSS(): string {
     const attributes: Array<string> = [];
+    attributes.push('text-align: ' + this.textAlign);
     attributes.push('font-family: ' + this.fontFamily);
     attributes.push('color: ' + TextStyle.toRGBA(this.fontColor, this.fontOpacity));
     attributes.push('background-color: ' + TextStyle.toRGBA(this.backgroundColor, this.backgroundOpacity));

--- a/src/track/text-track-display.ts
+++ b/src/track/text-track-display.ts
@@ -212,7 +212,7 @@ function parseCue(input, cue, regionList) {
             settings.percent(k, v);
             break;
           case 'align':
-            settings.alt(k, v, ['start', 'center', 'end', 'left', 'right']);
+            settings.alt(k, v, ['center', 'left', 'right']);
             break;
         }
       },
@@ -641,7 +641,7 @@ class CueStyleBox extends StyleBox {
     // mirrors of them except "middle" which is "center" in CSS.
     this.div = window.document.createElement('div');
     styles = {
-      textAlign: cue.align === 'middle' ? 'center' : cue.align,
+      textAlign: styleOptions.textAlign,
       font: styleOptions.font,
       whiteSpace: 'pre-line',
       position: 'absolute'
@@ -661,19 +661,14 @@ class CueStyleBox extends StyleBox {
     // position of the cue box. The reference edge will be resolved later when
     // the box orientation styles are applied.
     let textPos = 0;
-    let align = cue.positionAlign || cue.align;
-    switch (align) {
-      case 'start':
+    switch (styleOptions.textAlign) {
       case 'left':
-      case 'line-left':
         textPos = cue.position;
         break;
       case 'center':
         textPos = cue.position - cue.size / 2;
         break;
-      case 'end':
       case 'right':
-      case 'line-right':
         textPos = cue.position - cue.size;
         break;
     }
@@ -982,7 +977,6 @@ function convertCueToDOMTree(window, cuetext) {
 }
 
 const FONT_SIZE_PERCENT = 0.058;
-const FONT_STYLE = 'sans-serif';
 const CUE_BACKGROUND_PADDING = '1.5%';
 
 // Runs the processing model over the cues and regions passed to it.
@@ -1033,6 +1027,7 @@ function processCues(window, cues, overlay, style) {
     fontSize = Math.round(dimensionSize * FONT_SIZE_PERCENT * 100) / 100;
   let styleOptions = {
     font: fontSize * fontScale * style.implicitFontScale + 'px ' + style.fontFamily,
+    textAlign: style.textAlign,
     color: TextStyle.toRGBA(style.fontColor, style.fontOpacity),
     backgroundColor: TextStyle.toRGBA(style.backgroundColor, style.backgroundOpacity),
     textShadow: style.getTextShadow()

--- a/src/track/track.ts
+++ b/src/track/track.ts
@@ -30,7 +30,7 @@ export default class Track {
   private static _langComparer(inputLanguages: [string, (string | undefined)], trackLang: string, equal?: boolean): boolean {
     //first check is there is a complete match
     for(const language of inputLanguages) {
-      if(language?.trim() !== "") {
+      if(language?.trim() !== '') {
         if (equal) {
           if(this._isLangEqual(language, trackLang))
             return true;

--- a/src/types/interfaces/engine.ts
+++ b/src/types/interfaces/engine.ts
@@ -10,6 +10,7 @@ import {PKDrmDataObject} from '../drm-data';
 import {PKABRRestrictionObject} from '../restrictions-types';
 import Track from '../../track/track';
 import {PKTextTrack} from '../../track/text-track';
+import {IMediaSourceAdapter} from '../../types';
 
 export interface IEngineStatic {
   id: string;
@@ -86,4 +87,5 @@ export interface IEngine extends FakeEventTarget {
   crossOrigin: string | null
   targetBuffer: number;
   availableBuffer: number;
+  _mediaSourceAdapter: IMediaSourceAdapter | null;
 }

--- a/src/types/interfaces/engine.ts
+++ b/src/types/interfaces/engine.ts
@@ -87,5 +87,5 @@ export interface IEngine extends FakeEventTarget {
   crossOrigin: string | null
   targetBuffer: number;
   availableBuffer: number;
-  _mediaSourceAdapter: IMediaSourceAdapter | null;
+  mediaSourceAdapter: IMediaSourceAdapter | null;
 }

--- a/src/types/interfaces/media-source-adapter.ts
+++ b/src/types/interfaces/media-source-adapter.ts
@@ -1,16 +1,16 @@
-
 import VideoTrack from '../../track/video-track';
 import AudioTrack from '../../track/audio-track';
-import { PKTextTrack} from '../../track/text-track';
-import {PKDrmConfigObject} from '../drm-config';
-import {PKMediaSourceCapabilities} from '../media-source-capabilities';
-import {PKMediaSourceObject} from '../media-source';
+import { PKTextTrack } from '../../track/text-track';
+import { PKDrmConfigObject } from '../drm-config';
+import { PKMediaSourceCapabilities } from '../media-source-capabilities';
+import { PKMediaSourceObject } from '../media-source';
 import ImageTrack from '../../track/image-track';
-import {PKDrmDataObject} from '../drm-data';
+import { PKDrmDataObject } from '../drm-data';
 import { FakeEventTarget } from '../../event/fake-event-target';
-import {ThumbnailInfo} from '../../thumbnail/thumbnail-info';
+import { ThumbnailInfo } from '../../thumbnail/thumbnail-info';
 import Track from '../../track/track';
-import {PKABRRestrictionObject} from '../restrictions-types';
+import TextStyle from '../../track/text-style';
+import { PKABRRestrictionObject } from '../restrictions-types';
 
 export interface IMediaSourceAdapterStatic {
   id: string;
@@ -26,7 +26,7 @@ export interface IMediaSourceAdapter extends FakeEventTarget {
   liveDuration: number;
   capabilities: PKMediaSourceCapabilities;
   targetBuffer: number;
-  load(startTime?: number): Promise<{tracks: Track[]}>;
+  load(startTime?: number): Promise<{ tracks: Track[] }>;
   handleMediaError(error?: MediaError): boolean;
   destroy(): Promise<any>;
   selectVideoTrack(videoTrack: VideoTrack): void;
@@ -45,7 +45,8 @@ export interface IMediaSourceAdapter extends FakeEventTarget {
   detachMediaSource(): void;
   getSegmentDuration(): number;
   disableNativeTextTracks(): void;
-  getThumbnail(time: number): ThumbnailInfo | null
+  getThumbnail(time: number): ThumbnailInfo | null;
   getDrmInfo(): PKDrmDataObject | null;
   applyABRRestriction(restriction: PKABRRestrictionObject): void;
+  applyTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName?: string): void;
 }

--- a/src/types/text-config.ts
+++ b/src/types/text-config.ts
@@ -7,7 +7,6 @@ export interface PKTextConfigObject {
   useNativeTextTrack: boolean;
   textTrackDisplaySetting: PKTextTrackDisplaySettingObject;
   textStyle: PKTextStyleObject;
-  forceCenter: boolean;
   captionsTextTrack1Label: string;
   captionsTextTrack1LanguageCode: string;
   captionsTextTrack2Label: string;

--- a/src/types/text-style.ts
+++ b/src/types/text-style.ts
@@ -1,4 +1,5 @@
 export type FontSizeOptions = '50%' | '75%' | '100%' | '200%' | '300%' | '400%';
+export type FontAlignmentOptions = 'left' | 'center' | 'right';
 export type FontScaleOptions = -2 | -1 | 0 | 2 | 3 | 4;
 /**
  * @typedef {Object} PKTextStyleObject
@@ -12,12 +13,13 @@ export type FontScaleOptions = -2 | -1 | 0 | 2 | 3 | 4;
  * @property {number} backgroundOpacity=1
  */
 export type PKTextStyleObject = {
-  fontSize: FontSizeOptions,
-  fontScale: FontScaleOptions,
-  fontFamily: string,
-  fontColor: [number, number, number],
-  fontOpacity: number,
-  fontEdge: Array<[number, number, number, number, number, number]>,
-  backgroundColor: [number, number, number],
-  backgroundOpacity: number
+  fontSize: FontSizeOptions;
+  textAlign: FontAlignmentOptions;
+  fontScale: FontScaleOptions;
+  fontFamily: string;
+  fontColor: [number, number, number];
+  fontOpacity: number;
+  fontEdge: Array<[number, number, number, number, number, number]>;
+  backgroundColor: [number, number, number];
+  backgroundOpacity: number;
 };

--- a/src/types/text-track-display-setting.ts
+++ b/src/types/text-track-display-setting.ts
@@ -1,7 +1,6 @@
 export type PKTextTrackDisplaySettingObject = {
   line: string | number,
   lineAlign: string,
-  align: string,
   position: number,
   positionAlign: string,
   snapToLines: boolean,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './util';
-export {ResizeWatcher} from './resize-watcher';
-export {MultiMap} from './multi-map';
-export {binarySearch} from './binary-search';
+export { ResizeWatcher } from './resize-watcher';
+export { MultiMap } from './multi-map';
+export { binarySearch } from './binary-search';
+export * from './styles';

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,0 +1,24 @@
+import * as Utils from './util';
+
+/**
+ * The text style class name.
+ * @type {string}
+ * @const
+ */
+const SUBTITLES_STYLE_CLASS_NAME: string = 'playkit-subtitles-style';
+
+export const getSubtitleStyleSheet = (playerId: string): CSSStyleSheet => {
+  let element = Utils.Dom.getElementBySelector(`.${playerId}.${SUBTITLES_STYLE_CLASS_NAME}`);
+  if (!element) {
+    element = Utils.Dom.createElement('style');
+    Utils.Dom.addClassName(element, playerId);
+    Utils.Dom.addClassName(element, SUBTITLES_STYLE_CLASS_NAME);
+    Utils.Dom.appendChild(document.head, element);
+  }
+  return element.sheet;
+};
+
+export const resetSubtitleStyleSheet = (playerId: string): void => {
+  const element = Utils.Dom.getElementBySelector(`.${playerId}.${SUBTITLES_STYLE_CLASS_NAME}`);
+  element?.remove();
+};

--- a/tests/e2e/player.spec.js
+++ b/tests/e2e/player.spec.js
@@ -1667,6 +1667,7 @@ describe('Player', function () {
         const settings = {
           fontEdge: TextStyle.EdgeStyles.RAISED,
           fontSize: '75%',
+          textAlign: "center",
           fontScale: -1,
           fontColor: TextStyle.StandardColors.CYAN,
           fontOpacity: TextStyle.StandardOpacities.SEMI_LOW,
@@ -1724,36 +1725,25 @@ describe('Player', function () {
 
     describe('configure text track display', () => {
       it('should change textDisplay settings by config', () => {
-        const settings = {line: -4};
-        player = new Player({text: {textTrackDisplaySetting: settings}});
-        player._textDisplaySettings.should.deep.equal(settings);
-      });
-
-      it('should forceCenter override textTrackDisplaySetting', () => {
-        const settings = {position: '10%', align: 'left', size: '10'};
-        player = new Player({text: {forceCenter: true, textTrackDisplaySetting: settings}});
-        player._textDisplaySettings.should.deep.equal({position: 'auto', align: 'center', size: '100'});
-      });
-
-      it('should forceCenter keep the other values from textTrackDisplaySetting', () => {
-        const settings = {line: '-4', lineAlign: 'end', position: '10%'};
-        player = new Player({text: {forceCenter: true, textTrackDisplaySetting: settings}});
-        player._textDisplaySettings.should.deep.equal(Utils.Object.mergeDeep(settings, {position: 'auto', align: 'center', size: '100'}));
-      });
-
-      it('should configure change of textTrackDisplaySetting will apply forceCenter', () => {
-        const settings = {position: '10%', align: 'left', size: '10'};
-        player = new Player({text: {forceCenter: true, textTrackDisplaySetting: settings}});
-        player.configure({text: {textTrackDisplaySetting: settings}});
-        player._textDisplaySettings.should.deep.equal({position: 'auto', align: 'center', size: '100'});
+        const textTrackDisplaySetting = {line: -4};
+        player = new Player({text: {textTrackDisplaySetting}});
+        player._textDisplaySettings.should.deep.equal({
+          ...textTrackDisplaySetting,
+          align: "center",
+          position: "auto"
+        });
       });
 
       it('should empty configure will not take the previous config and change the values from setTextDisplaySettings', () => {
-        const settings = {position: '10%', align: 'left', size: '10'};
-        player = new Player({text: {forceCenter: true, textTrackDisplaySetting: settings}});
+        const settings = {position: '10%', size: '10'};
+        player = new Player({text: {textTrackDisplaySetting: settings}});
         player.setTextDisplaySettings(settings);
         player.configure({text: {}});
-        player._textDisplaySettings.should.deep.equal(settings);
+        player._textDisplaySettings.should.deep.equal({
+          ...settings,
+          align: "center",
+          position: "auto"
+        });
       });
 
       it('should keep the current setting for empty config', () => {


### PR DESCRIPTION
### Description of the Changes

1. Add `textAlign`: string (left/right/center) property to `config.text.textStyle`;
2. Remove `align` option form `config.text.textTrackDisplaySetting`;
3. Remove `forceCenter` option from `config.text`
4. upd documentation;
5. handle caption alignment based on `config.text.textStyle.textAlign` configuration;
6. upd tests;

<img width="1043" alt="image" src="https://github.com/kaltura/playkit-js/assets/51074448/aa3fca8f-977b-4c2e-a9d7-1c10dbb6887c">


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
