### PR TITLE
fix(SUP-47317): [Saxion] inquiry about correct work of default captions

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2688,10 +2688,10 @@ export default class Player extends FakeEventTarget {
     let language = configuredLanguage;
     if (language === AUTO) {
       const localeTrack: T | undefined = tracks.find((track) => Track.langComparer(Locale.language, track.language));
-      if (localeTrack) {
-        language = localeTrack.language;
-      } else if (defaultTrack && defaultTrack.language !== OFF) {
+      if (defaultTrack && defaultTrack.language !== OFF) {
         language = defaultTrack.language;
+      } else if (localeTrack) {
+        language = localeTrack.language;
       } else if (tracks && tracks.length > 0) {
         language = tracks[0].language;
       }


### PR DESCRIPTION
issue:
when set textLangauge config to auto captions mark as default are the one that see on screen

root cause:
when set textLangauge config to auto, the order that captions is choosen is first by locale, and in case no captions with locale langauge then it will choose according default.

solution:
change the order of cations are choose to first take the default and if no default then choose according the locale

solve [SUP-47317](https://kaltura.atlassian.net/browse/SUP-47317)

[SUP-47317]: https://kaltura.atlassian.net/browse/SUP-47317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ