### PR TITLE
fix(SUP-52558): Safari - Playback is not Working After navigating to Next Episode. Player is on Pause State & Unable to Play

### DIFF
--- a/src/engines/html5/media-source/adapters/fairplay-drm-handler.ts
+++ b/src/engines/html5/media-source/adapters/fairplay-drm-handler.ts
@@ -112,8 +112,10 @@ class FairPlayDrmHandler {
 
   public destroy(): void {
     this._eventManager.destroy();
-    this._keySession.close();
-    this._keySession = null;
+    if (this._keySession) {
+      this._keySession.close();
+      this._keySession = null;
+    }
   }
 
   private _onWebkitKeyMessage(event: any): void {


### PR DESCRIPTION
issue:
when click on next episode the player show spinner

root cause:
console show this error:Unhandled Promise Rejection: TypeError: undefined is not an object (evaluating 'this._keySession.close')
on code keySession is created only if event webkitneedkey is occurred, but this event not must to occurs all the time, and so keySession remains undefined

solution:
add check if keySession exist before try to close it

solved [SUP-52558](https://kaltura.atlassian.net/browse/SUP-52558)

[SUP-52558]: https://kaltura.atlassian.net/browse/SUP-52558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ