### PR TITLE
fix(FEC-14058): Playlist - Loading Youtube and Image entries throws an error

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -1918,8 +1918,7 @@ export default class Player extends FakeEventTarget {
     this._engine = this._engineDecoratorManager ? (new EngineDecorator(engine, this._engineDecoratorManager) as EngineDecoratorType) : engine;
 
     if (this._cachedUrls.length) {
-      this._engine.setCachedUrls(this._cachedUrls);
-      this._cachedUrls = [];
+      this.setCachedUrls(this._cachedUrls);
     }
   }
 
@@ -2881,7 +2880,7 @@ export default class Player extends FakeEventTarget {
   public setCachedUrls(cachedUrls: string[]): void {
     this._cachedUrls = cachedUrls;
 
-    if (this._engine) {
+    if (this._engine && this._engine.setCachedUrls) {
       this._engine.setCachedUrls(cachedUrls);
       this._cachedUrls = [];
     }


### PR DESCRIPTION
### Description of the Changes

Add validation for call to engine setCachedUrls, since non html5 engines don't have this API

Resolves FEC-14058

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
