### PR TITLE
fix (SUP-46985): Replay button unresponsive when PiP is activated

### DIFF
--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -519,6 +519,14 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @returns {?Promise<*>} - play promise
    */
   public play(): Promise<void> {
+    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    if (isSafari) {
+      if (this._el.currentTime >= this._el.duration - 0.1 || this._el.ended) {
+        this._el.pause();
+        this._el.currentTime = 0;
+      }
+    }
+
     const playPromise = this._el.play();
     if (playPromise) {
       playPromise.catch((err) => this.dispatchEvent(new FakeEvent(CustomEventType.PLAY_FAILED, { error: err })));

--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -19,7 +19,7 @@ import { CapabilityResult, ICapability } from '../../types';
 import { PKABRRestrictionObject, PKDrmConfigObject, PKDrmDataObject, PKMediaSourceObject, PKVideoElementStore } from '../../types';
 import { IEngine } from '../../types';
 import Track from '../../track/track';
-import { Env } from '../../../src/playkit';
+import Env from '../../../src/utils/env';
 
 const SHORT_BUFFERING_TIMEOUT: number = 200;
 
@@ -526,7 +526,6 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     const durationMs = Math.round(this._el.duration * 1000);
 
     if (currentTimeMs >= durationMs || this._el.ended) {
-      this._el.pause();
       this._el.currentTime = 0;
     }
   }

--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -515,16 +515,30 @@ export default class Html5 extends FakeEventTarget implements IEngine {
   }
 
   /**
+   * Checks if the video playback has ended and resets it if necessary.
+   * Specifically handles Safari in Picture-in-Picture mode for non-live streams.
+   *
+   * @private
+   * @returns {void}
+   */
+  private resetIfPlaybackEnded(): void {
+    const currentTimeMs = Math.round(this._el.currentTime * 1000);
+    const durationMs = Math.round(this._el.duration * 1000);
+
+    if (currentTimeMs >= durationMs || this._el.ended) {
+      this._el.pause();
+      this._el.currentTime = 0;
+    }
+  }
+
+  /**
    * Start/resume playback.
    * @public
    * @returns {?Promise<*>} - play promise
    */
   public play(): Promise<void> {
     if (Env.isSafari && this.isInPictureInPicture && !this.isLive()) {
-      if (this._el.currentTime >= this._el.duration - 0.1 || this._el.ended) {
-        this._el.pause();
-        this._el.currentTime = 0;
-      }
+      this.resetIfPlaybackEnded();
     }
 
     const playPromise = this._el.play();

--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -520,7 +520,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    */
   public play(): Promise<void> {
     const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    if (isSafari) {
+    if (isSafari && this.isInPictureInPicture) {
       if (this._el.currentTime >= this._el.duration - 0.1 || this._el.ended) {
         this._el.pause();
         this._el.currentTime = 0;

--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -19,6 +19,7 @@ import { CapabilityResult, ICapability } from '../../types';
 import { PKABRRestrictionObject, PKDrmConfigObject, PKDrmDataObject, PKMediaSourceObject, PKVideoElementStore } from '../../types';
 import { IEngine } from '../../types';
 import Track from '../../track/track';
+import { Env } from '../../../src/playkit';
 
 const SHORT_BUFFERING_TIMEOUT: number = 200;
 
@@ -519,8 +520,7 @@ export default class Html5 extends FakeEventTarget implements IEngine {
    * @returns {?Promise<*>} - play promise
    */
   public play(): Promise<void> {
-    const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    if (isSafari && this.isInPictureInPicture) {
+    if (Env.isSafari && this.isInPictureInPicture && !this.isLive()) {
       if (this._el.currentTime >= this._el.duration - 0.1 || this._el.ended) {
         this._el.pause();
         this._el.currentTime = 0;


### PR DESCRIPTION
Issue:
On safari, when PiP is open, video ends and try to play it again with start over, nothing happened.
Safari PiP locks the video in an "ended" state, preventing .play() from restarting playback unless the video is explicitly paused and its currentTime is reset.
Unlike Chrome, Safari doesn't automatically reset currentTime to 0 when a video ends.
 
Fix:
Added a browser check to detect Safari using the user agent.
Applied a conditional reset of the video (pause() and currentTime = 0) only when:
The browser is Safari.
The video is in Picture-in-Picture (PiP) mode.

solved [SUP-46985](https://kaltura.atlassian.net/browse/SUP-46985)

[SUP-46985]: https://kaltura.atlassian.net/browse/SUP-46985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ