### PR TITLE
fix(FEC-14574): Fix no save normal speed regression

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -758,6 +758,8 @@ export default class Player extends FakeEventTarget {
       this._eventManager.listenOnce(this, Html5EventType.CAN_PLAY, () => {
         if (typeof this._playbackAttributesState.rate === 'number') {
           this.playbackRate = this._playbackAttributesState.rate;
+        } else {
+          this.playbackRate = this.defaultPlaybackRate;
         }
       });
     }
@@ -1073,8 +1075,8 @@ export default class Player extends FakeEventTarget {
    */
   public get defaultPlaybackRate(): number {
     if (this._engine) {
-      if(this._defaultPlaybackRate > 0) {
-        return this._defaultPlaybackRate
+      if(typeof this._defaultPlaybackRate === 'number' || this._defaultPlaybackRate > 0) {
+        return this._defaultPlaybackRate;
       }
       return this._engine.defaultPlaybackRate;
     }
@@ -1888,6 +1890,8 @@ export default class Player extends FakeEventTarget {
       this.playbackRate = this._playbackAttributesState.rate;
     } else if (typeof this._config.playback.playbackRate === 'number') {
       this.playbackRate = this._config.playback.playbackRate;
+    } else {
+      this.playbackRate = this.defaultPlaybackRate;
     }
   }
 
@@ -2389,8 +2393,6 @@ export default class Player extends FakeEventTarget {
       this._checkEndTime();
       if (typeof this._playbackAttributesState.rate === 'number') {
         this.playbackRate = this._playbackAttributesState.rate;
-      } else {
-        this.playbackRate = this.defaultPlaybackRate;
       }
     }
   }


### PR DESCRIPTION
### Description of the Changes

Fix for https://kaltura.atlassian.net/browse/FEC-14574
Issue was that default speed was set in wrong place, so it's overwrote saved speed

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
