### PR TITLE
fix(SUP-52745): Standard EAD showing twice

### DIFF
--- a/src/track/audio-track.ts
+++ b/src/track/audio-track.ts
@@ -84,12 +84,12 @@ export function audioDescriptionTrackHandler(tracks: Track[], audioFlavors: Arra
   function findMatchingFlavor(track: AudioTrack, audioFlavors: Array<any>): any {
     if (audioFlavors.length === 0) return null;
     let matchingFlavor: any = null;
-    if (track.label) {
-      matchingFlavor = audioFlavors.find((flavor) => flavor.label === track.label);
-    }
-    // if no match found by label, try matching by flavorId
-    if (!matchingFlavor && track.flavorId) {
+    if (track.flavorId) {
       matchingFlavor = audioFlavors.find((flavor) => flavor.id === track.flavorId);
+    }
+    // if no match found by id, try matching by label
+    if (!matchingFlavor && track.label) {
+      matchingFlavor = audioFlavors.find((flavor) => flavor.label === track.label);
     }
     return matchingFlavor;
   }

--- a/tests/e2e/track/audio-track-description.spec.js
+++ b/tests/e2e/track/audio-track-description.spec.js
@@ -323,7 +323,7 @@ describe('Audio Track Description Handler', () => {
       tracks[1].label.should.equal('Track Label B - Audio Description');
     });
 
-    it('should prioritize label matching over flavorId matching', () => {
+    it('should prioritize flavorId matching over label matching', () => {
       const tracks = [
         new AudioTrack({
           label: 'English',
@@ -349,10 +349,10 @@ describe('Audio Track Description Handler', () => {
 
       audioDescriptionTrackHandler(tracks, audioFlavors);
 
-      // Track should match by label (flavor123) not by flavorId (flavor789)
-      // Therefore, should NOT be marked as audio description
-      tracks[0].language.should.equal('en');
-      tracks[0].label.should.equal('English');
+      // Track matches by flavorId (flavor789) which has audio_description tag
+      // Therefore, should be marked as audio description
+      tracks[0].language.should.equal('ad-en');
+      tracks[0].label.should.equal('English - Audio Description');
     });
 
     it('should not match when neither label nor flavorId match', () => {


### PR DESCRIPTION
issue:
see audio description label 2 times under note icon.

root cause:
on hls- when have audio description and audio with same language and the label (i.e - english lang and english as label) there is match flavor and track and the compare is by label, so it return the first flavor found, and used it info for 2 different tracks. so one track get wrong flavor information

solution:
change the order of the matching- first by id and if this is not working then by label

solved [SUP-52745](https://kaltura.atlassian.net/browse/SUP-52745)


[SUP-52745]: https://kaltura.atlassian.net/browse/SUP-52745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ