### PR TITLE
fix(SUP-52119): embedded video stuck on loading at end of video in Firefox on macOS

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -61,4 +61,5 @@ Env['isIOS'] = Env.os.name === 'iOS';
 Env['isMacOS'] = Env.os.name === 'Mac OS';
 Env['isChrome'] = Boolean(Env.browser.name?.includes('Chrome'));
 Env['isEdge'] = Boolean(Env.browser.name === 'Edge');
+Env['isFirefox'] = Boolean(Env.browser.name?.includes('Firefox'));
 export default Env;


### PR DESCRIPTION
issue:
sometimes video on firefox stuck on spinner without any error

solution:
on hls plugin
here add check if is firefox on env

solved [SUP-52119](https://kaltura.atlassian.net/browse/SUP-52119)
related to https://github.com/kaltura/playkit-js-hls/pull/239


[SUP-52119]: https://kaltura.atlassian.net/browse/SUP-52119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ