### PR TITLE
fix(ADA-3093): Remove Talkback stop

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -1833,7 +1833,6 @@ export default class Player extends FakeEventTarget {
     const el = (this._el = Utils.Dom.createElement('div'));
     Utils.Dom.addClassName(el, CONTAINER_CLASS_NAME);
     Utils.Dom.setAttribute(el, 'id', this._playerId);
-    Utils.Dom.setAttribute(el, 'tabindex', '-1');
   }
 
   /**

--- a/src/utils/poster-manager.ts
+++ b/src/utils/poster-manager.ts
@@ -59,7 +59,6 @@ class PosterManager {
     if (!this._el) {
       const el = (this._el = Utils.Dom.createElement('div'));
       Utils.Dom.setAttribute(el, 'id', Utils.Generator.uniqueId(5));
-      Utils.Dom.setAttribute(el, 'tabindex', '-1');
     }
   }
 


### PR DESCRIPTION
This fixes https://kaltura.atlassian.net/browse/ADA-3093
### Description of the Changes

The ticket's issue is multiple swipes when reaching pre-playback button while using android Talkback. Talkback sees the playkit-container and the playkit-poster as accessibility nodes, because of the use of tabindex="-1". Tabindex="-1" should be used to stop focusing an interactive item or to make it be focused programmatically. None of these cases are being used here, so removing it fixes one of the multiple swipes for Talkback


### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
