### PR TITLE
fix(audio-tracks): use Intl.DisplayNames for native language labels (SUP-52289)

### DIFF
--- a/api-extractor/playkit-js.api.json
+++ b/api-extractor/playkit-js.api.json
@@ -288,12 +288,174 @@
           "isAbstract": false,
           "name": "AudioTrack",
           "preserveMemberOrder": false,
-          "members": [],
+          "members": [
+            {
+              "kind": "Constructor",
+              "canonicalReference": "@playkit-js/playkit-js!AudioTrack:constructor(1)",
+              "docComment": "/**\n * @constructor Constructs a new instance of the `AudioTrack` class\n *\n * @param settings - The track settings object.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "constructor(settings?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "any"
+                },
+                {
+                  "kind": "Content",
+                  "text": ");"
+                }
+              ],
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "settings",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": true
+                }
+              ]
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@playkit-js/playkit-js!AudioTrack#flavorId:member",
+              "docComment": "/**\n * Getter for the flavor ID of the track.\n *\n * @returns {string | undefined} - The flavor ID of the track.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "get flavorId(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | undefined"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n\nset flavorId(value: string | undefined);"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "flavorId",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@playkit-js/playkit-js!AudioTrack#kind:member",
+              "docComment": "/**\n * Getter for the kind value of the track.\n *\n * @returns {AudioTrackKind} - The kind value of the track.\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "get kind(): "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "AudioTrackKind",
+                  "canonicalReference": "@playkit-js/playkit-js!AudioTrackKind:enum"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n\nset kind(value: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "AudioTrackKind",
+                  "canonicalReference": "@playkit-js/playkit-js!AudioTrackKind:enum"
+                },
+                {
+                  "kind": "Content",
+                  "text": ");"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "kind",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            }
+          ],
           "extendsTokenRange": {
             "startIndex": 1,
             "endIndex": 2
           },
           "implementsTokenRanges": []
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "@playkit-js/playkit-js!AudioTrackKind:enum",
+          "docComment": "",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare enum AudioTrackKind "
+            }
+          ],
+          "fileUrlPath": "src/track/audio-track.ts",
+          "releaseTag": "Public",
+          "name": "AudioTrackKind",
+          "preserveMemberOrder": false,
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@playkit-js/playkit-js!AudioTrackKind.DESCRIPTION:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DESCRIPTION = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"description\""
+                }
+              ],
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "name": "DESCRIPTION"
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "@playkit-js/playkit-js!AudioTrackKind.MAIN:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MAIN = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"main\""
+                }
+              ],
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "name": "MAIN"
+            }
+          ]
         },
         {
           "kind": "Variable",
@@ -876,6 +1038,104 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "applyABRRestriction"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@playkit-js/playkit-js!BaseMediaSourceAdapter#applyTextTrackStyles:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "applyTextTrackStyles(sheet: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "CSSStyleSheet",
+                  "canonicalReference": "!CSSStyleSheet:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", styles: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TextStyle",
+                  "canonicalReference": "@playkit-js/playkit-js!TextStyle:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", containerId: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", engineClassName?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 9,
+                "endIndex": 10
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "sheet",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "styles",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "containerId",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 6
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "engineClassName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 8
+                  },
+                  "isOptional": true
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "applyTextTrackStyles"
             },
             {
               "kind": "Method",
@@ -1887,6 +2147,54 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@playkit-js/playkit-js!BaseMediaSourceAdapter#setCachedUrls:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setCachedUrls(cachedUrls: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "cachedUrls",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setCachedUrls"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@playkit-js/playkit-js!BaseMediaSourceAdapter#setMaxBitrate:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -2264,7 +2572,7 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    readonly MEDIA_LOADED: \"medialoaded\";\n    readonly PLAYER_RESET: \"playerreset\";\n    readonly PLAYER_DESTROY: \"playerdestroy\";\n    readonly ENTER_FULLSCREEN: \"enterfullscreen\";\n    readonly EXIT_FULLSCREEN: \"exitfullscreen\";\n    readonly PLAY_FAILED: \"playfailed\";\n    readonly AUTOPLAY_FAILED: \"autoplayfailed\";\n    readonly FALLBACK_TO_MUTED_AUTOPLAY: \"fallbacktomutedautoplay\";\n    readonly CHANGE_SOURCE_STARTED: \"changesourcestarted\";\n    readonly CHANGE_SOURCE_ENDED: \"changesourceended\";\n    readonly MUTE_CHANGE: \"mutechange\";\n    readonly VIDEO_TRACK_CHANGED: \"videotrackchanged\";\n    readonly AUDIO_TRACK_CHANGED: \"audiotrackchanged\";\n    readonly TEXT_TRACK_CHANGED: \"texttrackchanged\";\n    readonly IMAGE_TRACK_CHANGED: \"imagetrackchanged\";\n    readonly TEXT_TRACK_ADDED: \"texttrackadded\";\n    readonly TEXT_CUE_CHANGED: \"textcuechanged\";\n    readonly TRACKS_CHANGED: \"trackschanged\";\n    readonly ABR_MODE_CHANGED: \"abrmodechanged\";\n    readonly PLAYER_STATE_CHANGED: \"playerstatechanged\";\n    readonly PLAYBACK_START: \"playbackstart\";\n    readonly FIRST_PLAY: \"firstplay\";\n    readonly FIRST_PLAYING: \"firstplaying\";\n    readonly PLAYBACK_ENDED: \"playbackended\";\n    readonly SOURCE_SELECTED: \"sourceselected\";\n    readonly TEXT_STYLE_CHANGED: \"textstylechanged\";\n    readonly MEDIA_RECOVERED: \"mediarecovered\";\n    readonly VR_STEREO_MODE_CHANGED: \"vrstereomodechanged\";\n    readonly FPS_DROP: \"fpsdrop\";\n    readonly BOOKMARK_ERROR: \"bookmarkerror\";\n    readonly CONCURRENCY_LIMIT: \"concurrencylimit\";\n    readonly RESIZE: \"resize\";\n    readonly TIMED_METADATA: \"timedmetadata\";\n    readonly TIMED_METADATA_CHANGE: \"timedmetadatachange\";\n    readonly TIMED_METADATA_ADDED: \"timedmetadataadded\";\n    readonly FRAG_LOADED: \"fragloaded\";\n    readonly MANIFEST_LOADED: \"manifestloaded\";\n    readonly USER_GESTURE: \"usergesture\";\n    readonly DRM_LICENSE_LOADED: \"drmlicenseloaded\";\n    readonly SOURCE_URL_SWITCHED: \"sourceurlswitched\";\n}"
+              "text": "{\n    readonly MEDIA_LOADED: \"medialoaded\";\n    readonly PLAYER_RESET: \"playerreset\";\n    readonly PLAYER_DESTROY: \"playerdestroy\";\n    readonly ENTER_FULLSCREEN: \"enterfullscreen\";\n    readonly EXIT_FULLSCREEN: \"exitfullscreen\";\n    readonly PLAY_FAILED: \"playfailed\";\n    readonly AUTOPLAY_FAILED: \"autoplayfailed\";\n    readonly FALLBACK_TO_MUTED_AUTOPLAY: \"fallbacktomutedautoplay\";\n    readonly CHANGE_SOURCE_STARTED: \"changesourcestarted\";\n    readonly CHANGE_SOURCE_ENDED: \"changesourceended\";\n    readonly MUTE_CHANGE: \"mutechange\";\n    readonly VIDEO_TRACK_CHANGED: \"videotrackchanged\";\n    readonly AUDIO_TRACK_CHANGED: \"audiotrackchanged\";\n    readonly TEXT_TRACK_CHANGED: \"texttrackchanged\";\n    readonly IMAGE_TRACK_CHANGED: \"imagetrackchanged\";\n    readonly TEXT_TRACK_ADDED: \"texttrackadded\";\n    readonly TEXT_CUE_CHANGED: \"textcuechanged\";\n    readonly TRACKS_CHANGED: \"trackschanged\";\n    readonly ABR_MODE_CHANGED: \"abrmodechanged\";\n    readonly PLAYER_STATE_CHANGED: \"playerstatechanged\";\n    readonly PLAYBACK_START: \"playbackstart\";\n    readonly FIRST_PLAY: \"firstplay\";\n    readonly FIRST_PLAYING: \"firstplaying\";\n    readonly PLAYBACK_ENDED: \"playbackended\";\n    readonly SOURCE_SELECTED: \"sourceselected\";\n    readonly TEXT_STYLE_CHANGED: \"textstylechanged\";\n    readonly MEDIA_RECOVERED: \"mediarecovered\";\n    readonly VR_STEREO_MODE_CHANGED: \"vrstereomodechanged\";\n    readonly FPS_DROP: \"fpsdrop\";\n    readonly BOOKMARK_ERROR: \"bookmarkerror\";\n    readonly CONCURRENCY_LIMIT: \"concurrencylimit\";\n    readonly RESIZE: \"resize\";\n    readonly TIMED_METADATA: \"timedmetadata\";\n    readonly TIMED_METADATA_CHANGE: \"timedmetadatachange\";\n    readonly TIMED_METADATA_ADDED: \"timedmetadataadded\";\n    readonly FRAG_LOADED: \"fragloaded\";\n    readonly MANIFEST_LOADED: \"manifestloaded\";\n    readonly USER_GESTURE: \"usergesture\";\n    readonly DRM_LICENSE_LOADED: \"drmlicenseloaded\";\n    readonly SOURCE_URL_SWITCHED: \"sourceurlswitched\";\n    readonly TIMELINE_REGION_ADDED: \"timelineregionadded\";\n    readonly TIMELINE_REGION_ENTER: \"timelineregionenter\";\n    readonly TIMELINE_REGION_EXIT: \"timelineregionexit\";\n    readonly PLAY_REACHED_25_PERCENT: \"playreached25percent\";\n    readonly PLAY_REACHED_50_PERCENT: \"playreached50percent\";\n    readonly PLAY_REACHED_75_PERCENT: \"playreached75percent\";\n    readonly PLAY_REACHED_90_PERCENT: \"playreached90percent\";\n    readonly PLAY_REACHED_100_PERCENT: \"playreached100percent\";\n    readonly THUMBNAIL_KS_UPDATED: \"thumbnailksupdated\";\n}"
             }
           ],
           "fileUrlPath": "src/event/event-type.ts",
@@ -2517,7 +2825,7 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    readonly HTML5: \"html5\";\n    readonly FLASH: \"flash\";\n    readonly SILVERLIGHT: \"silverlight\";\n    readonly CAST: \"cast\";\n    readonly YOUTUBE: \"youtube\";\n    readonly IMAGE: \"image\";\n}"
+              "text": "{\n    readonly HTML5: \"html5\";\n    readonly FLASH: \"flash\";\n    readonly SILVERLIGHT: \"silverlight\";\n    readonly CAST: \"cast\";\n    readonly YOUTUBE: \"youtube\";\n    readonly IMAGE: \"image\";\n    readonly DOCUMENT: \"document\";\n}"
             }
           ],
           "fileUrlPath": "src/engines/engine-type.ts",
@@ -2572,7 +2880,7 @@
             {
               "kind": "Constructor",
               "canonicalReference": "@playkit-js/playkit-js!Error_2:constructor(1)",
-              "docComment": "/**\n * @constructor Constructs a new instance of the `Error` class\n *\n * @param severity - error's severity\n *\n * @param category - error's category.\n *\n * @param code - error's code.\n *\n * @param data - additional data for the error.\n */\n",
+              "docComment": "/**\n * @constructor Constructs a new instance of the `Error` class\n *\n * @param severity - error's severity\n *\n * @param category - error's category.\n *\n * @param code - error's code.\n *\n * @param data - additional data for the error.\n *\n * @param errorDetails - error details including title and message - optional.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -2601,6 +2909,14 @@
                 {
                   "kind": "Content",
                   "text": ", data?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "any"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", errorDetails?: "
                 },
                 {
                   "kind": "Content",
@@ -2644,6 +2960,14 @@
                   "parameterTypeTokenRange": {
                     "startIndex": 7,
                     "endIndex": 8
+                  },
+                  "isOptional": true
+                },
+                {
+                  "parameterName": "errorDetails",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 9,
+                    "endIndex": 10
                   },
                   "isOptional": true
                 }
@@ -2793,6 +3117,36 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "data",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@playkit-js/playkit-js!Error_2#errorDetails:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "errorDetails: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "any"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "errorDetails",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
@@ -4045,6 +4399,32 @@
         },
         {
           "kind": "TypeAlias",
+          "canonicalReference": "@playkit-js/playkit-js!FontAlignmentOptions:type",
+          "docComment": "",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export type FontAlignmentOptions = "
+            },
+            {
+              "kind": "Content",
+              "text": "'default' | 'left' | 'center' | 'right'"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "src/types/text-style.ts",
+          "releaseTag": "Public",
+          "name": "FontAlignmentOptions",
+          "typeTokenRange": {
+            "startIndex": 1,
+            "endIndex": 2
+          }
+        },
+        {
+          "kind": "TypeAlias",
           "canonicalReference": "@playkit-js/playkit-js!FontScaleOptions:type",
           "docComment": "",
           "excerptTokens": [
@@ -4054,7 +4434,7 @@
             },
             {
               "kind": "Content",
-              "text": "-2 | -1 | 0 | 2 | 3 | 4"
+              "text": "-1 | 0 | 2"
             },
             {
               "kind": "Content",
@@ -4080,7 +4460,7 @@
             },
             {
               "kind": "Content",
-              "text": "'50%' | '75%' | '100%' | '200%' | '300%' | '400%'"
+              "text": "'100%' | '112.5%' | '125%'"
             },
             {
               "kind": "Content",
@@ -4214,6 +4594,67 @@
             }
           ],
           "name": "getLogLevel"
+        },
+        {
+          "kind": "Function",
+          "canonicalReference": "@playkit-js/playkit-js!getNativeLanguageName:function(1)",
+          "docComment": "/**\n * Returns the native language name for a given ISO language code using Intl.DisplayNames. Falls back to the provided fallback string if the code is absent or the API throws.\n *\n * @param langCode - ISO 639-1/2 language code (e.g. \"es\", \"ja\")\n *\n * @param fallback - Value to return when the code cannot be resolved\n *\n * @returns {string} - Native language name or fallback\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare function getNativeLanguageName(langCode: "
+            },
+            {
+              "kind": "Content",
+              "text": "string | undefined | null"
+            },
+            {
+              "kind": "Content",
+              "text": ", fallback: "
+            },
+            {
+              "kind": "Content",
+              "text": "string"
+            },
+            {
+              "kind": "Content",
+              "text": "): "
+            },
+            {
+              "kind": "Content",
+              "text": "string"
+            },
+            {
+              "kind": "Content",
+              "text": ";"
+            }
+          ],
+          "fileUrlPath": "src/utils/locale.ts",
+          "returnTypeTokenRange": {
+            "startIndex": 5,
+            "endIndex": 6
+          },
+          "releaseTag": "Public",
+          "overloadIndex": 1,
+          "parameters": [
+            {
+              "parameterName": "langCode",
+              "parameterTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isOptional": false
+            },
+            {
+              "parameterName": "fallback",
+              "parameterTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "isOptional": false
+            }
+          ],
+          "name": "getNativeLanguageName"
         },
         {
           "kind": "Variable",
@@ -5731,6 +6172,38 @@
             },
             {
               "kind": "PropertySignature",
+              "canonicalReference": "@playkit-js/playkit-js!IEngine#mediaSourceAdapter:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "mediaSourceAdapter: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "IMediaSourceAdapter",
+                  "canonicalReference": "@playkit-js/playkit-js!IMediaSourceAdapter:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": " | null"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "mediaSourceAdapter",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
               "canonicalReference": "@playkit-js/playkit-js!IEngine#muted:member",
               "docComment": "",
               "excerptTokens": [
@@ -6023,7 +6496,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "\"none\" | \"metadata\" | \"auto\" | \"\""
+                  "text": "'none' | 'metadata' | 'auto' | ''"
                 },
                 {
                   "kind": "Content",
@@ -6451,6 +6924,79 @@
                 }
               ],
               "name": "selectVideoTrack"
+            },
+            {
+              "kind": "MethodSignature",
+              "canonicalReference": "@playkit-js/playkit-js!IEngine#setCachedUrls:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setCachedUrls(cachedUrls: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "any"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "cachedUrls",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "name": "setCachedUrls"
+            },
+            {
+              "kind": "MethodSignature",
+              "canonicalReference": "@playkit-js/playkit-js!IEngine#shouldAddTextTrack:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "shouldAddTextTrack?(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": true,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [],
+              "name": "shouldAddTextTrack"
             },
             {
               "kind": "PropertySignature",
@@ -9155,6 +9701,101 @@
             },
             {
               "kind": "MethodSignature",
+              "canonicalReference": "@playkit-js/playkit-js!IMediaSourceAdapter#applyTextTrackStyles:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "applyTextTrackStyles(sheet: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "CSSStyleSheet",
+                  "canonicalReference": "!CSSStyleSheet:interface"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", styles: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "TextStyle",
+                  "canonicalReference": "@playkit-js/playkit-js!TextStyle:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", containerId: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", engineClassName?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "returnTypeTokenRange": {
+                "startIndex": 9,
+                "endIndex": 10
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "sheet",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "styles",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 3,
+                    "endIndex": 4
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "containerId",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 6
+                  },
+                  "isOptional": false
+                },
+                {
+                  "parameterName": "engineClassName",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 8
+                  },
+                  "isOptional": true
+                }
+              ],
+              "name": "applyTextTrackStyles"
+            },
+            {
+              "kind": "MethodSignature",
               "canonicalReference": "@playkit-js/playkit-js!IMediaSourceAdapter#attachMediaSource:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -9923,6 +10564,51 @@
             },
             {
               "kind": "MethodSignature",
+              "canonicalReference": "@playkit-js/playkit-js!IMediaSourceAdapter#setCachedUrls:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setCachedUrls(cachedUrls: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "any"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isOptional": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "cachedUrls",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "name": "setCachedUrls"
+            },
+            {
+              "kind": "MethodSignature",
               "canonicalReference": "@playkit-js/playkit-js!IMediaSourceAdapter#setMaxBitrate:member(1)",
               "docComment": "",
               "excerptTokens": [
@@ -10577,8 +11263,9 @@
               "text": "MediaType: "
             },
             {
-              "kind": "Content",
-              "text": "{\n    readonly VOD: \"Vod\";\n    readonly LIVE: \"Live\";\n    readonly AUDIO: \"Audio\";\n    readonly IMAGE: \"Image\";\n    readonly UNKNOWN: \"Unknown\";\n}"
+              "kind": "Reference",
+              "text": "PKMediaTypes",
+              "canonicalReference": "@playkit-js/playkit-js!~PKMediaTypes:type"
             }
           ],
           "fileUrlPath": "src/enums/media-type.ts",
@@ -11134,16 +11821,16 @@
             },
             {
               "kind": "Content",
-              "text": ";\n    tags?: "
+              "text": ";\n    tags?: string;\n    epgId?: string;\n    recordingId?: string;\n    audioFlavors?: "
             },
             {
               "kind": "Reference",
-              "text": "Object",
-              "canonicalReference": "!Object:interface"
+              "text": "Array",
+              "canonicalReference": "!Array:interface"
             },
             {
               "kind": "Content",
-              "text": ";\n    epgId?: string;\n    recordingId?: string;\n}"
+              "text": "<any>;\n    createdAt?: number;\n    updatedAt?: number;\n    endDate?: number;\n}"
             },
             {
               "kind": "Content",
@@ -11274,7 +11961,7 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    audioLanguage: string;\n    textLanguage: string;\n    captionsDisplay: boolean;\n    additionalAudioLanguage: string;\n    additionalTextLanguage: string;\n    volume: number;\n    playsinline: boolean;\n    crossOrigin: string;\n    preload: string;\n    autoplay: "
+              "text": "{\n    audioLanguage: string;\n    textLanguage: string;\n    captionsDisplay: boolean;\n    additionalAudioLanguage: string | [string];\n    additionalTextLanguage: string | [string];\n    volume: number;\n    playsinline: boolean;\n    crossOrigin: string;\n    preload: string;\n    autoplay: "
             },
             {
               "kind": "Reference",
@@ -11283,7 +11970,7 @@
             },
             {
               "kind": "Content",
-              "text": ";\n    allowMutedAutoPlay: boolean;\n    muted: boolean;\n    pictureInPicture: boolean;\n    streamPriority: "
+              "text": ";\n    allowMutedAutoPlay: boolean;\n    updateAudioDescriptionLabels: boolean;\n    muted: boolean;\n    pictureInPicture: boolean;\n    streamPriority: "
             },
             {
               "kind": "Reference",
@@ -11336,25 +12023,7 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    html5: {\n        hls: "
-            },
-            {
-              "kind": "Reference",
-              "text": "Object",
-              "canonicalReference": "!Object:interface"
-            },
-            {
-              "kind": "Content",
-              "text": ";\n        dash: "
-            },
-            {
-              "kind": "Reference",
-              "text": "Object",
-              "canonicalReference": "!Object:interface"
-            },
-            {
-              "kind": "Content",
-              "text": ";\n    };\n}"
+              "text": "{\n    html5: {\n        hls: any;\n        dash: any;\n    };\n}"
             },
             {
               "kind": "Content",
@@ -11366,7 +12035,7 @@
           "name": "PKPlaybackOptionsObject",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 6
+            "endIndex": 2
           }
         },
         {
@@ -11670,6 +12339,24 @@
             },
             {
               "kind": "Content",
+              "text": ">;\n    document: "
+            },
+            {
+              "kind": "Reference",
+              "text": "Array",
+              "canonicalReference": "!Array:interface"
+            },
+            {
+              "kind": "Content",
+              "text": "<"
+            },
+            {
+              "kind": "Reference",
+              "text": "PKMediaSourceObject",
+              "canonicalReference": "@playkit-js/playkit-js!PKMediaSourceObject:type"
+            },
+            {
+              "kind": "Content",
               "text": ">;\n    captions?: "
             },
             {
@@ -11715,7 +12402,7 @@
             },
             {
               "kind": "Content",
-              "text": ";\n    id?: string;\n    poster?: string;\n    duration?: number;\n    startTime?: number;\n    vr?: any;\n    imageSourceOptions?: "
+              "text": ";\n    id?: string;\n    poster?: string;\n    duration?: number;\n    startTime?: number;\n    endTime?: number;\n    vr?: any;\n    imageSourceOptions?: "
             },
             {
               "kind": "Reference",
@@ -11724,7 +12411,16 @@
             },
             {
               "kind": "Content",
-              "text": ";\n    seekFrom?: number;\n    clipTo?: number;\n}"
+              "text": ";\n    seekFrom?: number;\n    clipTo?: number;\n    mediaEntryType?: "
+            },
+            {
+              "kind": "Reference",
+              "text": "PKMediaTypes",
+              "canonicalReference": "@playkit-js/playkit-js!~PKMediaTypes:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n}"
             },
             {
               "kind": "Content",
@@ -11736,7 +12432,7 @@
           "name": "PKSourcesConfigObject",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 30
+            "endIndex": 36
           }
         },
         {
@@ -11833,7 +12529,7 @@
             },
             {
               "kind": "Content",
-              "text": "<'DASH' | 'HLS' | 'PROGRESSIVE' | 'IMAGE', "
+              "text": "<'DASH' | 'HLS' | 'PROGRESSIVE' | 'IMAGE' | 'DOCUMENT', "
             },
             {
               "kind": "Reference",
@@ -12150,7 +12846,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "@playkit-js/playkit-js!PKTextStyleObject:type",
-          "docComment": "/**\n * @typedef {Object} PKTextStyleObject  @property {\"50%\" | \"75%\" | \"100%\" | \"200%\" | \"300%\" | \"400%\"} fontSize='100%' - Percentage unit relative to the parent element's font size.  @property {-2 | -1 | 0 | 2 | 3 | 4} fontScale=0 - - Integer number representing the scaling factor relative to the parent element's font size.  @property {string} fontFamily='sans-serif'  @property {[number, number, number]} fontColor=[255, 255, 255] - Color in RGB format.  @property {number} fontOpacity=1  @property {Array<[number, number, number, number, number, number]>} fontEdge=[]  @property {[number, number, number]} backgroundColor=[0, 0, 0] - Color in RGB format.  @property {number} backgroundOpacity=1\n */\n",
+          "docComment": "/**\n * @typedef {Object} PKTextStyleObject  @property {\"100%\" | \"112.5%\" | \"125%\"} fontSize='100%' - Percentage unit relative to the parent element's font size.  @property {-1 | 0 | 2} fontScale=0 - - Integer number representing the scaling factor relative to the parent element's font size.  @property {string} fontFamily='sans-serif'  @property {[number, number, number]} fontColor=[255, 255, 255] - Color in RGB format.  @property {number} fontOpacity=1  @property {Array<[number, number, number, number, number, number]>} fontEdge=[]  @property {[number, number, number]} backgroundColor=[0, 0, 0] - Color in RGB format.  @property {number} backgroundOpacity=1  @property {number} fontWeight=400\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12164,6 +12860,15 @@
               "kind": "Reference",
               "text": "FontSizeOptions",
               "canonicalReference": "@playkit-js/playkit-js!FontSizeOptions:type"
+            },
+            {
+              "kind": "Content",
+              "text": ";\n    textAlign: "
+            },
+            {
+              "kind": "Reference",
+              "text": "FontAlignmentOptions",
+              "canonicalReference": "@playkit-js/playkit-js!FontAlignmentOptions:type"
             },
             {
               "kind": "Content",
@@ -12185,7 +12890,7 @@
             },
             {
               "kind": "Content",
-              "text": "<[number, number, number, number, number, number]>;\n    backgroundColor: [number, number, number];\n    backgroundOpacity: number;\n}"
+              "text": "<[number, number, number, number, number, number]>;\n    backgroundColor: [number, number, number];\n    backgroundOpacity: number;\n    fontWeight: number;\n}"
             },
             {
               "kind": "Content",
@@ -12197,7 +12902,7 @@
           "name": "PKTextStyleObject",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 8
+            "endIndex": 10
           }
         },
         {
@@ -12955,6 +13660,85 @@
               "isStatic": false,
               "isProtected": false,
               "isAbstract": false
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@playkit-js/playkit-js!Player#changeQuality:member(1)",
+              "docComment": "/**\n * change quality  @function changeQuality\n *\n * @param track - the track to change\n *\n * @returns {void}\n *\n * @public\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "changeQuality(track: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "any | string"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "track",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "changeQuality"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@playkit-js/playkit-js!Player#clearReset:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "clearReset(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "clearReset"
             },
             {
               "kind": "Property",
@@ -15392,6 +16176,54 @@
             },
             {
               "kind": "Method",
+              "canonicalReference": "@playkit-js/playkit-js!Player#setCachedUrls:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setCachedUrls(cachedUrls: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "cachedUrls",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setCachedUrls"
+            },
+            {
+              "kind": "Method",
               "canonicalReference": "@playkit-js/playkit-js!Player.setCapabilities:member(1)",
               "docComment": "/**\n * Sets an engine capabilities.\n *\n * @param engineType - The engine type.\n *\n * @param capabilities - The engine capabilities.\n *\n * @returns {void}\n *\n * @static\n *\n * @public\n */\n",
               "excerptTokens": [
@@ -15453,6 +16285,54 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "setCapabilities"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@playkit-js/playkit-js!Player#setClipTo:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setClipTo(clipTo: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "clipTo",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setClipTo"
             },
             {
               "kind": "Method",
@@ -15518,6 +16398,54 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "setLogLevel"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@playkit-js/playkit-js!Player#setSeekFrom:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "setSeekFrom(seekFrom: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "number"
+                },
+                {
+                  "kind": "Content",
+                  "text": "): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "void"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 3,
+                "endIndex": 4
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [
+                {
+                  "parameterName": "seekFrom",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 1,
+                    "endIndex": 2
+                  },
+                  "isOptional": false
+                }
+              ],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "setSeekFrom"
             },
             {
               "kind": "Method",
@@ -15665,6 +16593,37 @@
               "isOptional": false,
               "isAbstract": false,
               "name": "setTextDisplaySettings"
+            },
+            {
+              "kind": "Method",
+              "canonicalReference": "@playkit-js/playkit-js!Player#shouldAddTextTrack:member(1)",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "shouldAddTextTrack(): "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isStatic": false,
+              "returnTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "releaseTag": "Public",
+              "isProtected": false,
+              "overloadIndex": 1,
+              "parameters": [],
+              "isOptional": false,
+              "isAbstract": false,
+              "name": "shouldAddTextTrack"
             },
             {
               "kind": "Method",
@@ -16159,7 +17118,7 @@
             },
             {
               "kind": "Content",
-              "text": "'dash' | 'hls' | 'progressive' | 'image'"
+              "text": "'dash' | 'hls' | 'progressive' | 'image' | 'document'"
             },
             {
               "kind": "Content",
@@ -16603,7 +17562,7 @@
             },
             {
               "kind": "Content",
-              "text": "{\n    readonly DASH: \"dash\";\n    readonly HLS: \"hls\";\n    readonly PROGRESSIVE: \"progressive\";\n    readonly IMAGE: \"image\";\n}"
+              "text": "{\n    readonly DASH: \"dash\";\n    readonly HLS: \"hls\";\n    readonly PROGRESSIVE: \"progressive\";\n    readonly IMAGE: \"image\";\n    readonly DOCUMENT: \"document\";\n}"
             }
           ],
           "fileUrlPath": "src/engines/stream-type.ts",
@@ -16754,6 +17713,45 @@
               "isOptional": false,
               "releaseTag": "Public",
               "name": "EdgeStyles",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 4
+              },
+              "isStatic": true,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@playkit-js/playkit-js!TextStyle.FontAlignment:member",
+              "docComment": "/**\n * Possible font alignments are left, center, right\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static FontAlignment: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        label: string;\n        value: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "FontAlignmentOptions",
+                  "canonicalReference": "@playkit-js/playkit-js!FontAlignmentOptions:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";\n    }[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "FontAlignment",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 4
@@ -16980,7 +17978,7 @@
             {
               "kind": "Property",
               "canonicalReference": "@playkit-js/playkit-js!TextStyle.FontSizes:member",
-              "docComment": "/**\n * Possible font sizes are 50%, 75%, 100%, 200%, 300%, 400%\n */\n",
+              "docComment": "/**\n * Possible font sizes are 100%, 115%, 125%\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -17006,7 +18004,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";\n    }[]"
+                  "text": ";\n        name?: string;\n    }[]"
                 },
                 {
                   "kind": "Content",
@@ -17022,6 +18020,36 @@
                 "endIndex": 6
               },
               "isStatic": true,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@playkit-js/playkit-js!TextStyle#fontWeight:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "set fontWeight(weight: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "string | number"
+                },
+                {
+                  "kind": "Content",
+                  "text": ");"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "fontWeight",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
               "isProtected": false,
               "isAbstract": false
             },
@@ -17217,6 +18245,36 @@
             },
             {
               "kind": "Property",
+              "canonicalReference": "@playkit-js/playkit-js!TextStyle.StandardFontWeights:member",
+              "docComment": "/**\n * Possible font weights are Light, Normal, SemiBold, Bold\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "static StandardFontWeights: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "{\n        label: string;\n        value: number;\n    }[]"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "StandardFontWeights",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": true,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "@playkit-js/playkit-js!TextStyle.StandardOpacities:member",
               "docComment": "/**\n * Defined in {@link https://goo.gl/ZcqOOM FCC 12-9}, paragraph 111.  @enum {Object.<string, number>}}  @export\n */\n",
               "excerptTokens": [
@@ -17242,6 +18300,37 @@
                 "endIndex": 2
               },
               "isStatic": true,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "@playkit-js/playkit-js!TextStyle#textAlign:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "textAlign: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "FontAlignmentOptions",
+                  "canonicalReference": "@playkit-js/playkit-js!FontAlignmentOptions:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "textAlign",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
               "isProtected": false,
               "isAbstract": false
             },
@@ -18774,7 +19863,7 @@
                 },
                 {
                   "kind": "Content",
-                  "text": "string"
+                  "text": "string | string[]"
                 },
                 {
                   "kind": "Content",
@@ -18858,10 +19947,10 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ";"
+                  "text": ";\n\nset language(value: string);"
                 }
               ],
-              "isReadonly": true,
+              "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",
               "name": "language",
@@ -19292,6 +20381,34 @@
               "variableTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 2
+              }
+            },
+            {
+              "kind": "Variable",
+              "canonicalReference": "@playkit-js/playkit-js!Utils.getSubtitleStyleSheet:var",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "getSubtitleStyleSheet: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(playerId: string) => "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "CSSStyleSheet",
+                  "canonicalReference": "!CSSStyleSheet:interface"
+                }
+              ],
+              "fileUrlPath": "src/utils/styles.ts",
+              "isReadonly": true,
+              "releaseTag": "Public",
+              "name": "getSubtitleStyleSheet",
+              "variableTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
               }
             },
             {
@@ -19855,6 +20972,29 @@
               "variableTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 6
+              }
+            },
+            {
+              "kind": "Variable",
+              "canonicalReference": "@playkit-js/playkit-js!Utils.resetSubtitleStyleSheet:var",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "resetSubtitleStyleSheet: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "(playerId: string) => void"
+                }
+              ],
+              "fileUrlPath": "src/utils/styles.ts",
+              "isReadonly": true,
+              "releaseTag": "Public",
+              "name": "resetSubtitleStyleSheet",
+              "variableTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
               }
             },
             {

--- a/api-extractor/report-temp/playkit-js.api.md
+++ b/api-extractor/report-temp/playkit-js.api.md
@@ -59,6 +59,19 @@ export const AdTagType: {
 
 // @public
 export class AudioTrack extends Track {
+    constructor(settings?: any);
+    get flavorId(): string | undefined;
+    set flavorId(value: string | undefined);
+    get kind(): AudioTrackKind;
+    set kind(value: AudioTrackKind);
+}
+
+// @public (undocumented)
+export enum AudioTrackKind {
+    // (undocumented)
+    DESCRIPTION = "description",
+    // (undocumented)
+    MAIN = "main"
 }
 
 // Warning: (ae-forgotten-export) The symbol "PKAutoPlayTypes" needs to be exported by the entry point playkit.d.ts
@@ -71,6 +84,8 @@ export class BaseMediaSourceAdapter extends FakeEventTarget implements IMediaSou
     constructor(videoElement: HTMLVideoElement, source: PKMediaSourceObject, config?: any);
     // (undocumented)
     applyABRRestriction(restrictions: PKABRRestrictionObject): void;
+    // (undocumented)
+    applyTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName?: string): void;
     // (undocumented)
     attachMediaSource(): void;
     static canPlayType(mimeType: string, preferNative: boolean): boolean;
@@ -129,6 +144,8 @@ export class BaseMediaSourceAdapter extends FakeEventTarget implements IMediaSou
     selectTextTrack(textTrack: TextTrack_2): void;
     // (undocumented)
     selectVideoTrack(videoTrack: VideoTrack): void;
+    // (undocumented)
+    setCachedUrls(cachedUrls: string[]): void;
     // (undocumented)
     setMaxBitrate(bitrate: number): void;
     protected _sourceObj?: PKMediaSourceObject;
@@ -208,6 +225,15 @@ export const CustomEventType: {
     readonly USER_GESTURE: "usergesture";
     readonly DRM_LICENSE_LOADED: "drmlicenseloaded";
     readonly SOURCE_URL_SWITCHED: "sourceurlswitched";
+    readonly TIMELINE_REGION_ADDED: "timelineregionadded";
+    readonly TIMELINE_REGION_ENTER: "timelineregionenter";
+    readonly TIMELINE_REGION_EXIT: "timelineregionexit";
+    readonly PLAY_REACHED_25_PERCENT: "playreached25percent";
+    readonly PLAY_REACHED_50_PERCENT: "playreached50percent";
+    readonly PLAY_REACHED_75_PERCENT: "playreached75percent";
+    readonly PLAY_REACHED_90_PERCENT: "playreached90percent";
+    readonly PLAY_REACHED_100_PERCENT: "playreached100percent";
+    readonly THUMBNAIL_KS_UPDATED: "thumbnailksupdated";
 };
 
 // @public (undocumented)
@@ -262,6 +288,7 @@ export const EngineType: {
     readonly CAST: "cast";
     readonly YOUTUBE: "youtube";
     readonly IMAGE: "image";
+    readonly DOCUMENT: "document";
 };
 
 // Warning: (ae-forgotten-export) The symbol "IEnv" needs to be exported by the entry point playkit.d.ts
@@ -271,7 +298,7 @@ export const Env: IEnv;
 
 // @public
 class Error_2 {
-    constructor(severity: number, category: number, code: number, data?: any);
+    constructor(severity: number, category: number, code: number, data?: any, errorDetails?: any);
     // Warning: (ae-forgotten-export) The symbol "CategoryType" needs to be exported by the entry point playkit.d.ts
     static Category: CategoryType;
     // (undocumented)
@@ -282,6 +309,8 @@ class Error_2 {
     code: number;
     // (undocumented)
     data: any;
+    // (undocumented)
+    errorDetails: any;
     // Warning: (ae-forgotten-export) The symbol "SeverityType" needs to be exported by the entry point playkit.d.ts
     static Severity: SeverityType;
     // (undocumented)
@@ -343,10 +372,13 @@ export class FakeEventTarget {
 export function filterTracksByRestriction(videoTracks: VideoTrack[], restriction: PKABRRestrictionObject): VideoTrack[];
 
 // @public (undocumented)
-export type FontScaleOptions = -2 | -1 | 0 | 2 | 3 | 4;
+export type FontAlignmentOptions = 'default' | 'left' | 'center' | 'right';
 
 // @public (undocumented)
-export type FontSizeOptions = '50%' | '75%' | '100%' | '200%' | '300%' | '400%';
+export type FontScaleOptions = -1 | 0 | 2;
+
+// @public (undocumented)
+export type FontSizeOptions = '100%' | '112.5%' | '125%';
 
 // @public (undocumented)
 const _Generator: {
@@ -362,6 +394,12 @@ export function getLogger(name?: string): ILogger;
 
 // @public
 export function getLogLevel(name?: string): ILogLevel;
+
+// @public
+export function getNativeLanguageName(langCode: string | undefined | null, fallback: string): string;
+
+// @public (undocumented)
+const getSubtitleStyleSheet: (playerId: string) => CSSStyleSheet;
 
 // @public (undocumented)
 export const Html5EventType: {
@@ -501,6 +539,8 @@ export interface IEngine extends FakeEventTarget {
     // (undocumented)
     loop: boolean;
     // (undocumented)
+    mediaSourceAdapter: IMediaSourceAdapter | null;
+    // (undocumented)
     muted: boolean;
     // (undocumented)
     networkState: number;
@@ -521,7 +561,7 @@ export interface IEngine extends FakeEventTarget {
     // (undocumented)
     poster: string;
     // (undocumented)
-    preload: "none" | "metadata" | "auto" | "";
+    preload: 'none' | 'metadata' | 'auto' | '';
     // (undocumented)
     readyState: number;
     // (undocumented)
@@ -544,6 +584,10 @@ export interface IEngine extends FakeEventTarget {
     selectTextTrack(textTrack: TextTrack_2): void;
     // (undocumented)
     selectVideoTrack(videoTrack: VideoTrack): void;
+    // (undocumented)
+    setCachedUrls(cachedUrls: string[]): any;
+    // (undocumented)
+    shouldAddTextTrack?(): void;
     // (undocumented)
     src: string;
     // (undocumented)
@@ -750,6 +794,8 @@ export interface IMediaSourceAdapter extends FakeEventTarget {
     // (undocumented)
     applyABRRestriction(restriction: PKABRRestrictionObject): void;
     // (undocumented)
+    applyTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName?: string): void;
+    // (undocumented)
     attachMediaSource(): void;
     // (undocumented)
     capabilities: PKMediaSourceCapabilities;
@@ -795,6 +841,8 @@ export interface IMediaSourceAdapter extends FakeEventTarget {
     selectTextTrack(textTrack: TextTrack_2): void;
     // (undocumented)
     selectVideoTrack(videoTrack: VideoTrack): void;
+    // (undocumented)
+    setCachedUrls(cachedUrls: string[]): any;
     // (undocumented)
     setMaxBitrate(bitrate: number): void;
     // (undocumented)
@@ -844,14 +892,10 @@ export const LogLevelType: Record<keyof LoggerLevels, keyof LoggerLevels>;
 // @public (undocumented)
 export type MaybeState = State | null;
 
+// Warning: (ae-forgotten-export) The symbol "PKMediaTypes" needs to be exported by the entry point playkit.d.ts
+//
 // @public (undocumented)
-export const MediaType: {
-    readonly VOD: "Vod";
-    readonly LIVE: "Live";
-    readonly AUDIO: "Audio";
-    readonly IMAGE: "Image";
-    readonly UNKNOWN: "Unknown";
-};
+export const MediaType: PKMediaTypes;
 
 // @public (undocumented)
 const MimeType_2: PKMimeTypes;
@@ -1013,9 +1057,13 @@ export type PKMetadataConfigObject = {
     description?: string;
     mediaType?: string;
     metas?: Object;
-    tags?: Object;
+    tags?: string;
     epgId?: string;
     recordingId?: string;
+    audioFlavors?: Array<any>;
+    createdAt?: number;
+    updatedAt?: number;
+    endDate?: number;
 };
 
 // @public (undocumented)
@@ -1040,14 +1088,15 @@ export type PKPlaybackConfigObject = {
     audioLanguage: string;
     textLanguage: string;
     captionsDisplay: boolean;
-    additionalAudioLanguage: string;
-    additionalTextLanguage: string;
+    additionalAudioLanguage: string | [string];
+    additionalTextLanguage: string | [string];
     volume: number;
     playsinline: boolean;
     crossOrigin: string;
     preload: string;
     autoplay: PKAutoPlayTypes;
     allowMutedAutoPlay: boolean;
+    updateAudioDescriptionLabels: boolean;
     muted: boolean;
     pictureInPicture: boolean;
     streamPriority: Array<PKStreamPriorityObject>;
@@ -1060,8 +1109,8 @@ export type PKPlaybackConfigObject = {
 // @public (undocumented)
 export type PKPlaybackOptionsObject = {
     html5: {
-        hls: Object;
-        dash: Object;
+        hls: any;
+        dash: any;
     };
 };
 
@@ -1121,6 +1170,7 @@ export type PKSourcesConfigObject = {
     dash: Array<PKMediaSourceObject>;
     progressive: Array<PKMediaSourceObject>;
     image: Array<PKMediaSourceObject>;
+    document: Array<PKMediaSourceObject>;
     captions?: Array<PKExternalCaptionObject>;
     thumbnails?: PKExternalThumbnailsConfig;
     options: PKMediaSourceOptionsObject;
@@ -1131,10 +1181,12 @@ export type PKSourcesConfigObject = {
     poster?: string;
     duration?: number;
     startTime?: number;
+    endTime?: number;
     vr?: any;
     imageSourceOptions?: ImageSourceOptions;
     seekFrom?: number;
     clipTo?: number;
+    mediaEntryType?: PKMediaTypes;
 };
 
 // @public (undocumented)
@@ -1158,7 +1210,7 @@ export type PKStreamPriorityObject = {
 };
 
 // @public (undocumented)
-export type PKStreamTypes = Record<'DASH' | 'HLS' | 'PROGRESSIVE' | 'IMAGE', PlayerStreamTypes>;
+export type PKStreamTypes = Record<'DASH' | 'HLS' | 'PROGRESSIVE' | 'IMAGE' | 'DOCUMENT', PlayerStreamTypes>;
 
 // @public (undocumented)
 export interface PKTextConfigObject {
@@ -1187,6 +1239,7 @@ export interface PKTextConfigObject {
 // @public
 export type PKTextStyleObject = {
     fontSize: FontSizeOptions;
+    textAlign: FontAlignmentOptions;
     fontScale: FontScaleOptions;
     fontFamily: string;
     fontColor: [number, number, number];
@@ -1194,6 +1247,7 @@ export type PKTextStyleObject = {
     fontEdge: Array<[number, number, number, number, number, number]>;
     backgroundColor: [number, number, number];
     backgroundOpacity: number;
+    fontWeight: number;
 };
 
 // @public (undocumented)
@@ -1259,6 +1313,9 @@ export class Player extends FakeEventTarget {
     get AdTagType(): typeof AdTagType;
     attachMediaSource(): void;
     get buffered(): TimeRanges | null;
+    changeQuality(track: any | string): void;
+    // (undocumented)
+    clearReset(): void;
     get config(): any;
     configure(config?: any): void;
     get CorsType(): typeof CorsType;
@@ -1349,13 +1406,21 @@ export class Player extends FakeEventTarget {
     get seeking(): boolean | null;
     seekToLiveEdge(): void;
     selectTrack(track?: Track): void;
+    // (undocumented)
+    setCachedUrls(cachedUrls: string[]): void;
     static setCapabilities(engineType: string, capabilities: {
         [name: string]: any;
     }): void;
+    // (undocumented)
+    setClipTo(clipTo: number): void;
     setLogLevel(level: ILogLevel, name?: string): void;
+    // (undocumented)
+    setSeekFrom(seekFrom: number): void;
     setSources(sources: PKSourcesConfigObject): void;
     setSourcesMetadata(sourcesMetadata: PKMetadataConfigObject): void;
     setTextDisplaySettings(settings: PKTextTrackDisplaySettingObject): void;
+    // (undocumented)
+    shouldAddTextTrack(): boolean;
     showBlackCover(): void;
     showTextTrack(): void;
     get sources(): PKSourcesConfigObject;
@@ -1379,7 +1444,7 @@ export class Player extends FakeEventTarget {
 }
 
 // @public (undocumented)
-export type PlayerStreamTypes = 'dash' | 'hls' | 'progressive' | 'image';
+export type PlayerStreamTypes = 'dash' | 'hls' | 'progressive' | 'image' | 'document';
 
 // Warning: (ae-forgotten-export) The symbol "EngineProvider" needs to be exported by the entry point playkit.d.ts
 //
@@ -1393,6 +1458,9 @@ export const registerMediaSourceAdapter: typeof MediaSourceProvider.register;
 
 // @public (undocumented)
 export const RequestType: PKRequestType;
+
+// @public (undocumented)
+const resetSubtitleStyleSheet: (playerId: string) => void;
 
 // @public
 class ResizeWatcher extends FakeEventTarget {
@@ -1442,6 +1510,7 @@ export const StreamType: {
     readonly HLS: "hls";
     readonly PROGRESSIVE: "progressive";
     readonly IMAGE: "image";
+    readonly DOCUMENT: "document";
 };
 
 // @public (undocumented)
@@ -1458,6 +1527,10 @@ export class TextStyle {
     static EdgeStyles: {
         [edgeStyle: string]: Array<[number, number, number, number, number, number]>;
     };
+    static FontAlignment: {
+        label: string;
+        value: FontAlignmentOptions;
+    }[];
     fontColor: [number, number, number];
     fontEdge: Array<[number, number, number, number, number, number]>;
     static FontFamily: {
@@ -1472,7 +1545,11 @@ export class TextStyle {
     static FontSizes: {
         label: FontSizeOptions;
         value: FontScaleOptions;
+        name?: string;
     }[];
+    set fontWeight(weight: string | number);
+    // (undocumented)
+    get fontWeight(): number;
     // (undocumented)
     static fromJson(setting: PKTextStyleObject): TextStyle;
     // (undocumented)
@@ -1483,9 +1560,15 @@ export class TextStyle {
     static StandardColors: {
         [coloer: string]: [number, number, number];
     };
+    static StandardFontWeights: {
+        label: string;
+        value: number;
+    }[];
     static StandardOpacities: {
         [opacityLevel: string]: number;
     };
+    // (undocumented)
+    textAlign: FontAlignmentOptions;
     toCSS(): string;
     // (undocumented)
     static toJson(text: TextStyle): PKTextStyleObject;
@@ -1582,8 +1665,9 @@ export class Track {
     get label(): string | undefined;
     set label(value: string);
     protected _label: string | undefined;
-    static langComparer(inputLang: string, trackLang: string, additionalLanguage?: string, equal?: boolean): boolean;
+    static langComparer(inputLang: string, trackLang: string, additionalLanguage?: string | string[], equal?: boolean): boolean;
     get language(): string;
+    set language(value: string);
 }
 
 // @public (undocumented)
@@ -1618,7 +1702,9 @@ declare namespace Utils {
         _Generator as Generator,
         _Dom as Dom,
         _Http as Http,
-        _VERSION as VERSION
+        _VERSION as VERSION,
+        getSubtitleStyleSheet,
+        resetSubtitleStyleSheet
     }
 }
 export { Utils }
@@ -1648,8 +1734,8 @@ export * from "js-logger";
 
 // Warnings were encountered during analysis:
 //
-// src/types/sources-config.ts:13:3 - (ae-forgotten-export) The symbol "PKExternalCaptionObject" needs to be exported by the entry point playkit.d.ts
-// src/utils/util.ts:504:4 - (ae-forgotten-export) The symbol "jsonp" needs to be exported by the entry point playkit.d.ts
+// src/types/sources-config.ts:15:3 - (ae-forgotten-export) The symbol "PKExternalCaptionObject" needs to be exported by the entry point playkit.d.ts
+// src/utils/util.ts:503:4 - (ae-forgotten-export) The symbol "jsonp" needs to be exported by the entry point playkit.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-extractor/report/playkit-js.api.md
+++ b/api-extractor/report/playkit-js.api.md
@@ -59,6 +59,19 @@ export const AdTagType: {
 
 // @public
 export class AudioTrack extends Track {
+    constructor(settings?: any);
+    get flavorId(): string | undefined;
+    set flavorId(value: string | undefined);
+    get kind(): AudioTrackKind;
+    set kind(value: AudioTrackKind);
+}
+
+// @public (undocumented)
+export enum AudioTrackKind {
+    // (undocumented)
+    DESCRIPTION = "description",
+    // (undocumented)
+    MAIN = "main"
 }
 
 // Warning: (ae-forgotten-export) The symbol "PKAutoPlayTypes" needs to be exported by the entry point playkit.d.ts
@@ -71,6 +84,8 @@ export class BaseMediaSourceAdapter extends FakeEventTarget implements IMediaSou
     constructor(videoElement: HTMLVideoElement, source: PKMediaSourceObject, config?: any);
     // (undocumented)
     applyABRRestriction(restrictions: PKABRRestrictionObject): void;
+    // (undocumented)
+    applyTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName?: string): void;
     // (undocumented)
     attachMediaSource(): void;
     static canPlayType(mimeType: string, preferNative: boolean): boolean;
@@ -129,6 +144,8 @@ export class BaseMediaSourceAdapter extends FakeEventTarget implements IMediaSou
     selectTextTrack(textTrack: TextTrack_2): void;
     // (undocumented)
     selectVideoTrack(videoTrack: VideoTrack): void;
+    // (undocumented)
+    setCachedUrls(cachedUrls: string[]): void;
     // (undocumented)
     setMaxBitrate(bitrate: number): void;
     protected _sourceObj?: PKMediaSourceObject;
@@ -208,6 +225,15 @@ export const CustomEventType: {
     readonly USER_GESTURE: "usergesture";
     readonly DRM_LICENSE_LOADED: "drmlicenseloaded";
     readonly SOURCE_URL_SWITCHED: "sourceurlswitched";
+    readonly TIMELINE_REGION_ADDED: "timelineregionadded";
+    readonly TIMELINE_REGION_ENTER: "timelineregionenter";
+    readonly TIMELINE_REGION_EXIT: "timelineregionexit";
+    readonly PLAY_REACHED_25_PERCENT: "playreached25percent";
+    readonly PLAY_REACHED_50_PERCENT: "playreached50percent";
+    readonly PLAY_REACHED_75_PERCENT: "playreached75percent";
+    readonly PLAY_REACHED_90_PERCENT: "playreached90percent";
+    readonly PLAY_REACHED_100_PERCENT: "playreached100percent";
+    readonly THUMBNAIL_KS_UPDATED: "thumbnailksupdated";
 };
 
 // @public (undocumented)
@@ -262,6 +288,7 @@ export const EngineType: {
     readonly CAST: "cast";
     readonly YOUTUBE: "youtube";
     readonly IMAGE: "image";
+    readonly DOCUMENT: "document";
 };
 
 // Warning: (ae-forgotten-export) The symbol "IEnv" needs to be exported by the entry point playkit.d.ts
@@ -271,7 +298,7 @@ export const Env: IEnv;
 
 // @public
 class Error_2 {
-    constructor(severity: number, category: number, code: number, data?: any);
+    constructor(severity: number, category: number, code: number, data?: any, errorDetails?: any);
     // Warning: (ae-forgotten-export) The symbol "CategoryType" needs to be exported by the entry point playkit.d.ts
     static Category: CategoryType;
     // (undocumented)
@@ -282,6 +309,8 @@ class Error_2 {
     code: number;
     // (undocumented)
     data: any;
+    // (undocumented)
+    errorDetails: any;
     // Warning: (ae-forgotten-export) The symbol "SeverityType" needs to be exported by the entry point playkit.d.ts
     static Severity: SeverityType;
     // (undocumented)
@@ -343,10 +372,13 @@ export class FakeEventTarget {
 export function filterTracksByRestriction(videoTracks: VideoTrack[], restriction: PKABRRestrictionObject): VideoTrack[];
 
 // @public (undocumented)
-export type FontScaleOptions = -2 | -1 | 0 | 2 | 3 | 4;
+export type FontAlignmentOptions = 'default' | 'left' | 'center' | 'right';
 
 // @public (undocumented)
-export type FontSizeOptions = '50%' | '75%' | '100%' | '200%' | '300%' | '400%';
+export type FontScaleOptions = -1 | 0 | 2;
+
+// @public (undocumented)
+export type FontSizeOptions = '100%' | '112.5%' | '125%';
 
 // @public (undocumented)
 const _Generator: {
@@ -362,6 +394,12 @@ export function getLogger(name?: string): ILogger;
 
 // @public
 export function getLogLevel(name?: string): ILogLevel;
+
+// @public
+export function getNativeLanguageName(langCode: string | undefined | null, fallback: string): string;
+
+// @public (undocumented)
+const getSubtitleStyleSheet: (playerId: string) => CSSStyleSheet;
 
 // @public (undocumented)
 export const Html5EventType: {
@@ -501,6 +539,8 @@ export interface IEngine extends FakeEventTarget {
     // (undocumented)
     loop: boolean;
     // (undocumented)
+    mediaSourceAdapter: IMediaSourceAdapter | null;
+    // (undocumented)
     muted: boolean;
     // (undocumented)
     networkState: number;
@@ -521,7 +561,7 @@ export interface IEngine extends FakeEventTarget {
     // (undocumented)
     poster: string;
     // (undocumented)
-    preload: "none" | "metadata" | "auto" | "";
+    preload: 'none' | 'metadata' | 'auto' | '';
     // (undocumented)
     readyState: number;
     // (undocumented)
@@ -544,6 +584,10 @@ export interface IEngine extends FakeEventTarget {
     selectTextTrack(textTrack: TextTrack_2): void;
     // (undocumented)
     selectVideoTrack(videoTrack: VideoTrack): void;
+    // (undocumented)
+    setCachedUrls(cachedUrls: string[]): any;
+    // (undocumented)
+    shouldAddTextTrack?(): void;
     // (undocumented)
     src: string;
     // (undocumented)
@@ -750,6 +794,8 @@ export interface IMediaSourceAdapter extends FakeEventTarget {
     // (undocumented)
     applyABRRestriction(restriction: PKABRRestrictionObject): void;
     // (undocumented)
+    applyTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName?: string): void;
+    // (undocumented)
     attachMediaSource(): void;
     // (undocumented)
     capabilities: PKMediaSourceCapabilities;
@@ -795,6 +841,8 @@ export interface IMediaSourceAdapter extends FakeEventTarget {
     selectTextTrack(textTrack: TextTrack_2): void;
     // (undocumented)
     selectVideoTrack(videoTrack: VideoTrack): void;
+    // (undocumented)
+    setCachedUrls(cachedUrls: string[]): any;
     // (undocumented)
     setMaxBitrate(bitrate: number): void;
     // (undocumented)
@@ -844,14 +892,10 @@ export const LogLevelType: Record<keyof LoggerLevels, keyof LoggerLevels>;
 // @public (undocumented)
 export type MaybeState = State | null;
 
+// Warning: (ae-forgotten-export) The symbol "PKMediaTypes" needs to be exported by the entry point playkit.d.ts
+//
 // @public (undocumented)
-export const MediaType: {
-    readonly VOD: "Vod";
-    readonly LIVE: "Live";
-    readonly AUDIO: "Audio";
-    readonly IMAGE: "Image";
-    readonly UNKNOWN: "Unknown";
-};
+export const MediaType: PKMediaTypes;
 
 // @public (undocumented)
 const MimeType_2: PKMimeTypes;
@@ -1013,9 +1057,13 @@ export type PKMetadataConfigObject = {
     description?: string;
     mediaType?: string;
     metas?: Object;
-    tags?: Object;
+    tags?: string;
     epgId?: string;
     recordingId?: string;
+    audioFlavors?: Array<any>;
+    createdAt?: number;
+    updatedAt?: number;
+    endDate?: number;
 };
 
 // @public (undocumented)
@@ -1040,14 +1088,15 @@ export type PKPlaybackConfigObject = {
     audioLanguage: string;
     textLanguage: string;
     captionsDisplay: boolean;
-    additionalAudioLanguage: string;
-    additionalTextLanguage: string;
+    additionalAudioLanguage: string | [string];
+    additionalTextLanguage: string | [string];
     volume: number;
     playsinline: boolean;
     crossOrigin: string;
     preload: string;
     autoplay: PKAutoPlayTypes;
     allowMutedAutoPlay: boolean;
+    updateAudioDescriptionLabels: boolean;
     muted: boolean;
     pictureInPicture: boolean;
     streamPriority: Array<PKStreamPriorityObject>;
@@ -1060,8 +1109,8 @@ export type PKPlaybackConfigObject = {
 // @public (undocumented)
 export type PKPlaybackOptionsObject = {
     html5: {
-        hls: Object;
-        dash: Object;
+        hls: any;
+        dash: any;
     };
 };
 
@@ -1121,6 +1170,7 @@ export type PKSourcesConfigObject = {
     dash: Array<PKMediaSourceObject>;
     progressive: Array<PKMediaSourceObject>;
     image: Array<PKMediaSourceObject>;
+    document: Array<PKMediaSourceObject>;
     captions?: Array<PKExternalCaptionObject>;
     thumbnails?: PKExternalThumbnailsConfig;
     options: PKMediaSourceOptionsObject;
@@ -1131,10 +1181,12 @@ export type PKSourcesConfigObject = {
     poster?: string;
     duration?: number;
     startTime?: number;
+    endTime?: number;
     vr?: any;
     imageSourceOptions?: ImageSourceOptions;
     seekFrom?: number;
     clipTo?: number;
+    mediaEntryType?: PKMediaTypes;
 };
 
 // @public (undocumented)
@@ -1158,7 +1210,7 @@ export type PKStreamPriorityObject = {
 };
 
 // @public (undocumented)
-export type PKStreamTypes = Record<'DASH' | 'HLS' | 'PROGRESSIVE' | 'IMAGE', PlayerStreamTypes>;
+export type PKStreamTypes = Record<'DASH' | 'HLS' | 'PROGRESSIVE' | 'IMAGE' | 'DOCUMENT', PlayerStreamTypes>;
 
 // @public (undocumented)
 export interface PKTextConfigObject {
@@ -1187,6 +1239,7 @@ export interface PKTextConfigObject {
 // @public
 export type PKTextStyleObject = {
     fontSize: FontSizeOptions;
+    textAlign: FontAlignmentOptions;
     fontScale: FontScaleOptions;
     fontFamily: string;
     fontColor: [number, number, number];
@@ -1194,6 +1247,7 @@ export type PKTextStyleObject = {
     fontEdge: Array<[number, number, number, number, number, number]>;
     backgroundColor: [number, number, number];
     backgroundOpacity: number;
+    fontWeight: number;
 };
 
 // @public (undocumented)
@@ -1259,6 +1313,9 @@ export class Player extends FakeEventTarget {
     get AdTagType(): typeof AdTagType;
     attachMediaSource(): void;
     get buffered(): TimeRanges | null;
+    changeQuality(track: any | string): void;
+    // (undocumented)
+    clearReset(): void;
     get config(): any;
     configure(config?: any): void;
     get CorsType(): typeof CorsType;
@@ -1349,13 +1406,21 @@ export class Player extends FakeEventTarget {
     get seeking(): boolean | null;
     seekToLiveEdge(): void;
     selectTrack(track?: Track): void;
+    // (undocumented)
+    setCachedUrls(cachedUrls: string[]): void;
     static setCapabilities(engineType: string, capabilities: {
         [name: string]: any;
     }): void;
+    // (undocumented)
+    setClipTo(clipTo: number): void;
     setLogLevel(level: ILogLevel, name?: string): void;
+    // (undocumented)
+    setSeekFrom(seekFrom: number): void;
     setSources(sources: PKSourcesConfigObject): void;
     setSourcesMetadata(sourcesMetadata: PKMetadataConfigObject): void;
     setTextDisplaySettings(settings: PKTextTrackDisplaySettingObject): void;
+    // (undocumented)
+    shouldAddTextTrack(): boolean;
     showBlackCover(): void;
     showTextTrack(): void;
     get sources(): PKSourcesConfigObject;
@@ -1379,7 +1444,7 @@ export class Player extends FakeEventTarget {
 }
 
 // @public (undocumented)
-export type PlayerStreamTypes = 'dash' | 'hls' | 'progressive' | 'image';
+export type PlayerStreamTypes = 'dash' | 'hls' | 'progressive' | 'image' | 'document';
 
 // Warning: (ae-forgotten-export) The symbol "EngineProvider" needs to be exported by the entry point playkit.d.ts
 //
@@ -1393,6 +1458,9 @@ export const registerMediaSourceAdapter: typeof MediaSourceProvider.register;
 
 // @public (undocumented)
 export const RequestType: PKRequestType;
+
+// @public (undocumented)
+const resetSubtitleStyleSheet: (playerId: string) => void;
 
 // @public
 class ResizeWatcher extends FakeEventTarget {
@@ -1442,6 +1510,7 @@ export const StreamType: {
     readonly HLS: "hls";
     readonly PROGRESSIVE: "progressive";
     readonly IMAGE: "image";
+    readonly DOCUMENT: "document";
 };
 
 // @public (undocumented)
@@ -1458,6 +1527,10 @@ export class TextStyle {
     static EdgeStyles: {
         [edgeStyle: string]: Array<[number, number, number, number, number, number]>;
     };
+    static FontAlignment: {
+        label: string;
+        value: FontAlignmentOptions;
+    }[];
     fontColor: [number, number, number];
     fontEdge: Array<[number, number, number, number, number, number]>;
     static FontFamily: {
@@ -1472,7 +1545,11 @@ export class TextStyle {
     static FontSizes: {
         label: FontSizeOptions;
         value: FontScaleOptions;
+        name?: string;
     }[];
+    set fontWeight(weight: string | number);
+    // (undocumented)
+    get fontWeight(): number;
     // (undocumented)
     static fromJson(setting: PKTextStyleObject): TextStyle;
     // (undocumented)
@@ -1483,9 +1560,15 @@ export class TextStyle {
     static StandardColors: {
         [coloer: string]: [number, number, number];
     };
+    static StandardFontWeights: {
+        label: string;
+        value: number;
+    }[];
     static StandardOpacities: {
         [opacityLevel: string]: number;
     };
+    // (undocumented)
+    textAlign: FontAlignmentOptions;
     toCSS(): string;
     // (undocumented)
     static toJson(text: TextStyle): PKTextStyleObject;
@@ -1582,8 +1665,9 @@ export class Track {
     get label(): string | undefined;
     set label(value: string);
     protected _label: string | undefined;
-    static langComparer(inputLang: string, trackLang: string, additionalLanguage?: string, equal?: boolean): boolean;
+    static langComparer(inputLang: string, trackLang: string, additionalLanguage?: string | string[], equal?: boolean): boolean;
     get language(): string;
+    set language(value: string);
 }
 
 // @public (undocumented)
@@ -1618,7 +1702,9 @@ declare namespace Utils {
         _Generator as Generator,
         _Dom as Dom,
         _Http as Http,
-        _VERSION as VERSION
+        _VERSION as VERSION,
+        getSubtitleStyleSheet,
+        resetSubtitleStyleSheet
     }
 }
 export { Utils }
@@ -1648,8 +1734,8 @@ export * from "js-logger";
 
 // Warnings were encountered during analysis:
 //
-// src/types/sources-config.ts:13:3 - (ae-forgotten-export) The symbol "PKExternalCaptionObject" needs to be exported by the entry point playkit.d.ts
-// src/utils/util.ts:504:4 - (ae-forgotten-export) The symbol "jsonp" needs to be exported by the entry point playkit.d.ts
+// src/types/sources-config.ts:15:3 - (ae-forgotten-export) The symbol "PKExternalCaptionObject" needs to be exported by the entry point playkit.d.ts
+// src/utils/util.ts:503:4 - (ae-forgotten-export) The symbol "jsonp" needs to be exported by the entry point playkit.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/engines/html5/media-source/adapters/native-adapter.ts
+++ b/src/engines/html5/media-source/adapters/native-adapter.ts
@@ -17,6 +17,7 @@ import { FairPlayDrmHandler } from './fairplay-drm-handler';
 import { IDrmProtocol, IMediaSourceAdapter, PKABRRestrictionObject, PKDrmConfigObject, PKDrmDataObject, PKMediaSourceObject, PKRequestObject, PKVideoDimensionsObject } from '../../../../types';
 import { FairPlayDrmHandlerV2 } from './fairplay-drm-handler-v2';
 import { ManifestHandler } from './manifest-handler';
+import { getNativeLanguageName } from '../../../../utils/locale';
 
 const BACK_TO_FOCUS_TIMEOUT: number = 1000;
 const MAX_MEDIA_RECOVERY_ATTEMPTS: number = 3;
@@ -802,7 +803,7 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         const settings = {
           id: audioTracks[i].id,
           active: audioTracks[i].enabled,
-          label: audioTracks[i].label,
+          label: getNativeLanguageName(audioTracks[i].language, audioTracks[i].label),
           language: audioTracks[i].language,
           index: i,
           kind: audioTracks[i].kind,

--- a/src/playkit.ts
+++ b/src/playkit.ts
@@ -23,6 +23,7 @@ import {MediaType} from './enums/media-type';
 import {CustomEventType, EventType, Html5EventType} from './event/event-type';
 import {AbrMode} from './track/abr-mode-type';
 import getLogger, {getLogLevel, LogLevel, LogLevelType, setLogLevel, setLogHandler} from './utils/logger';
+import {getNativeLanguageName} from './utils/locale';
 import {CorsType} from './engines/html5/cors-types';
 import {DrmScheme} from './drm/drm-scheme';
 import {MimeType} from './enums/mime-type';
@@ -127,6 +128,9 @@ export {ThumbnailInfo};
 
 // Export logger utils
 export {getLogger, LogLevel, getLogLevel, setLogLevel, setLogHandler};
+
+// Export language utility
+export {getNativeLanguageName};
 
 export {Player}
 

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,3 +1,7 @@
+// Intl.DisplayNames is supported in modern browsers (Chrome 81+, Firefox 86+, Safari 14.1+).
+// Older browsers will fall back to the provided fallback value.
+const _displayNamesCache = new Map<string, Intl.DisplayNames>();
+
 /**
  * Returns the native language name for a given ISO language code using Intl.DisplayNames.
  * Falls back to the provided fallback string if the code is absent or the API throws.
@@ -8,7 +12,11 @@
 export function getNativeLanguageName(langCode: string | undefined | null, fallback: string): string {
   if (!langCode) return fallback;
   try {
-    const dn = new Intl.DisplayNames([langCode], { type: 'language' });
+    let dn = _displayNamesCache.get(langCode);
+    if (!dn) {
+      dn = new Intl.DisplayNames([langCode], {type: 'language'});
+      _displayNamesCache.set(langCode, dn);
+    }
     return dn.of(langCode) || fallback;
   } catch (_e) {
     return fallback;

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,4 +1,21 @@
 /**
+ * Returns the native language name for a given ISO language code using Intl.DisplayNames.
+ * Falls back to the provided fallback string if the code is absent or the API throws.
+ * @param {string | undefined | null} langCode - ISO 639-1/2 language code (e.g. "es", "ja")
+ * @param {string} fallback - Value to return when the code cannot be resolved
+ * @returns {string} - Native language name or fallback
+ */
+export function getNativeLanguageName(langCode: string | undefined | null, fallback: string): string {
+  if (!langCode) return fallback;
+  try {
+    const dn = new Intl.DisplayNames([langCode], { type: 'language' });
+    return dn.of(langCode) || fallback;
+  } catch (_e) {
+    return fallback;
+  }
+}
+
+/**
  * Locale class
  * @class
  *

--- a/tests/e2e/utils/get-native-language-name.spec.js
+++ b/tests/e2e/utils/get-native-language-name.spec.js
@@ -1,0 +1,43 @@
+import {getNativeLanguageName} from '../../../src/utils/locale';
+
+describe('[SUP-52289] getNativeLanguageName — ISO code to native language name', () => {
+  it('should return the native language name for a valid ISO language code (es)', () => {
+    // "es" should resolve to the Spanish name for Spanish — "español"
+    const result = getNativeLanguageName('es', 'Spanish');
+    result.should.not.equal('Spanish');
+    result.toLowerCase().should.equal('español');
+  });
+
+  it('should return the native language name for Japanese (ja)', () => {
+    const result = getNativeLanguageName('ja', 'Japanese');
+    result.should.not.equal('Japanese');
+    result.should.equal('日本語');
+  });
+
+  it('should fall back to the provided fallback when langCode is null', () => {
+    getNativeLanguageName(null, 'Unknown').should.equal('Unknown');
+  });
+
+  it('should fall back to the provided fallback when langCode is undefined', () => {
+    getNativeLanguageName(undefined, 'Track 1').should.equal('Track 1');
+  });
+
+  it('should fall back to the provided fallback when langCode is an empty string', () => {
+    getNativeLanguageName('', 'Track 1').should.equal('Track 1');
+  });
+
+  it('should not throw for an unrecognised code — returns a non-empty string', () => {
+    // Intl.DisplayNames in Chrome returns a formatted result rather than throwing or returning null.
+    // The important guarantee is that the call does not throw and always returns a string.
+    let result;
+    let threw = false;
+    try {
+      result = getNativeLanguageName('zzz-invalid', 'Fallback');
+    } catch (_e) {
+      threw = true;
+    }
+    threw.should.equal(false);
+    result.should.be.a('string');
+    result.length.should.be.above(0);
+  });
+});


### PR DESCRIPTION
## Problem

On iOS Safari, when the player falls back from DASH to HLS, audio track labels are sourced from the HLS manifest NAME= attribute (English words: "Spanish", "Japanese"). The DASH code path derives labels from the ISO language code which the player translates. This causes inconsistent audio track labels depending on the streaming format.

## Root Cause

native-adapter.ts _getParsedAudioTracks sets label: audioTracks[i].label directly from the browser's AudioTrack.label property, which is populated from the HLS manifest NAME= field. There is no normalisation to native script name.

## Fix

Added getNativeLanguageName(langCode, fallback) in src/utils/locale.ts using Intl.DisplayNames to convert an ISO 639 code into the native script name (e.g. "es" -> "español", "ja" -> "日本語"). The function is exported from playkit.ts so downstream adapters can import it.

Applied the helper in native-adapter.ts _getParsedAudioTracks:

  label: getNativeLanguageName(audioTracks[i].language, audioTracks[i].label),

The ISO language code is the primary input; the original manifest label is the safe fallback.

## Files Changed

- src/utils/locale.ts — added getNativeLanguageName export
- src/playkit.ts — re-exported getNativeLanguageName
- src/engines/html5/media-source/adapters/native-adapter.ts — applied helper at label assignment
- tests/e2e/utils/get-native-language-name.spec.js — regression tests (6 cases, all PASS)

## Tests

- Regression test: tests/e2e/utils/get-native-language-name.spec.js — PASS
- Full suite: 509 tests completed, 0 failures

## Companion PR

kaltura/playkit-js-hls — imports getNativeLanguageName and applies it in _parseAudioTracks

## Jira

https://kaltura.atlassian.net/browse/SUP-52289