### PR TITLE
fix(SUP-52923): detect AD tracks via manifest NAME when CHARACTERISTICS absent

### DIFF
--- a/src/track/audio-track.ts
+++ b/src/track/audio-track.ts
@@ -107,10 +107,13 @@ export function audioDescriptionTrackHandler(tracks: Track[], audioFlavors: Arra
       if (track instanceof AudioTrack) {
         const matchingFlavor: any = findMatchingFlavor(track, audioFlavors);
 
-        const isAudioDescription = (matchingFlavor && matchingFlavor.tags?.includes(FlavorAssetTags.AUDIO_DESCRIPTION)) || track.kind.includes(AudioTrackKind.DESCRIPTION);
+        const isAdByFlavor = Boolean(matchingFlavor && matchingFlavor.tags?.includes(FlavorAssetTags.AUDIO_DESCRIPTION));
+        const isAdByKind = track.kind.includes(AudioTrackKind.DESCRIPTION);
+        const isAdByManifestName = /audio.?desc/i.test(track.manifestName);
+        const isAudioDescription = isAdByFlavor || isAdByKind || isAdByManifestName;
         if (isAudioDescription) {
           track.language = `ad-${track.language}`;
-          if (matchingFlavor && !/audio.?desc/i.test(track.label ?? '')) {
+          if ((isAdByFlavor || isAdByManifestName) && !/audio.?desc/i.test(track.label ?? '')) {
             track.label = `${track.label ?? ''} - Audio Description`;
           }
         }

--- a/tests/e2e/track/audio-track-description.spec.js
+++ b/tests/e2e/track/audio-track-description.spec.js
@@ -381,4 +381,84 @@ describe('Audio Track Description Handler', () => {
       tracks[0].label.should.equal('Unmatched Label');
     });
   });
+
+  describe('manifestName-based AD detection (SUP-52923 regression)', () => {
+    it('should detect AD track via manifestName when no CHARACTERISTICS and no flavor tag', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'English',
+          language: 'en',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'English'
+        }),
+        new AudioTrack({
+          label: 'English',
+          language: 'en',
+          index: 1,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'Engl - Audio Description'
+        })
+      ];
+
+      audioDescriptionTrackHandler(tracks, []);
+
+      tracks[0].language.should.equal('en');
+      tracks[0].label.should.equal('English');
+
+      tracks[1].language.should.equal('ad-en');
+      tracks[1].label.should.equal('English - Audio Description');
+    });
+
+    it('should detect AD track via manifestName for non-English language (SUP-52923 Spanish case)', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'Español',
+          language: 'es',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'Spanish - Audio Description'
+        })
+      ];
+
+      audioDescriptionTrackHandler(tracks, []);
+
+      tracks[0].language.should.equal('ad-es');
+      tracks[0].label.should.equal('Español - Audio Description');
+    });
+
+    it('should not append label suffix when manifestName already contains Audio Description', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'English - Audio Description',
+          language: 'en',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'English - Audio Description'
+        })
+      ];
+
+      audioDescriptionTrackHandler(tracks, []);
+
+      tracks[0].language.should.equal('ad-en');
+      tracks[0].label.should.equal('English - Audio Description');
+    });
+
+    it('should not mark a track as AD when manifestName does not contain audio description keywords', () => {
+      const tracks = [
+        new AudioTrack({
+          label: 'English',
+          language: 'en',
+          index: 0,
+          kind: AudioTrackKind.MAIN,
+          manifestName: 'English Commentary'
+        })
+      ];
+
+      audioDescriptionTrackHandler(tracks, []);
+
+      tracks[0].language.should.equal('en');
+      tracks[0].label.should.equal('English');
+    });
+  });
 });


### PR DESCRIPTION
**Issue:** The fix for SUP-52840 (dedup labels via `manifestName`) introduced a regression for entries where AD tracks are identified only by their manifest `NAME` attribute (e.g. `"Engl - Audio Description"`) and have no `CHARACTERISTICS="public.accessibility.describes-video"` attribute and no Kaltura flavor tag.

**Root cause:** `audioDescriptionTrackHandler` detected AD tracks via two paths only: the Kaltura flavor `audio_description` tag, and `track.kind === "description"` (set by hls-adapter only when `CHARACTERISTICS` is present). Tracks without either were classified as regular audio and routed to the music-note audio selector instead of the AD button.

**Fix:** Added a third detection path using the `manifestName` field that was introduced in PR #884 for SUP-52840. When `manifestName` matches `/audio.?desc/i` (covers "Audio Description", "Audio-Description", "Engl - Audio Description", "Spanish - Audio Description", etc.), the track is classified as AD and gets the `"ad-"` language prefix so the UI routes it to the AD button. The label-appending guard already present prevents double-appending when the label already contains "Audio Description".

This ensures both SUP-52840 (same-language AD tracks via CHARACTERISTICS) and SUP-52923 (AD tracks identified only by their manifest NAME) are handled correctly.

[SUP-52923](https://kaltura.atlassian.net/browse/SUP-52923)

[SUP-52840]: https://kaltura.atlassian.net/browse/SUP-52840

[SUP-52923]: https://kaltura.atlassian.net/browse/SUP-52923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ