### PR TITLE
feat(FEC-15007): Live streaming: report primary vs secondary stream dimension to Kava on live playback events

### DIFF
--- a/src/engines/html5/html5.ts
+++ b/src/engines/html5/html5.ts
@@ -500,6 +500,13 @@ export default class Html5 extends FakeEventTarget implements IEngine {
     return false;
   }
 
+  public getLiveEntryStValue(): string {
+    if (this._mediaSourceAdapter && typeof this._mediaSourceAdapter.getLiveEntryStValue === 'function') {
+      return this._mediaSourceAdapter.getLiveEntryStValue();
+    }
+    return '';
+  }
+
   /**
    * Get the start time of DVR window in live playback in seconds.
    * @returns {Number} - start time of DVR window.

--- a/src/player.ts
+++ b/src/player.ts
@@ -2952,6 +2952,18 @@ export default class Player extends FakeEventTarget {
   }
 
   /**
+   * Gets the live stream type.
+   * @returns {string} - Live stream type -  primary / backup
+   * @public
+   */
+  public getLiveEntryStValue(): string {
+    if (this._engine && typeof this._engine.getLiveEntryStValue === 'function') {
+      return this._engine.getLiveEntryStValue();
+    }
+    return '';
+  }
+
+  /**
    * Gets the player event types.
    * @returns {PKEventTypes} - The event types of the player.
    * @public

--- a/src/types/interfaces/engine.ts
+++ b/src/types/interfaces/engine.ts
@@ -55,7 +55,8 @@ export interface IEngine extends FakeEventTarget {
   getNativeTextTracks(): TextTrack[];
   getDrmInfo(): PKDrmDataObject | null;
   setCachedUrls(cachedUrls: string[]);
-  shouldAddTextTrack?(): void
+  shouldAddTextTrack?(): void;
+  getLiveEntryStValue(): string;
   id: string;
   currentTime: number;
   duration: number;

--- a/src/types/interfaces/engine.ts
+++ b/src/types/interfaces/engine.ts
@@ -56,7 +56,7 @@ export interface IEngine extends FakeEventTarget {
   getDrmInfo(): PKDrmDataObject | null;
   setCachedUrls(cachedUrls: string[]);
   shouldAddTextTrack?(): void;
-  getLiveEntryStValue(): string;
+  getLiveEntryStValue?(): string;
   id: string;
   currentTime: number;
   duration: number;

--- a/src/types/interfaces/media-source-adapter.ts
+++ b/src/types/interfaces/media-source-adapter.ts
@@ -50,4 +50,5 @@ export interface IMediaSourceAdapter extends FakeEventTarget {
   applyABRRestriction(restriction: PKABRRestrictionObject): void;
   applyTextTrackStyles(sheet: CSSStyleSheet, styles: TextStyle, containerId: string, engineClassName?: string): void;
   setCachedUrls(cachedUrls: string[]);
+  getLiveEntryStValue?(): string;
 }


### PR DESCRIPTION
### Description of the Changes

Adding getLiveEntryStValue function to extract live stream type from the manifest response.

related pr: https://github.com/kaltura/kaltura-player-js/pull/1247, https://github.com/kaltura/playkit-js-hls/pull/247, https://github.com/kaltura/playkit-js-dash/pull/274, https://github.com/kaltura/playkit-js-kava/pull/224

solves [FEC-15007](https://kaltura.atlassian.net/browse/FEC-15007)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-15007]: https://kaltura.atlassian.net/browse/FEC-15007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ