### PR TITLE
fix(SUP-51711): Audio Description Language selection not working as expected in some browsers

### DIFF
--- a/src/track/audio-track.ts
+++ b/src/track/audio-track.ts
@@ -104,7 +104,7 @@ export function audioDescriptionTrackHandler(tracks: Track[], audioFlavors: Arra
         if (isAudioDescription) {
           // set the language to ad-<language> for audio description tracks
           track.language = `ad-${track.language}`;
-          if (track.label && !track.label.includes('- Audio Description')) {
+          if (matchingFlavor) {
             // add "Audio Description" to the label if custom label is not provided
             track.label = `${track.label} - Audio Description`;
           }

--- a/src/track/audio-track.ts
+++ b/src/track/audio-track.ts
@@ -64,7 +64,7 @@ class AudioTrack extends Track {
    * Setter for the flavor ID of the track.
    * @public
    * @param {string | undefined} value - The flavor ID of the track.
-  */
+   */
   public set flavorId(value: string | undefined) {
     this._flavorId = value;
   }
@@ -81,21 +81,30 @@ class AudioTrack extends Track {
 }
 
 export function audioDescriptionTrackHandler(tracks: Track[], audioFlavors: Array<any> = []): void {
+  function findMatchingFlavor(track: AudioTrack, audioFlavors: Array<any>): any {
+    if (audioFlavors.length === 0) return null;
+    let matchingFlavor: any = null;
+    if (track.label) {
+      matchingFlavor = audioFlavors.find((flavor) => flavor.label === track.label);
+    }
+    // if no match found by label, try matching by flavorId
+    if (!matchingFlavor && track.flavorId) {
+      matchingFlavor = audioFlavors.find((flavor) => flavor.id === track.flavorId);
+    }
+    return matchingFlavor;
+  }
+
   if (tracks?.length) {
-    const hasAudioFlavors = audioFlavors.length > 0;
     // iterate over the audio tracks and set the isAudioDescription flag based on the audioFlavors tags
     tracks.forEach((track) => {
       if (track instanceof AudioTrack) {
-        let matchingFlavor: any = null;
-        if (hasAudioFlavors) {
-          matchingFlavor = audioFlavors.find((flavor) => flavor.id === track.flavorId);
-        }
+        const matchingFlavor: any = findMatchingFlavor(track, audioFlavors);
 
         const isAudioDescription = (matchingFlavor && matchingFlavor.tags?.includes(FlavorAssetTags.AUDIO_DESCRIPTION)) || track.kind.includes(AudioTrackKind.DESCRIPTION);
         if (isAudioDescription) {
           // set the language to ad-<language> for audio description tracks
           track.language = `ad-${track.language}`;
-          if (matchingFlavor) {
+          if (track.label && !track.label.includes('- Audio Description')) {
             // add "Audio Description" to the label if custom label is not provided
             track.label = `${track.label} - Audio Description`;
           }

--- a/tests/e2e/track/audio-track-description.spec.js
+++ b/tests/e2e/track/audio-track-description.spec.js
@@ -279,4 +279,106 @@ describe('Audio Track Description Handler', () => {
       tracks[1].label.should.equal('Polish AD');
     });
   });
+
+  describe('Label to flavorId fallback matching', () => {
+    it('should match by flavorId when label does not match', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'Track Label A',
+          language: 'en',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          flavorId: 'flavor123'
+        }),
+        new AudioTrack({
+          label: 'Track Label B',
+          language: 'es',
+          index: 1,
+          kind: AudioTrackKind.MAIN,
+          flavorId: 'flavor456'
+        })
+      ];
+
+      const audioFlavors = [
+        {
+          label: 'Flavor Label X',
+          tags: ['audio_only'],
+          id: 'flavor123'
+        },
+        {
+          label: 'Flavor Label Y',
+          tags: ['audio_only', 'audio_description'],
+          id: 'flavor456'
+        }
+      ];
+
+      audioDescriptionTrackHandler(tracks, audioFlavors);
+
+      // First track: label doesn't match, but flavorId matches (no audio_description tag)
+      tracks[0].language.should.equal('en');
+      tracks[0].label.should.equal('Track Label A');
+
+      // Second track: label doesn't match, but flavorId matches (has audio_description tag)
+      tracks[1].language.should.equal('ad-es');
+      tracks[1].label.should.equal('Track Label B - Audio Description');
+    });
+
+    it('should prioritize label matching over flavorId matching', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'English',
+          language: 'en',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          flavorId: 'flavor789'
+        })
+      ];
+
+      const audioFlavors = [
+        {
+          label: 'English',
+          tags: ['audio_only'],
+          id: 'flavor123'
+        },
+        {
+          label: 'Other Language',
+          tags: ['audio_only', 'audio_description'],
+          id: 'flavor789'
+        }
+      ];
+
+      audioDescriptionTrackHandler(tracks, audioFlavors);
+
+      // Track should match by label (flavor123) not by flavorId (flavor789)
+      // Therefore, should NOT be marked as audio description
+      tracks[0].language.should.equal('en');
+      tracks[0].label.should.equal('English');
+    });
+
+    it('should not match when neither label nor flavorId match', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'Unmatched Label',
+          language: 'fr',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          flavorId: 'unmatched_flavor'
+        })
+      ];
+
+      const audioFlavors = [
+        {
+          label: 'Different Label',
+          tags: ['audio_only', 'audio_description'],
+          id: 'different_flavor'
+        }
+      ];
+
+      audioDescriptionTrackHandler(tracks, audioFlavors);
+
+      // Track should remain unchanged (no match by label or flavorId)
+      tracks[0].language.should.equal('fr');
+      tracks[0].label.should.equal('Unmatched Label');
+    });
+  });
 });


### PR DESCRIPTION
### Description of the Changes

Use label to compare audio flavor and track, fallback to flavorId if label comparison fails.
This is needed because dash provides us limited information for comparison.

Related PR: 
https://github.com/kaltura/playkit-js-dash/pull/271

Resolves [SUP-51711](https://kaltura.atlassian.net/browse/SUP-51711)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-51711]: https://kaltura.atlassian.net/browse/SUP-51711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ