### PR TITLE
fix(SUP-52923): detect AD tracks via manifest NAME when CHARACTERISTICS is absent

### DIFF
--- a/src/track/audio-track.ts
+++ b/src/track/audio-track.ts
@@ -107,7 +107,10 @@ export function audioDescriptionTrackHandler(tracks: Track[], audioFlavors: Arra
       if (track instanceof AudioTrack) {
         const matchingFlavor: any = findMatchingFlavor(track, audioFlavors);
 
-        const isAudioDescription = (matchingFlavor && matchingFlavor.tags?.includes(FlavorAssetTags.AUDIO_DESCRIPTION)) || track.kind.includes(AudioTrackKind.DESCRIPTION);
+        const isAudioDescription =
+          (matchingFlavor && matchingFlavor.tags?.includes(FlavorAssetTags.AUDIO_DESCRIPTION)) ||
+          track.kind.includes(AudioTrackKind.DESCRIPTION) ||
+          /audio.?desc/i.test(track.manifestName);
         if (isAudioDescription) {
           track.language = `ad-${track.language}`;
           if (matchingFlavor && !/audio.?desc/i.test(track.label ?? '')) {

--- a/tests/e2e/track/audio-track-description.spec.js
+++ b/tests/e2e/track/audio-track-description.spec.js
@@ -381,4 +381,86 @@ describe('Audio Track Description Handler', () => {
       tracks[0].label.should.equal('Unmatched Label');
     });
   });
+
+  describe('manifestName-based AD detection (SUP-52923)', () => {
+    it('should detect AD via manifestName when CHARACTERISTICS is absent', () => {
+      // Reproduces SUP-52923: manifest has NAME="Engl - Audio Description"
+      // but no CHARACTERISTICS attribute, so kind=MAIN. No flavor metadata.
+      const tracks = [
+        new AudioTrack({
+          label: 'English',
+          language: 'en',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'English'
+        }),
+        new AudioTrack({
+          label: 'English',
+          language: 'en',
+          index: 1,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'Engl - Audio Description'
+        })
+      ];
+
+      audioDescriptionTrackHandler(tracks, []);
+
+      // Main track unchanged
+      tracks[0].language.should.equal('en');
+      tracks[0].label.should.equal('English');
+
+      // EAD track detected via manifestName → ad- prefix + label from manifestName via dedup
+      tracks[1].language.should.equal('ad-en');
+      tracks[1].label.should.equal('Engl - Audio Description');
+    });
+
+    it('should not double-append "Audio Description" when manifestName already contains it', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'English',
+          language: 'en',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'English'
+        }),
+        new AudioTrack({
+          label: 'English - Audio Description',
+          language: 'en',
+          index: 1,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'English - Audio Description'
+        })
+      ];
+
+      audioDescriptionTrackHandler(tracks, []);
+
+      // Label should NOT become "English - Audio Description - Audio Description"
+      tracks[1].language.should.equal('ad-en');
+      tracks[1].label.should.equal('English - Audio Description');
+    });
+
+    it('should not flag a non-AD track with an unrelated manifestName', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'English',
+          language: 'en',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'English'
+        }),
+        new AudioTrack({
+          label: 'Spanish',
+          language: 'es',
+          index: 1,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'Spanish'
+        })
+      ];
+
+      audioDescriptionTrackHandler(tracks, []);
+
+      tracks[0].language.should.equal('en');
+      tracks[1].language.should.equal('es');
+    });
+  });
 });


### PR DESCRIPTION
**Issue:** The SUP-52840 fix (PR #884) introduced `manifestName` threading and a dedup label pass to handle same-language AD tracks. However, AD detection itself — which sets `language = "ad-<lang>"` to route the track to the AD button — still relied solely on the Kaltura flavor `audio_description` tag or the HLS `CHARACTERISTICS="public.accessibility.describes-video"` attribute. Tracks whose manifest `NAME` contains "Audio Description" but lack `CHARACTERISTICS` and have no Kaltura flavor metadata were not detected as AD tracks, causing them to appear in the audio selector (music note icon) instead of the dedicated AD button.

**Root cause:** `audioDescriptionTrackHandler` in `src/track/audio-track.ts` set `isAudioDescription = true` only via:
1. Kaltura flavor asset tag `audio_description`, or
2. `track.kind === AudioTrackKind.DESCRIPTION` (only set when `CHARACTERISTICS` is present in the HLS manifest)

The `manifestName` field introduced by PR #884 was available but unused for detection — only used for label deduplication display.

**Fix:** Add a third detection path: `/audio.?desc/i.test(track.manifestName)`. When the raw HLS manifest `NAME` attribute matches this pattern (e.g. `"Engl - Audio Description"`, `"English - Audio Description"`, `"Audio Desc"`), the track is treated as an AD track. The label guard (`!/audio.?desc/i.test(track.label)`) already in place prevents double-appending "Audio Description" to the label.

This makes both scenarios work correctly:
- **SUP-52923:** `NAME="Engl - Audio Description"`, no `CHARACTERISTICS` → AD button shows (was: music icon)
- **SUP-52840:** duplicate `NAME="English"` / `NAME="English - Audio Description"` → distinct labels + AD button (preserved)

[SUP-52923](https://kaltura.atlassian.net/browse/SUP-52923)

[SUP-52923]: https://kaltura.atlassian.net/browse/SUP-52923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ