### PR TITLE
fix(tracks): respect ui.locale when resolving auto caption language (SUP-52418)

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -2851,9 +2851,13 @@ export default class Player extends FakeEventTarget {
   private _getLanguage<T extends PKTextTrack | AudioTrack>(tracks: T[], configuredLanguage: string, defaultTrack?: T): string {
     let language = configuredLanguage;
     if (language === AUTO) {
+      const uiLocale: string | undefined = this._config?.ui?.locale;
+      const uiLocaleTrack: T | undefined = uiLocale ? tracks.find((track) => Track.langComparer(uiLocale, track.language)) : undefined;
       const localeTrack: T | undefined = tracks.find((track) => Track.langComparer(Locale.language, track.language));
       if (defaultTrack && defaultTrack.language !== OFF) {
         language = defaultTrack.language;
+      } else if (uiLocaleTrack) {
+        language = uiLocaleTrack.language;
       } else if (localeTrack) {
         language = localeTrack.language;
       } else if (tracks && tracks.length > 0) {

--- a/tests/e2e/track/regression-SUP-52418.spec.js
+++ b/tests/e2e/track/regression-SUP-52418.spec.js
@@ -1,0 +1,104 @@
+import Player from '../../../src/player';
+import TextTrack from '../../../src/track/text-track';
+import {createElement, getConfigStructure, removeElement, removeVideoElementsFromTestPage} from '../../utils/test-utils';
+
+const targetId = 'player-placeholder_regression-SUP-52418';
+
+/**
+ * Regression test for SUP-52418:
+ * Player Default Language Configuration for Japanese not being respected.
+ *
+ * Root cause: _getLanguage() resolves "auto" textLanguage by checking Locale.language
+ * (browser OS language from navigator.languages[0]) BEFORE checking ui.locale (the
+ * player-configured locale). On an English-locale browser, English captions are
+ * selected even when ui.locale is set to "ja".
+ *
+ * Fix: Insert ui.locale as a fallback BEFORE Locale.language in the priority order:
+ *   1. defaultTrack.language (stream default flag)
+ *   2. ui.locale (player-configured locale)       <-- NEW
+ *   3. Locale.language (browser OS language)
+ *   4. tracks[0].language (first track)
+ */
+describe('SUP-52418 regression — ui.locale respected when textLanguage="auto"', () => {
+  let player, playerContainer;
+
+  before(() => {
+    playerContainer = createElement('DIV', targetId);
+  });
+
+  afterEach(() => {
+    if (player) {
+      player.destroy();
+      player = null;
+    }
+  });
+
+  after(() => {
+    removeVideoElementsFromTestPage();
+    removeElement(targetId);
+  });
+
+  it('should return ui.locale language when textLanguage="auto" and no track has .default=true', () => {
+    // Arrange: configure player with ui.locale="ja" and textLanguage="auto"
+    const config = getConfigStructure(targetId);
+    config.ui = {locale: 'ja'};
+    config.playback.textLanguage = 'auto';
+
+    player = new Player(config);
+
+    // Build caption tracks: en, pt, es, ja — none marked as default
+    const enTrack = new TextTrack({active: false, label: 'English', language: 'en', kind: 'subtitles'});
+    const ptTrack = new TextTrack({active: false, label: 'Portuguese', language: 'pt', kind: 'subtitles'});
+    const esTrack = new TextTrack({active: false, label: 'Spanish', language: 'es', kind: 'subtitles'});
+    const jaTrack = new TextTrack({active: false, label: 'Japanese', language: 'ja', kind: 'subtitles'});
+
+    const textTracks = [enTrack, ptTrack, esTrack, jaTrack];
+
+    // Act: resolve the default language with no defaultTrack (no .default=true stream flag)
+    const resolvedLanguage = player._getLanguage(textTracks, 'auto', undefined);
+
+    // Assert: must pick "ja" from ui.locale, NOT "en" from browser locale
+    resolvedLanguage.should.equal('ja');
+  });
+
+  it('should still respect stream default track over ui.locale', () => {
+    // Arrange: a stream-default English track should win over ui.locale="ja"
+    const config = getConfigStructure(targetId);
+    config.ui = {locale: 'ja'};
+    config.playback.textLanguage = 'auto';
+
+    player = new Player(config);
+
+    const enTrack = new TextTrack({active: false, label: 'English', language: 'en', kind: 'subtitles', default: true});
+    const jaTrack = new TextTrack({active: false, label: 'Japanese', language: 'ja', kind: 'subtitles'});
+
+    const textTracks = [enTrack, jaTrack];
+
+    // Act: the stream-marked default track (en) is passed as defaultTrack
+    const resolvedLanguage = player._getLanguage(textTracks, 'auto', enTrack);
+
+    // Assert: stream default wins
+    resolvedLanguage.should.equal('en');
+  });
+
+  it('should fall through to first track when ui.locale language is not in the track list', () => {
+    // Arrange: ui.locale="ja" but no Japanese track exists
+    const config = getConfigStructure(targetId);
+    config.ui = {locale: 'ja'};
+    config.playback.textLanguage = 'auto';
+
+    player = new Player(config);
+
+    const enTrack = new TextTrack({active: false, label: 'English', language: 'en', kind: 'subtitles'});
+    const ptTrack = new TextTrack({active: false, label: 'Portuguese', language: 'pt', kind: 'subtitles'});
+
+    const textTracks = [enTrack, ptTrack];
+
+    // Act: no defaultTrack, ui.locale="ja" not present in tracks
+    const resolvedLanguage = player._getLanguage(textTracks, 'auto', undefined);
+
+    // Assert: falls through — Locale.language or first track applies (not "ja")
+    // We only assert it is NOT "ja" since the exact fallback depends on browser locale
+    resolvedLanguage.should.not.equal('ja');
+  });
+});


### PR DESCRIPTION
## Problem
When `playback.textLanguage` is set to `"auto"` and the player is configured with `ui.locale: "ja"`, captions default to the browser OS language instead of the configured locale. On an English-locale browser (`navigator.language = "en-US"`), English captions are selected even though the player is explicitly configured for Japanese.

Only the English caption asset was fetched over the network — Japanese was never even requested.

## Root Cause
`_getLanguage()` in `src/player.ts` resolves `"auto"` using this priority order:
1. Caption track with `.default = true` (stream default)
2. `Locale.language` — reads `navigator.languages[0]` (browser OS language)
3. `tracks[0]` (first track in API response)

`ui.locale` was never consulted. The `Locale` class reads only `navigator.languages`, so an English-locale browser always selected English captions regardless of the player config.

## Fix
Added `ui.locale` as a fallback **before** `Locale.language` (browser OS language) in the priority chain inside `_getLanguage()`.

New priority order:
1. Stream default track (`.default = true`)
2. `this._config?.ui?.locale` (player-configured locale) — NEW
3. `Locale.language` (browser OS language)
4. `tracks[0]` (first track)

The change is two lines: read `this._config?.ui?.locale` and find a matching track with `Track.langComparer` before the existing `localeTrack` check.

## Files Changed
- `src/player.ts` — `_getLanguage()` method: +4 lines
- `tests/e2e/track/regression-SUP-52418.spec.js` — regression test (new file, 3 test cases)

## Tests
- **Test file**: `tests/e2e/track/regression-SUP-52418.spec.js`
- **Regression test**: PASS (confirmed RED before fix, GREEN after)
  - `should return ui.locale language when textLanguage="auto" and no track has .default=true`
  - `should still respect stream default track over ui.locale`
  - `should fall through to first track when ui.locale language is not in the track list`
- **Full suite**: 506 tests completed, 0 failed, 2 skipped — no regressions

## Jira
[SUP-52418 — Player Default Language Configuration for Japanese not being respected](https://kaltura.atlassian.net/browse/SUP-52418)

---

## PDLC Agent Token Usage
| Phase | Agent | Tokens | Tool Uses |
|---|---|---|---|
| Fix | player-code-fixer | 0 | 68 |
| Triage | player-triage | 0 | 32 |
| Reproduction | player-reproduction | 0 | 14 |
| Reproduction | player-reproduction | 0 | 14 |
| Triage | player-triage | 0 | 37 |
| Fix | player-code-fixer | 0 | 42 |
| **Total** | | **0** | |