### PR TITLE
feat(FEC-14583): Fix default audio track + Update prioritizeAudioDescription description in configuration.md file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1099,7 +1099,9 @@ var config = {
 > >
 > > ##### Default: `undefined`
 > >
-> > ##### Description: When set to true, audio description tracks (identified by language prefix "ad-") will be prioritized and appear at the top of the audio tracks list. When set to false, regular audio tracks appear first. Otherwise, when undefined, no prioritization is applied to audio description tracks.
+> > ##### Description: When set to true, the default audio track will be the audio description track and audio description tracks (identified by language prefix "ad-") will be prioritized and appear at the top of the audio tracks list
+> When set to false, the default audio track will be the regular audio track and regular audio tracks appear first. 
+> Otherwise, when undefined, the default audio track will be the regular audio track and no prioritization is applied to audio description tracks in the list's order.
 >
 > ##
 > 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1100,8 +1100,8 @@ var config = {
 > > ##### Default: `undefined`
 > >
 > > ##### Description: When set to true, the default audio track will be the audio description track and audio description tracks (identified by language prefix "ad-") will be prioritized and appear at the top of the audio tracks list
-> When set to false, the default audio track will be the regular audio track and regular audio tracks appear first. 
-> Otherwise, when undefined, the default audio track will be the regular audio track and no prioritization is applied to audio description tracks in the list's order.
+> > When set to false, the default audio track will be the regular audio track and regular audio tracks appear first. 
+> > Otherwise, when undefined, the default audio track will be the regular audio track and no prioritization is applied to audio description tracks in the list's order.
 >
 > ##
 > 

--- a/src/player.ts
+++ b/src/player.ts
@@ -2775,6 +2775,7 @@ export default class Player extends FakeEventTarget {
 
         return (
           this._playbackAttributesState.audioLanguage ||
+          playbackConfig.audioLanguage ||
           nonAudioDescriptionTrack?.language ||
           this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio)
         );

--- a/src/player.ts
+++ b/src/player.ts
@@ -2756,6 +2756,9 @@ export default class Player extends FakeEventTarget {
     ): string => {
       const userPreferences = this._playbackAttributesState.audioLanguage || playbackConfig.audioLanguage;
       const audioTracks = this._getAudioTracks();
+      const nonAudioDescriptionTrack = audioTracks.find(
+        (track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX) && Track.langComparer(Locale.language, track.language)
+      ) || audioTracks.find((track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX));
 
       if (!userPreferences && prioritizeAudioDescription === true) {
         // If no user preferences and prioritizeAudioDescription is true - look for audio description tracks first
@@ -2763,16 +2766,13 @@ export default class Player extends FakeEventTarget {
         if (audioDescriptionTrack) {
           return audioDescriptionTrack.language;
         } else {
-          return this._getLanguage<AudioTrack>(audioTracks, playbackConfig.audioLanguage, activeTracks.audio);
+          return nonAudioDescriptionTrack?.language ||
+            this._getLanguage<AudioTrack>(audioTracks, playbackConfig.audioLanguage, activeTracks.audio);
         }
       } else {
         // If there is a user audio language preference, return it.
         // Otherwise - return the locale audio track or the first audio track whose language does NOT start with 'ad-' string.
         // If no such track exists - fall back to the default language selection logic.
-        const nonAudioDescriptionTrack = audioTracks.find(
-          (track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX) && Track.langComparer(Locale.language, track.language)
-        ) || audioTracks.find((track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX));
-
         return (
           playbackConfig.audioLanguage ||
           nonAudioDescriptionTrack?.language ||

--- a/src/player.ts
+++ b/src/player.ts
@@ -2765,8 +2765,21 @@ export default class Player extends FakeEventTarget {
           return this._getLanguage<AudioTrack>(audioTracks, playbackConfig.audioLanguage, activeTracks.audio);
         }
       } else {
-        // If there are no user preferences or the prioritizeAudioDescription is false - then return the language according to audioLanguage config
-        return this._playbackAttributesState.audioLanguage || this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio);
+        // If there are no user preferences or the prioritizeAudioDescription is false - return first audio language that does not start with 'ad-'
+
+        // If there is a user audio language preference, return it.
+        // Otherwise - return the first audio track whose language does NOT start with 'ad-' string.
+        // If no such track exists - fall back to the default language selection logic.
+        const audioTracks = this._getAudioTracks();
+        const nonAudioDescriptionTrack = audioTracks.find(
+          (track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX)
+        );
+
+        return (
+          this._playbackAttributesState.audioLanguage ||
+          nonAudioDescriptionTrack?.language ||
+          this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio)
+        );
       }
     }
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -2767,14 +2767,13 @@ export default class Player extends FakeEventTarget {
         }
       } else {
         // If there is a user audio language preference, return it.
-        // Otherwise - return the first audio track whose language does NOT start with 'ad-' string.
+        // Otherwise - return the locale audio track or the first audio track whose language does NOT start with 'ad-' string.
         // If no such track exists - fall back to the default language selection logic.
         const nonAudioDescriptionTrack = audioTracks.find(
-          (track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX)
-        );
+          (track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX) && Track.langComparer(Locale.language, track.language)
+        ) || audioTracks.find((track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX));
 
         return (
-          this._playbackAttributesState.audioLanguage ||
           playbackConfig.audioLanguage ||
           nonAudioDescriptionTrack?.language ||
           this._getLanguage<AudioTrack>(this._getAudioTracks(), playbackConfig.audioLanguage, activeTracks.audio)

--- a/src/player.ts
+++ b/src/player.ts
@@ -2755,9 +2755,10 @@ export default class Player extends FakeEventTarget {
       prioritizeAudioDescription: boolean | undefined
     ): string => {
       const userPreferences = this._playbackAttributesState.audioLanguage || playbackConfig.audioLanguage;
+      const audioTracks = this._getAudioTracks();
+
       if (!userPreferences && prioritizeAudioDescription === true) {
         // If no user preferences and prioritizeAudioDescription is true - look for audio description tracks first
-        const audioTracks = this._getAudioTracks();
         const audioDescriptionTrack = audioTracks.find((track) => track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX));
         if (audioDescriptionTrack) {
           return audioDescriptionTrack.language;
@@ -2770,7 +2771,6 @@ export default class Player extends FakeEventTarget {
         // If there is a user audio language preference, return it.
         // Otherwise - return the first audio track whose language does NOT start with 'ad-' string.
         // If no such track exists - fall back to the default language selection logic.
-        const audioTracks = this._getAudioTracks();
         const nonAudioDescriptionTrack = audioTracks.find(
           (track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX)
         );

--- a/src/player.ts
+++ b/src/player.ts
@@ -2766,8 +2766,6 @@ export default class Player extends FakeEventTarget {
           return this._getLanguage<AudioTrack>(audioTracks, playbackConfig.audioLanguage, activeTracks.audio);
         }
       } else {
-        // If there are no user preferences or the prioritizeAudioDescription is false - return first audio language that does not start with 'ad-'
-
         // If there is a user audio language preference, return it.
         // Otherwise - return the first audio track whose language does NOT start with 'ad-' string.
         // If no such track exists - fall back to the default language selection logic.

--- a/tests/e2e/track/default-tracks.spec.js
+++ b/tests/e2e/track/default-tracks.spec.js
@@ -99,8 +99,8 @@ describe('Audio Track Selection', () => {
         // set default tracks
         player._setDefaultTracks();
 
-        regularTrackFr.active.should.be.true;
-        regularTrackEn.active.should.be.false;
+        regularTrackEn.active.should.be.true;
+        regularTrackFr.active.should.be.false;
         adTrackEn.active.should.be.false;
         adTrackFr.active.should.be.false;
 
@@ -149,8 +149,8 @@ describe('Audio Track Selection', () => {
         player._setDefaultTracks();
 
         try {
-          regularTrackFr.active.should.be.true;
-          regularTrackEn.active.should.be.false;
+          regularTrackEn.active.should.be.true;
+          regularTrackFr.active.should.be.false;
           adTrackEn.active.should.be.false;
           adTrackFr.active.should.be.false;
           done();
@@ -222,8 +222,8 @@ describe('Audio Track Selection', () => {
         // set default tracks
         player._setDefaultTracks();
 
-        regularTrackFr.active.should.be.true;
-        regularTrackEn.active.should.be.false;
+        regularTrackEn.active.should.be.true;
+        regularTrackFr.active.should.be.false;
         done();
       });
 

--- a/tests/e2e/track/default-tracks.spec.js
+++ b/tests/e2e/track/default-tracks.spec.js
@@ -93,17 +93,22 @@ describe('Audio Track Selection', () => {
       playerContainer.appendChild(player.getView());
 
       player.ready().then(() => {
-        // Add tracks to player
-        player._tracks = arrayWithAdTracks;
+        try {
+          // Add tracks to player
+          player._tracks = arrayWithAdTracks;
 
-        // set default tracks
-        player._setDefaultTracks();
+          // set default tracks
+          player._setDefaultTracks();
 
-        regularTrackEn.active.should.be.true;
-        regularTrackFr.active.should.be.false;
-        adTrackEn.active.should.be.false;
-        adTrackFr.active.should.be.false;
-        done();
+          regularTrackFr.active.should.be.true;
+          regularTrackEn.active.should.be.false;
+          adTrackEn.active.should.be.false;
+          adTrackFr.active.should.be.false;
+
+          done();
+        } catch (e) {
+          done(e); // Will print which assertion failed and why
+        }
       });
 
       player.load();
@@ -148,8 +153,8 @@ describe('Audio Track Selection', () => {
         player._setDefaultTracks();
 
         try {
-          regularTrackEn.active.should.be.true;
-          regularTrackFr.active.should.be.false;
+          regularTrackFr.active.should.be.true;
+          regularTrackEn.active.should.be.false;
           adTrackEn.active.should.be.false;
           adTrackFr.active.should.be.false;
           done();
@@ -221,8 +226,8 @@ describe('Audio Track Selection', () => {
         // set default tracks
         player._setDefaultTracks();
 
-        regularTrackEn.active.should.be.true;
-        regularTrackFr.active.should.be.false;
+        regularTrackFr.active.should.be.true;
+        regularTrackEn.active.should.be.false;
         done();
       });
 

--- a/tests/e2e/track/default-tracks.spec.js
+++ b/tests/e2e/track/default-tracks.spec.js
@@ -103,7 +103,6 @@ describe('Audio Track Selection', () => {
         regularTrackFr.active.should.be.false;
         adTrackEn.active.should.be.false;
         adTrackFr.active.should.be.false;
-
         done();
       });
 

--- a/tests/e2e/track/default-tracks.spec.js
+++ b/tests/e2e/track/default-tracks.spec.js
@@ -93,22 +93,18 @@ describe('Audio Track Selection', () => {
       playerContainer.appendChild(player.getView());
 
       player.ready().then(() => {
-        try {
-          // Add tracks to player
-          player._tracks = arrayWithAdTracks;
+        // Add tracks to player
+        player._tracks = arrayWithAdTracks;
 
-          // set default tracks
-          player._setDefaultTracks();
+        // set default tracks
+        player._setDefaultTracks();
 
-          regularTrackFr.active.should.be.true;
-          regularTrackEn.active.should.be.false;
-          adTrackEn.active.should.be.false;
-          adTrackFr.active.should.be.false;
+        regularTrackFr.active.should.be.true;
+        regularTrackEn.active.should.be.false;
+        adTrackEn.active.should.be.false;
+        adTrackFr.active.should.be.false;
 
-          done();
-        } catch (e) {
-          done(e); // Will print which assertion failed and why
-        }
+        done();
       });
 
       player.load();


### PR DESCRIPTION
- Updates the documentation for the `prioritizeAudioDescription` configuration option to clarify its behavior for true, false, and undefined values.
- Prioritize audio description tracks as the default when `prioritizeAudioDescription` is true.
- Prioritize regular audio tracks as the default when `prioritizeAudioDescription` is false.
- Default to regular audio tracks and disable prioritization in the tracks list when `prioritizeAudioDescription` is undefined.
- Refactors selection to more clearly handle user preferences and fallback logic for audio tracks.