### PR TITLE
fix(SUP-38407): [GaTech] [Multistream - V7 Player] Child entries not loading high quality flavor assets

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -1869,7 +1869,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   private _selectEngineByPriority(): boolean {
-    const streamPriority = this._config.playback?.streamPriority || [];
+    const streamPriority = this._config.playback.streamPriority;
     const preferNative = this._config.playback.preferNative;
     const sources = this._sources;
     for (const priority of streamPriority) {

--- a/src/player.ts
+++ b/src/player.ts
@@ -1280,6 +1280,13 @@ export default class Player extends FakeEventTarget {
     });
   }
 
+  /**
+   * change quality in child entries
+   * @function changeChildQuality
+   * @param {?Track} track - the track to change
+   * @returns {void}
+   * @public
+   */
   public changeChildQuality(track: any | string): void{
     if (track === 'auto') {
       this.enableAdaptiveBitrate();

--- a/src/player.ts
+++ b/src/player.ts
@@ -1280,6 +1280,15 @@ export default class Player extends FakeEventTarget {
     });
   }
 
+  public changeChildQuality(track: any | string): void{
+    if (track === 'auto') {
+      this.enableAdaptiveBitrate();
+    } else {
+      this.selectTrack(track);
+    }
+    this._markActiveTrack(track);
+  }
+
   /**
    * Select a track
    * @function selectTrack
@@ -1860,7 +1869,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   private _selectEngineByPriority(): boolean {
-    const streamPriority = this._config.playback.streamPriority;
+    const streamPriority = this._config.playback?.streamPriority || [];
     const preferNative = this._config.playback.preferNative;
     const sources = this._sources;
     for (const priority of streamPriority) {


### PR DESCRIPTION
### Description of the Changes

Add function to change quality on child entries in dual screen.

part of - https://github.com/kaltura/playkit-js-dual-screen/pull/155

solves [SUP-38407](https://kaltura.atlassian.net/browse/SUP-38407)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-38407]: https://kaltura.atlassian.net/browse/SUP-38407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ