### PR TITLE
fix(SUP-37490): Align captions with clipTo/SeekFrom Values in PlayManifest

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2919,10 +2919,10 @@ export default class Player extends FakeEventTarget {
   }
 
   public setSeekFrom(seekFrom: number): void {
-    this._externalCaptionsHandler?.setSeekFrom(seekFrom);
+    this._externalCaptionsHandler.seekFrom = seekFrom;
   }
 
   public setClipTo(clipTo: number): void {
-    this._externalCaptionsHandler?.setClipTo(clipTo);
+    this._externalCaptionsHandler.clipTo = clipTo;
   }
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -2917,4 +2917,12 @@ export default class Player extends FakeEventTarget {
       this._cachedUrls = [];
     }
   }
+
+  public setCuesTimeRangeStart(cueRangeStart: number): void {
+    this._externalCaptionsHandler?.setCuesTimeRangeStart(cueRangeStart);
+  }
+
+  public setCuesTimeRangeEnd(cueRangeEnd: number): void {
+    this._externalCaptionsHandler?.setCuesTimeRangeEnd(cueRangeEnd);
+  }
 }

--- a/src/player.ts
+++ b/src/player.ts
@@ -2918,11 +2918,11 @@ export default class Player extends FakeEventTarget {
     }
   }
 
-  public setCuesTimeRangeStart(cueRangeStart: number): void {
-    this._externalCaptionsHandler?.setCuesTimeRangeStart(cueRangeStart);
+  public setSeekFrom(seekFrom: number): void {
+    this._externalCaptionsHandler?.setSeekFrom(seekFrom);
   }
 
-  public setCuesTimeRangeEnd(cueRangeEnd: number): void {
-    this._externalCaptionsHandler?.setCuesTimeRangeEnd(cueRangeEnd);
+  public setClipTo(clipTo: number): void {
+    this._externalCaptionsHandler?.setClipTo(clipTo);
   }
 }

--- a/src/track/external-captions-handler.ts
+++ b/src/track/external-captions-handler.ts
@@ -86,13 +86,13 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    */
   private _lastTimeUpdate: number = 0;
   /**
-   * when normalizing cues, this will be the new start time
+   * when normalizing cues, this will be the new cue time range start time
    */
-  private _cuesTimeRangeStart = -1;
+  private _seekFrom = -1;
   /**
-   * when normalizing cues, this will be the new end time
+   * when normalizing cues, this will be the new cue time range end time
    */
-  private _cuesTimeRangeEnd = -1;
+  private _clipTo = -1;
 
   /**
    * constructor
@@ -297,8 +297,8 @@ class ExternalCaptionsHandler extends FakeEventTarget {
    * @returns {void}
    */
   public reset(): void {
-    this._cuesTimeRangeStart = -1;
-    this._cuesTimeRangeEnd = -1;
+    this._seekFrom = -1;
+    this._clipTo = -1;
     this._resetCurrentTrack();
     this._textTrackModel = {} as VTTCue;
     this._resetExternalNativeTextTrack();
@@ -618,31 +618,31 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     return cuePoints.filter((cp: any) => cp.startTime >= seekFrom && (!clipTo || cp.startTime < clipTo));
   }
 
-  public setCuesTimeRangeStart(cuesTimeRangeStart: number): void {
-    this._cuesTimeRangeStart = cuesTimeRangeStart;
+  public setSeekFrom(seekFrom: number): void {
+    this._seekFrom = seekFrom;
   }
 
-  public setCuesTimeRangeEnd(cuesTimeRangeEnd: number): void {
-    this._cuesTimeRangeEnd = cuesTimeRangeEnd;
+  public setClipTo(clipTo: number): void {
+    this._clipTo = clipTo;
   }
 
   /**
-   * Translate the cues between [cue seek range start, cue seek range end] into a time range that starts from 0.
+   * Translate the cues between [seekFrom, clipTo] into a time range that starts from 0.
    * @param {TextTrack} textTrack - text track to be set
    * @returns {void}
    * @private
    */
   private _filterAndShiftCues(cuesArray: any[]): any[] {
     if (!cuesArray || !cuesArray.length) return [];
-    if (this._cuesTimeRangeStart === -1 && this._cuesTimeRangeEnd === -1) return cuesArray;
+    if (this._seekFrom === -1 && this._clipTo === -1) return cuesArray;
 
-    const cuesTimeRangeStart = this._cuesTimeRangeStart === -1 ? 0 : this._cuesTimeRangeStart;
-    const cuesTimeRangeEnd = this._cuesTimeRangeEnd === -1 ? undefined : this._cuesTimeRangeEnd;
+    const seekFrom = this._seekFrom === -1 ? 0 : this._seekFrom;
+    const clipTo = this._clipTo === -1 ? undefined : this._clipTo;
 
-    const filteredCues = this._filterCuePointsOutOfVideoRange(cuesArray, cuesTimeRangeStart, cuesTimeRangeEnd);
+    const filteredCues = this._filterCuePointsOutOfVideoRange(cuesArray, seekFrom, clipTo);
     filteredCues.forEach((cp: any) => {
-      cp.startTime = cp.startTime - cuesTimeRangeStart;
-      cp.endTime = cp.endTime - cuesTimeRangeStart;
+      cp.startTime = cp.startTime - seekFrom;
+      cp.endTime = cp.endTime - seekFrom;
     });
 
     return filteredCues;

--- a/src/track/external-captions-handler.ts
+++ b/src/track/external-captions-handler.ts
@@ -618,11 +618,11 @@ class ExternalCaptionsHandler extends FakeEventTarget {
     return cuePoints.filter((cp: any) => cp.startTime >= seekFrom && (!clipTo || cp.startTime < clipTo));
   }
 
-  public setSeekFrom(seekFrom: number): void {
+  public set seekFrom(seekFrom: number) {
     this._seekFrom = seekFrom;
   }
 
-  public setClipTo(clipTo: number): void {
+  public set clipTo(clipTo: number) {
     this._clipTo = clipTo;
   }
 


### PR DESCRIPTION
### Description of the Changes

- Add a new API for the player to set [seekFrom, clipTo] values

If seekFrom or clipTo are set
- Filter caption cues outside the [seekFrom, clipTo] range
- Translate the cues within the [seekFrom, clipTo] range into a time range that starts from 0

Related PR: https://github.com/kaltura/kaltura-player-js/pull/876

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
