### PR TITLE
fix(native-adapter): resolve duplicate audio track labels for Audio Description tracks (SUP-52840)

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.ts
+++ b/src/engines/html5/media-source/adapters/native-adapter.ts
@@ -811,8 +811,41 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
         };
         parsedTracks.push(new AudioTrack(settings));
       }
+      // If Intl.DisplayNames resolved two tracks to the same label (e.g. both "English"
+      // for standard and Audio Description tracks sharing language code "en"), fall back
+      // to the raw browser label which is typically populated from the manifest NAME
+      // attribute (e.g. "English - Audio Description").
+      this._resolveDuplicateAudioLabels(parsedTracks, audioTracks);
     }
     return parsedTracks;
+  }
+
+  /**
+   * Resolve duplicate audio track labels by falling back to the raw browser label.
+   * This handles the case where two tracks share the same ISO language code
+   * (e.g. "en" for both standard English and English Audio Description),
+   * causing Intl.DisplayNames to return identical labels for both.
+   * @param {Array<AudioTrack>} parsedTracks - The parsed audio tracks.
+   * @param {any} rawAudioTracks - The raw HTMLMediaElement audioTracks list.
+   * @private
+   */
+  private _resolveDuplicateAudioLabels(parsedTracks: AudioTrack[], rawAudioTracks: any): void {
+    const labelCounts = new Map<string, number>();
+    for (const track of parsedTracks) {
+      if (track.label) {
+        labelCounts.set(track.label, (labelCounts.get(track.label) || 0) + 1);
+      }
+    }
+    for (let i = 0; i < parsedTracks.length; i++) {
+      if ((labelCounts.get(parsedTracks[i].label!) || 0) > 1) {
+        // Fall back to the raw browser label (sourced from manifest NAME attribute)
+        // only when it differs from the Intl-translated name and is non-empty.
+        const rawLabel = rawAudioTracks[i].label;
+        if (rawLabel && rawLabel !== parsedTracks[i].label) {
+          parsedTracks[i].label = rawLabel;
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem
When an entry has both a standard English audio track and an English Audio Description track, the audio selector shows two identical "English" labels. Users cannot tell which track is which.

## Root Cause
_getParsedAudioTracks() calls getNativeLanguageName(audioTracks[i].language, audioTracks[i].label) for every track. When two tracks share language code "en", Intl.DisplayNames returns "English" for both — discarding the raw browser label (e.g. "English - Audio Description") that the browser sourced from the HLS manifest NAME attribute.

## Fix
Added _resolveDuplicateAudioLabels(parsedTracks, rawAudioTracks) private method called after the initial label-building loop.

It counts how many tracks share each translated label. For any track whose label is shared, it checks the corresponding raw HTMLMediaElement audioTracks[i].label (populated from the manifest NAME attribute). If the raw label is non-empty and differs from the translated name, it replaces the duplicate with the raw label.

## Files Changed
- src/engines/html5/media-source/adapters/native-adapter.ts (+33 lines)

## Tests
- Build: TypeScript + API Extractor completed successfully with no errors

## Jira
https://kaltura.atlassian.net/browse/SUP-52840