### PR TITLE
fix(SUP-45555): Missing Captions in SafariMac and iOS

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2620,7 +2620,7 @@ export default class Player extends FakeEventTarget {
     if (this._config.text.useShakaTextTrackDisplay) {
       this._applyCustomSubtitleStyles();
     }
-    if (!this._config.text.useNativeTextTrack && !this._config.text.useShakaTextTrackDisplay) {
+    if ((!this._config.text.useNativeTextTrack || this.isAudio() )&& !this._config.text.useShakaTextTrackDisplay) {
       processCues(window, cues, this._textDisplayEl, this._textStyle);
     }
   }

--- a/src/player.ts
+++ b/src/player.ts
@@ -2620,7 +2620,7 @@ export default class Player extends FakeEventTarget {
     if (this._config.text.useShakaTextTrackDisplay) {
       this._applyCustomSubtitleStyles();
     }
-    if ((!this._config.text.useNativeTextTrack || this.isAudio() )&& !this._config.text.useShakaTextTrackDisplay) {
+    if ((!this._config.text.useNativeTextTrack || this.isAudio()) && !this._config.text.useShakaTextTrackDisplay) {
       processCues(window, cues, this._textDisplayEl, this._textStyle);
     }
   }


### PR DESCRIPTION
**Issue:**
When play an audio entry with caption on safari, captions are missing.
Unlike Chrome, Safari ignores text tracks when there's no visual component. This is why it's needed manual processing.

**Fix:**
Check condition for audio entry.

solved [SUP-45555](https://kaltura.atlassian.net/browse/SUP-45555)


[SUP-45555]: https://kaltura.atlassian.net/browse/SUP-45555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ