### PR TITLE
fix(ADA-6): v7 player (accessibility) - Frames for Video Players Aren't Labeled

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2020,7 +2020,7 @@ export default class Player extends FakeEventTarget {
         title = Utils.Dom.createElement('title');
         head.appendChild(title);
       }
-      title.innerHTML = this._sources.metadata.name;
+      title.innerHTML = this._sources.metadata.name ? this._sources.metadata.name : '';
     }
   }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -2013,13 +2013,15 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   private _addTitleOnIframe(): void {
-    const head = Utils.Dom.getElementBySelector('head');
-    let title = head.querySelector('title');
-    if (!title){
-      title = Utils.Dom.createElement('title');
-      head.appendChild(title);
+    if (window.self !== window.top) {
+      const head = Utils.Dom.getElementBySelector('head');
+      let title = head.querySelector('title');
+      if (!title){
+        title = Utils.Dom.createElement('title');
+        head.appendChild(title);
+      }
+      title.innerHTML = this._sources.metadata.name;
     }
-    title.innerHTML = this._sources.metadata.name;
   }
 
   /**

--- a/src/player.ts
+++ b/src/player.ts
@@ -1968,6 +1968,7 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listen(this._engine, CustomEventType.DRM_LICENSE_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.MANIFEST_LOADED, (event: FakeEvent) => this.dispatchEvent(event));
       this._eventManager.listen(this._engine, CustomEventType.MEDIA_RECOVERED, () => this._handleRecovered());
+      this._eventManager.listen(this, CustomEventType.CHANGE_SOURCE_ENDED, () => this._addTitleOnIframe());
       this._eventManager.listen(this, Html5EventType.PLAY, this._onPlay.bind(this));
       this._eventManager.listen(this, Html5EventType.PAUSE, this._onPause.bind(this));
       this._eventManager.listen(this, Html5EventType.PLAYING, this._onPlaying.bind(this));
@@ -2004,6 +2005,21 @@ export default class Player extends FakeEventTarget {
         );
       }
     }
+  }
+
+  /**
+   * In iframe embed add title element with the entry name
+   * @returns {void}
+   * @private
+   */
+  private _addTitleOnIframe(): void {
+    const head = Utils.Dom.getElementBySelector('head');
+    let title = head.querySelector('title');
+    if (!title){
+      title = Utils.Dom.createElement('title');
+      head.appendChild(title);
+    }
+    title.innerHTML = this._sources.metadata.name;
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

Please add a detailed description of the change, whether it's an enhancement or a bugfix.
If the PR is related to an open issue please link to it.

**Issue:**
Iframe elements are labeled with uiConf/xxxxxx (the last parameter in the src url) in iframe lists (on screen readers) and not name.

**Solution:**
Add title element with the entry name

Solves [ADA-6](https://kaltura.atlassian.net/browse/ADA-6)

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-6]: https://kaltura.atlassian.net/browse/ADA-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ