### PR TITLE
fix(ADA-1778): [ORS] - Firefox playerkit - Focusable but hidden/unlabeled elements in tabbing order

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -1808,6 +1808,7 @@ export default class Player extends FakeEventTarget {
       const classNameWithId = `${ENGINE_CLASS_NAME}-${this._engine.id}`;
       Utils.Dom.addClassName(engineEl, classNameWithId);
       Utils.Dom.prependTo(engineEl, this._el);
+      Utils.Dom.setAttribute(engineEl, 'tabindex', '-1');
       if (this._engine.id === 'youtube') {
         this._el.style.zIndex = '1';
       } else if (this._el.style.zIndex) {


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When enable the "Show Tabbing Order" in Firefox browser, tab marker is shown on the video element.
<img width="325" alt="Screenshot_2" src="https://github.com/user-attachments/assets/60e549ce-ae3d-4374-9360-1da819c04c9b">


**Fix:**
Add tabIndex="-1" on the video element

solves [ADA-1788](https://kaltura.atlassian.net/browse/ADA-1788)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[ADA-1788]: https://kaltura.atlassian.net/browse/ADA-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ