### PR TITLE
feat(FEC-14583): Fix default audio track to check all user's preferred languages and not only current one

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2754,10 +2754,15 @@ export default class Player extends FakeEventTarget {
 
     const getAudioTrackPreferredLanguage = (): AudioTrack | undefined => {
       // Build the full preferred-language list from the browser
-      const preferredLanguages: string[] =
-        navigator?.languages?.length > 0
-          ? [...navigator.languages]
-          : (Locale.language ? [Locale.language] : []); // Fallback to Locale.language if navigator.languages isn't available
+      let preferredLanguages: string[];
+
+      if (navigator?.languages?.length) {
+        preferredLanguages = [...navigator.languages];
+      } else if (Locale.language) {
+        preferredLanguages = [Locale.language]; // Fallback to Locale.language if navigator.languages isn't available
+      } else {
+        preferredLanguages = [];
+      }
 
       let nonAudioDescriptionTrack: AudioTrack | undefined;
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -2764,8 +2764,6 @@ export default class Player extends FakeEventTarget {
         preferredLanguages = [];
       }
 
-      let nonAudioDescriptionTrack: AudioTrack | undefined;
-
       // Find the first  preferred language that matches any non ad track
       for (const lang of preferredLanguages) {
         const match = audioTracks.find(
@@ -2779,11 +2777,9 @@ export default class Player extends FakeEventTarget {
       }
 
       // Fallback to first non ad track if none matched preferred languages
-      if (!nonAudioDescriptionTrack) {
-        return audioTracks.find(
-          (track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX)
-        );
-      }
+      return audioTracks.find(
+        (track) => !track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX)
+      );
     }
 
     const getAudioLanguage = (

--- a/src/player.ts
+++ b/src/player.ts
@@ -2753,11 +2753,11 @@ export default class Player extends FakeEventTarget {
     const audioTracks = this._getAudioTracks();
 
     const getAudioTrackPreferredLanguage = (): AudioTrack | undefined => {
-      // Build the full preferred-language list from the browser.
+      // Build the full preferred-language list from the browser
       const preferredLanguages: string[] =
-        (typeof navigator !== 'undefined' && Array.isArray(navigator.languages) && navigator.languages.length > 0)
-          ? navigator.languages
-          : [Locale.language].filter(Boolean); // Fallback to Locale.language if navigator.languages isn't available
+        navigator?.languages?.length > 0
+          ? [...navigator.languages]
+          : (Locale.language ? [Locale.language] : []); // Fallback to Locale.language if navigator.languages isn't available
 
       let nonAudioDescriptionTrack: AudioTrack | undefined;
 

--- a/src/player.ts
+++ b/src/player.ts
@@ -2788,7 +2788,6 @@ export default class Player extends FakeEventTarget {
       const userPreferences = this._playbackAttributesState.audioLanguage || playbackConfig.audioLanguage;
       const nonAudioDescriptionTrack = getAudioTrackPreferredLanguage();
 
-
       if (!userPreferences && prioritizeAudioDescription === true) {
         // If no user preferences and prioritizeAudioDescription is true - look for audio description tracks first
         const audioDescriptionTrack = audioTracks.find((track) => track.language?.startsWith(AUDIO_DESCRIPTION_PREFIX));


### PR DESCRIPTION
- Adds a helper function `getAudioTrackPreferredLanguage` to select audio tracks based on the user's preferred browser languages.
- Uses navigator.languages for preferred language selection, with fallback to Locale.language.
- Prioritizes matching non-audio-description tracks to preferred languages, otherwise selects the first non-audio-description track.
- Refactors `getAudioLanguage` to use the new preferred language logic for audio track selection.
- Improves audio language selection to better respect user/browser language preferences.

[FEC-14583](https://kaltura.atlassian.net/browse/FEC-14583)
[FEC-14620](https://kaltura.atlassian.net/browse/FEC-14620)

[FEC-14583]: https://kaltura.atlassian.net/browse/FEC-14583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FEC-14620]: https://kaltura.atlassian.net/browse/FEC-14620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ