### PR TITLE
fix(SUP-48030): player V7 display issue on playlist with blocked and non-blocked content

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2950,4 +2950,8 @@ export default class Player extends FakeEventTarget {
   public setClipTo(clipTo: number): void {
     this._externalCaptionsHandler.clipTo = clipTo;
   }
+
+  public clearReset(): void {
+    this._reset = false;
+  }
 }


### PR DESCRIPTION
**Issue:**
When an entry that is part of a playlist got an error, it keeps the previous entry instead of the current entry to play.

**Fix:**
Add a case inside playNext, when a playlist that is part of the entry gets error.

solved [SUP-48030](https://kaltura.atlassian.net/browse/SUP-48030)

[SUP-48030]: https://kaltura.atlassian.net/browse/SUP-48030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ