### PR TITLE
fix(SUP-44939): [Player] Numeric Position not working on left-positioned captions, AWS

### DIFF
--- a/src/track/text-track-display.ts
+++ b/src/track/text-track-display.ts
@@ -665,8 +665,9 @@ class CueStyleBox extends StyleBox {
     // position of the cue box. The reference edge will be resolved later when
     // the box orientation styles are applied.
     let textPos = 0;
+    let align = cue.positionAlign || cue.align;
     if (useDefaultAlignment) {
-      switch (styleOptions.textAlign) {
+      switch (align) {
         case 'start':
         case 'left':
         case 'line-left':


### PR DESCRIPTION
issue: 
when use position configuration under text-> textTrackDisplaySetting the configuration is not apply

solution:
change the align is being checked when put the position from styleText configuration to textTrackDisplaySetting configuration

* regression from version 3.17.13

solved [SUP-44939](https://kaltura.atlassian.net/browse/SUP-44939)


[SUP-44939]: https://kaltura.atlassian.net/browse/SUP-44939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ