### PR TITLE
Fix case when prioritizeAudioDescription and alphabeticalSort both true

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2596,7 +2596,7 @@ export default class Player extends FakeEventTarget {
    * @private
    */
   private _getAudioTracks(): Array<AudioTrack> {
-    const audioTracks = this._getTracksByType<AudioTrack>(AudioTrack);
+    let audioTracks = this._getTracksByType<AudioTrack>(AudioTrack);
 
     const prioritizeTracks = this._config.playback.prioritizeAudioDescription;
     const alphabeticalSort = this._config.playback.alphabeticalSort;
@@ -2620,11 +2620,11 @@ export default class Player extends FakeEventTarget {
     }
 
     if (typeof prioritizeTracks === 'boolean') {
-      return audioTracks.sort(sortByAudioTrackType);
+      audioTracks = audioTracks.sort(sortByAudioTrackType);
     }
 
     if (alphabeticalSort) {
-      return audioTracks.sort(sortAlphabetically);
+      audioTracks = audioTracks.sort(sortAlphabetically);
     }
 
     return audioTracks;


### PR DESCRIPTION
### Description of the Changes

Fix case when prioritizeAudioDescription and alphabeticalSort both true

Related PRs: https://github.com/kaltura/playkit-js/pull/824

[FEC-14583](https://kaltura.atlassian.net/browse/FEC-14583)
