### PR TITLE
fix(SUP-52119): embedded video stuck on loading at end of video in Firefox on macOS

### DIFF
--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -1186,7 +1186,11 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     setTimeout(() => {
       // prevent sending waiting event for too short buffering
       if (!playing) {
-        this.dispatchEvent(new FakeEvent(Html5EventType.WAITING));
+        if ( Env.isFirefox && this._el.duration === this._el.currentTime) {
+          this.dispatchEvent(new FakeEvent(Html5EventType.ENDED));
+        } else {
+          this.dispatchEvent(new FakeEvent(Html5EventType.WAITING));
+        }
       }
     }, SHORT_BUFFERING_TIMEOUT);
   }

--- a/src/types/ua-parser.ts
+++ b/src/types/ua-parser.ts
@@ -208,4 +208,5 @@ export interface IEnv extends IResult {
   isMacOS: boolean;
   isChrome: boolean;
   isEdge: boolean;
+  isFirefox: boolean;
 }


### PR DESCRIPTION
issue:
sometimes video on firefox stuck on spinner without any error

solution:
in case there is a waiting event on firefox, check if the duration and current time are the same throw end event

solved [SUP-52119](https://kaltura.atlassian.net/browse/SUP-52119)


[SUP-52119]: https://kaltura.atlassian.net/browse/SUP-52119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ