### PR TITLE
fix(SUP-43040): v7 player issues when using picture-in-picture (pop-out)

### DIFF
--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -559,7 +559,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       // Currently it's supported in chrome and in safari. So if we consider checking support before,
       // we can use this flag to distinguish between the two. In the future we might need a different method.
       // Second condition is because flow does not support this API yet
-      if (document.pictureInPictureEnabled && !this._el.disablePictureInPicture && typeof this._el.requestPictureInPicture === 'function') {
+      if (document.pictureInPictureEnabled && typeof this._el.requestPictureInPicture === 'function' && !this._el.disablePictureInPicture) {
         this._el.requestPictureInPicture().catch(error => {
           this.dispatchEvent(
             new FakeEvent(

--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -559,7 +559,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
       // Currently it's supported in chrome and in safari. So if we consider checking support before,
       // we can use this flag to distinguish between the two. In the future we might need a different method.
       // Second condition is because flow does not support this API yet
-      if (document.pictureInPictureEnabled && typeof this._el.requestPictureInPicture === 'function') {
+      if (document.pictureInPictureEnabled && !this._el.disablePictureInPicture && typeof this._el.requestPictureInPicture === 'function') {
         this._el.requestPictureInPicture().catch(error => {
           this.dispatchEvent(
             new FakeEvent(


### PR DESCRIPTION
### Description of the Changes

**Issue:**
In dual screen player the pip option is disabled by adding disablePictureInPicture on the video element. was done here - [FEC-13591](https://kaltura.atlassian.net/browse/FEC-13591).
As a result from that when clicking on the pip button error is thrown and the video is frozen

**Solution:**
Call to pip function only if disablePictureInPicture is not true

Solves [SUP-43040](https://kaltura.atlassian.net/browse/SUP-43040)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-13591]: https://kaltura.atlassian.net/browse/FEC-13591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUP-43040]: https://kaltura.atlassian.net/browse/SUP-43040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ