### PR TITLE
fix(SUP-38407): [GaTech] [Multistream - V7 Player] Child entries not loading high quality flavor assets

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -1281,13 +1281,13 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
-   * change quality in child entries
-   * @function changeChildQuality
+   * change quality
+   * @function changeQuality
    * @param {?Track} track - the track to change
    * @returns {void}
    * @public
    */
-  public changeChildQuality(track: any | string): void{
+  public changeQuality(track: any | string): void{
     if (track === 'auto') {
       this.enableAdaptiveBitrate();
     } else {


### PR DESCRIPTION
### Description of the Changes

rename function from - https://github.com/kaltura/playkit-js/pull/793
part of - https://github.com/kaltura/playkit-js-dual-screen/pull/155

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
