### PR TITLE
fix(audio-track): deduplicate audio track labels and guard AD label append (SUP-52840)

### DIFF
--- a/src/engines/html5/media-source/adapters/native-adapter.ts
+++ b/src/engines/html5/media-source/adapters/native-adapter.ts
@@ -806,7 +806,10 @@ export default class NativeAdapter extends BaseMediaSourceAdapter {
           language: audioTracks[i].language,
           index: i,
           kind: audioTracks[i].kind,
-          flavorId: this._hlsManifestHandler.extractFlavorId(i)
+          flavorId: this._hlsManifestHandler.extractFlavorId(i),
+          // Safari exposes the raw manifest NAME in audioTracks[i].label — preserve it for
+          // the dedup pass in audioDescriptionTrackHandler.
+          manifestName: audioTracks[i].label || ''
         };
         parsedTracks.push(new AudioTrack(settings));
       }

--- a/src/track/audio-track.ts
+++ b/src/track/audio-track.ts
@@ -32,6 +32,12 @@ class AudioTrack extends Track {
    * @private
    */
   private _flavorId: string | undefined;
+  /**
+   * Raw manifest NAME attribute — preserved for label deduplication.
+   * @member
+   * @type {string}
+   */
+  public manifestName: string;
 
   /**
    * Getter for the kind value of the track.
@@ -77,13 +83,13 @@ class AudioTrack extends Track {
     super(settings);
     this._kind = settings.kind || AudioTrackKind.MAIN;
     this._flavorId = settings.flavorId;
+    this.manifestName = settings.manifestName || '';
   }
 }
 
 export function audioDescriptionTrackHandler(tracks: Track[], audioFlavors: Array<any> = []): void {
   if (tracks?.length) {
     const hasAudioFlavors = audioFlavors.length > 0;
-    // iterate over the audio tracks and set the isAudioDescription flag based on the audioFlavors tags
     tracks.forEach((track) => {
       if (track instanceof AudioTrack) {
         let matchingFlavor: any = null;
@@ -93,15 +99,27 @@ export function audioDescriptionTrackHandler(tracks: Track[], audioFlavors: Arra
 
         const isAudioDescription = (matchingFlavor && matchingFlavor.tags?.includes(FlavorAssetTags.AUDIO_DESCRIPTION)) || track.kind.includes(AudioTrackKind.DESCRIPTION);
         if (isAudioDescription) {
-          // set the language to ad-<language> for audio description tracks
           track.language = `ad-${track.language}`;
-          if (matchingFlavor) {
-            // add "Audio Description" to the label if custom label is not provided
+          if (matchingFlavor && !/audio.?desc/i.test(track.label)) {
             track.label = `${track.label} - Audio Description`;
           }
         }
       }
     });
+
+    // Dedup labels: when two tracks produce the same display label (e.g. both "English"
+    // because Intl.DisplayNames ignores the manifest NAME), fall back to the raw manifest
+    // NAME stored in manifestName. Affects only the label string — no language/kind change.
+    const audioTracks = tracks.filter((t): t is AudioTrack => t instanceof AudioTrack);
+    const labelCount = new Map<string, number>();
+    for (const t of audioTracks) {
+      labelCount.set(t.label, (labelCount.get(t.label) || 0) + 1);
+    }
+    for (const t of audioTracks) {
+      if ((labelCount.get(t.label) || 0) > 1 && t.manifestName && t.manifestName !== t.label) {
+        t.label = t.manifestName;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Three changes to fix duplicate audio track labels and dual checkmark when two tracks share the same ISO language code with no `CHARACTERISTICS` attribute in the manifest:

1. **`AudioTrack.manifestName`** — new public field carrying the raw manifest NAME through the pipeline
2. **`audioDescriptionTrackHandler` dedup pass** — after the existing forEach, detect when two AudioTracks have identical labels and replace with `manifestName`
3. **Guard on "- Audio Description" label append** — prevents double-append when the manifest NAME already contains "Audio Description"
4. **`native-adapter._getParsedAudioTracks`** — passes `manifestName` from `audioTracks[i].label` (Safari's native AudioTrackList exposes the HLS manifest NAME directly there)

## Root cause
See playkit-js-hls PR #246 for full context. The core issue: `Intl.DisplayNames("en").of("en")` always returns `"English"` regardless of the manifest track NAME, so two English-language tracks (one standard, one AD) become indistinguishable.

## Fix flow
```
_parseAudioTracks (hls-adapter)
  → AudioTrack { label: "English", manifestName: "Eng - Audio Description" }
audioDescriptionTrackHandler
  → matchingFlavor found (tags: audio_description)
  → language = "ad-en", label guard prevents double-append
  → dedup pass: "English"/"English" → "English"/"Eng - Audio Description"
audio-menu
  → activeAudioTrackId comparison (separate PR) → single checkmark
```

## Related PRs
- playkit-js-hls: #246
- playkit-js-ui: `fix/sup-52840-audio-menu-active-by-id`

## Test plan
- [ ] Entry `1_fwpyikph` (partner 5479302): audio menu shows `"English"` + `"Eng - Audio Description"`
- [ ] No double label like `"Eng - Audio Description - Audio Description"`
- [ ] Works on Chrome (hls.js path) and Safari (native adapter path)
- [ ] No regression for single-audio-track entries
- [ ] No regression for entries with `CHARACTERISTICS`-tagged AD tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)