### PR TITLE
fix: (SUP-48028): Player V7 does not display access control message

### DIFF
--- a/src/error/category.ts
+++ b/src/error/category.ts
@@ -50,7 +50,11 @@ const Category: CategoryType = {
   SITE_RESTRICTED: 16,
 
   /** Scheduled restriction error. */
-  SCHEDULED_RESTRICTED: 17
+  SCHEDULED_RESTRICTED: 17,
+
+  /** Access Control error */
+
+  ACCESS_CONTROL_BLOCKED: 18
 };
 
 export {Category};


### PR DESCRIPTION
**Issue:** Blocked Access Control error is not supported.

**Fix:** Add support to new Error type
solved [SUP-48028](https://kaltura.atlassian.net/browse/SUP-48028)
