### PR TITLE
fix(SUP-45003): [IKEA Ingka] - past scheduled embedded entries will show a wrong error message for V7 player

### DIFF
--- a/src/error/category.ts
+++ b/src/error/category.ts
@@ -44,7 +44,13 @@ const Category: CategoryType = {
   MEDIA_UNAVAILABLE: 14,
 
   /** IP restriction error. */
-  IP_RESTRICTED: 15
+  IP_RESTRICTED: 15,
+
+  /** Scheduled restriction error. */
+  SITE_RESTRICTED: 16,
+
+  /** Scheduled restriction error. */
+  SCHEDULED_RESTRICTED: 17
 };
 
 export {Category};


### PR DESCRIPTION
Adding error category to site restriction and scheduled restriction

Part of - https://github.com/kaltura/playkit-js-ui/pull/970, https://github.com/kaltura/kaltura-player-js/pull/897, https://github.com/kaltura/playkit-js-providers/pull/245

Resolves [SUP-45003](https://kaltura.atlassian.net/browse/SUP-45003)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-45003]: https://kaltura.atlassian.net/browse/SUP-45003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ